### PR TITLE
feat: environment, structured logging and database layer (#13, #38)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,77 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  # ─── Backend: lint + unit tests ──────────────────────────────────────────────
+  backend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements*.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Lint (ruff)
+        run: ruff check . --output-format github
+
+      - name: Run tests
+        run: pytest tests/ -v --tb=short -m "not integration"
+
+  # ─── Frontend: TypeScript type-check + build ─────────────────────────────────
+  frontend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint (eslint)
+        run: npm run lint
+
+      - name: Build (tsc + vite)
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 # Backend
 .env
 env/
+.venv/
 __pycache__/
+.pytest_cache/
+.ruff_cache/
+logs/
 
 # Frontend
 # Logs

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,81 @@
+# =============================================================================
+# CaduTrack Environment Variables
+# Copy this file to .env and fill in your actual values
+#   cp .env.example .env
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Database
+# -----------------------------------------------------------------------------
+# CaduTrack connects to the shared apollo-server-db PostgreSQL instance.
+# It owns the database named by DB_NAME and the schema named by DB_SCHEMA
+# inside it — no other service writes there.
+#
+# When running the API in Docker on apollo-server-network, use the container
+# name as the host: DB_HOST=apollo-server-db
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=cadutrack
+DB_USER=postgres
+DB_PASSWORD=your_secure_password
+
+# Optional: schema owned by this service inside DB_NAME. Defaults to cadutrack.
+# DB_SCHEMA=cadutrack
+
+# Optional: seconds to wait for a database connection before failing.
+# Keep it short so /health fails fast. Defaults to 5.
+# DB_CONNECT_TIMEOUT=5
+
+# -----------------------------------------------------------------------------
+# API
+# -----------------------------------------------------------------------------
+# Optional: host and port for the FastAPI server.
+# Defaults to 0.0.0.0:8000. Use 127.0.0.1 for local-only access.
+# API_HOST=0.0.0.0
+# API_PORT=8000
+
+# Optional: API key protecting mutating endpoints (POST / PUT / DELETE).
+# Sent by the client in the X-API-Key header.
+# Leave empty to disable the check — only safe behind Cloudflare Access.
+# API_KEY=your_secret_api_key_here
+
+# Optional: comma-separated browser origins allowed to call the API.
+# Defaults to the Vite dev server.
+# CORS_ORIGINS=http://localhost:5173,https://cadutrack.example.com
+
+# -----------------------------------------------------------------------------
+# Expiry alerts (Telegram)
+# -----------------------------------------------------------------------------
+# Token from @BotFather. Leave empty to disable alerts entirely.
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token
+# Target chat that receives the daily digest.
+TELEGRAM_CHAT_ID=your_telegram_chat_id
+
+# Optional: products expiring within this many days are included in the alert.
+# Defaults to 7.
+# ALERT_DAYS_AHEAD=7
+
+# Optional: time of day (HH:MM, in TIMEZONE) the daily alert is sent.
+# Defaults to 08:00.
+# ALERT_TIME=08:00
+
+# -----------------------------------------------------------------------------
+# Observability
+# -----------------------------------------------------------------------------
+# Optional: IANA timezone used for log timestamps and alert scheduling.
+# Examples: America/Mexico_City, Europe/Madrid, UTC. Defaults to UTC.
+# TIMEZONE=America/Mexico_City
+
+# Optional: root log level (DEBUG, INFO, WARNING, ERROR). Defaults to INFO.
+# LOG_LEVEL=INFO
+
+# Optional: absolute path to the rotating JSON log file, read by Promtail.
+# Leave empty to log to stdout only (the right choice outside Docker).
+# In the container this is /mnt/logs/cadutrack.log.
+# LOG_FILE=/mnt/logs/cadutrack.log
+
+# =============================================================================
+# Docker volume paths (used by compose.yaml bind mounts)
+# Relative paths are resolved from the directory where you run docker compose.
+# =============================================================================
+LOGS_PATH=./logs

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,151 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts.
+# this is typically a path given in POSIX (e.g. forward slashes)
+# format, relative to the token %(here)s which refers to the location of this
+# ini file
+script_location = %(here)s/alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+# Or organize into date-based subdirectories (requires recursive_version_locations = true)
+# file_template = %%(year)d/%%(month).2d/%%(day).2d_%%(hour).2d%%(minute).2d_%%(second).2d_%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.  for multiple paths, the path separator
+# is defined by "path_separator" below.
+prepend_sys_path = .
+
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the tzdata library which can be installed by adding
+# `alembic[tz]` to the pip requirements.
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to <script_location>/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "path_separator"
+# below.
+# version_locations = %(here)s/bar:%(here)s/bat:%(here)s/alembic/versions
+
+# path_separator; This indicates what character is used to split lists of file
+# paths, including version_locations and prepend_sys_path within configparser
+# files such as alembic.ini.
+# The default rendered in new alembic.ini files is "os", which uses os.pathsep
+# to provide os-dependent path splitting.
+#
+# Note that in order to support legacy alembic.ini files, this default does NOT
+# take place if path_separator is not present in alembic.ini.  If this
+# option is omitted entirely, fallback logic is as follows:
+#
+# 1. Parsing of the version_locations option falls back to using the legacy
+#    "version_path_separator" key, which if absent then falls back to the legacy
+#    behavior of splitting on spaces and/or commas.
+# 2. Parsing of the prepend_sys_path option falls back to the legacy
+#    behavior of splitting on spaces, commas, or colons.
+#
+# Valid values for path_separator are:
+#
+# path_separator = :
+# path_separator = ;
+# path_separator = space
+# path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# database URL.  This is consumed by the user-maintained env.py script only.
+# other means of configuring database URLs may be customized within the env.py
+# file.
+# Connection URL is built from environment variables in alembic/env.py
+# (see backend/.env.example). Do not set it here.
+sqlalchemy.url =
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+# hooks = ruff
+# ruff.type = module
+# ruff.module = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration.  This is also consumed by the user-maintained
+# env.py script only.
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/alembic/README
+++ b/backend/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,86 @@
+"""Alembic environment configuration for CaduTrack.
+
+Reads PostgreSQL connection parameters from app.config and applies migrations
+within the schema owned by this service (``cadutrack`` by default) on the
+shared apollo-server-db instance.
+"""
+
+import logging
+import os
+import sys
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool, text
+
+from alembic import context
+
+# Make the backend root importable so we can use the app package.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.config import settings  # noqa: E402
+from app.db.base import Base  # noqa: E402
+from app.models import *  # noqa: E402,F401,F403  — registers models on Base.metadata
+
+# Alembic Config object, providing access to values from alembic.ini
+alembic_config = context.config
+
+# Interpret the config file for Python logging only when running from the
+# Alembic CLI (i.e., logging has not been set up yet by the service).
+# When invoked programmatically the root logger already has handlers, so we
+# skip fileConfig to avoid clobbering the service's structured logging.
+if alembic_config.config_file_name is not None and not logging.root.handlers:
+    fileConfig(alembic_config.config_file_name)
+
+# Models declare their schema via Base.metadata, so autogenerate can diff them.
+target_metadata = Base.metadata
+
+
+def _configure(**kwargs) -> None:
+    """Shared context.configure options for both offline and online modes."""
+    context.configure(
+        target_metadata=target_metadata,
+        # Alembic's own bookkeeping table stays in public, matching the
+        # convention used by the other apollo-server services.
+        version_table_schema="public",
+        include_schemas=True,
+        compare_type=True,
+        **kwargs,
+    )
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode (no live DB connection required)."""
+    _configure(
+        url=settings.database_url,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode against a live database connection."""
+    configuration = dict(alembic_config.get_section(alembic_config.config_ini_section) or {})
+    configuration["sqlalchemy.url"] = settings.database_url
+
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        # The service's schema must exist before any migration runs against it.
+        connection.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{settings.db_schema}"'))
+        connection.commit()
+
+        _configure(connection=connection)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,85 @@
+"""
+Application configuration for CaduTrack.
+
+Values are read from environment variables (and a local .env file during
+development). See .env.example for the full documented list.
+
+Unlike the other apollo-server services, which parse os.getenv by hand, this one
+uses pydantic-settings: FastAPI already pulls in Pydantic, and typed settings
+give us validation and sane failure messages for free.
+"""
+
+from functools import lru_cache
+from urllib.parse import quote_plus
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Environment-driven settings, validated at startup."""
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    # ── Database ─────────────────────────────────────────────────────────────
+    # Points at the shared apollo-server-db instance. CaduTrack owns the
+    # database named by db_name and the schema named by db_schema inside it.
+    db_host: str = "localhost"
+    db_port: int = 5432
+    db_name: str = "cadutrack"
+    db_user: str = "postgres"
+    db_password: str = ""
+    db_schema: str = "cadutrack"
+    # Seconds to wait for a connection before giving up. Kept short so the
+    # /health probe fails fast instead of hanging the monitoring check.
+    db_connect_timeout: int = Field(default=5, ge=1)
+
+    # ── API ──────────────────────────────────────────────────────────────────
+    api_host: str = "0.0.0.0"
+    api_port: int = 8000
+    # When set, mutating endpoints require this value in the X-API-Key header.
+    api_key: str = ""
+    # Origins allowed to call the API from a browser (comma-separated in .env).
+    cors_origins: str = "http://localhost:5173"
+
+    # ── Alerts ───────────────────────────────────────────────────────────────
+    telegram_bot_token: str = ""
+    telegram_chat_id: str = ""
+    # Products expiring within this many days are included in the daily alert.
+    alert_days_ahead: int = Field(default=7, ge=1)
+    # Daily alert time, HH:MM in TIMEZONE.
+    alert_time: str = "08:00"
+
+    # ── Observability ────────────────────────────────────────────────────────
+    timezone: str = "UTC"
+    log_level: str = "INFO"
+    # Absolute path to the rotating log file. Empty means stdout only, which is
+    # what you want when running outside Docker.
+    log_file: str = ""
+
+    @property
+    def database_url(self) -> str:
+        """SQLAlchemy connection URL built from the DB_* settings."""
+        auth = quote_plus(self.db_user)
+        if self.db_password:
+            auth = f"{auth}:{quote_plus(self.db_password)}"
+        return (
+            f"postgresql+psycopg://{auth}@{self.db_host}:{self.db_port}/{quote_plus(self.db_name)}"
+        )
+
+    @property
+    def cors_origin_list(self) -> list[str]:
+        return [origin.strip() for origin in self.cors_origins.split(",") if origin.strip()]
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return the process-wide Settings instance."""
+    return Settings()
+
+
+settings = get_settings()

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -1,0 +1,26 @@
+"""Declarative base shared by every ORM model."""
+
+from sqlalchemy import MetaData
+from sqlalchemy.orm import DeclarativeBase
+
+from app.config import settings
+
+
+class Base(DeclarativeBase):
+    """Base class for all CaduTrack ORM models.
+
+    Every table lives in CaduTrack's own schema inside the shared
+    apollo-server-db instance, so the schema is pinned on the metadata rather
+    than repeated on each model. This also makes Alembic emit schema-qualified
+    DDL instead of relying on the connection's search_path.
+    """
+
+    metadata = MetaData(
+        schema=settings.db_schema,
+        naming_convention={
+            "ix": "ix_%(column_0_label)s",
+            "uq": "uq_%(table_name)s_%(column_0_name)s",
+            "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+            "pk": "pk_%(table_name)s",
+        },
+    )

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,0 +1,60 @@
+"""SQLAlchemy engine and session management."""
+
+import logging
+from collections.abc import Generator
+
+from sqlalchemy import create_engine, event, text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+engine = create_engine(
+    settings.database_url,
+    pool_pre_ping=True,
+    future=True,
+    connect_args={"connect_timeout": settings.db_connect_timeout},
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_search_path(dbapi_connection, connection_record):
+    """Pin every new connection to CaduTrack's schema.
+
+    The apollo-server-db instance is shared across services, so we never rely on
+    the default search_path.
+    """
+    with dbapi_connection.cursor() as cursor:
+        cursor.execute(f'SET search_path TO "{settings.db_schema}", public')
+
+
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
+
+
+def get_db() -> Generator[Session, None, None]:
+    """FastAPI dependency that yields a request-scoped session."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def check_connection() -> bool:
+    """Return True when the database answers a trivial query.
+
+    Used by the /health endpoint so monitoring can tell a live service with a
+    dead database apart from a service that is down entirely.
+    """
+    try:
+        with engine.connect() as connection:
+            connection.execute(text("SELECT 1"))
+        return True
+    except SQLAlchemyError as exc:
+        # /health is polled continuously, so log a one-line reason rather than a
+        # full traceback — otherwise every probe floods Loki while the DB is down.
+        logger.error("Database health check failed: %s", exc.__class__.__name__)
+        logger.debug("Database health check traceback", exc_info=exc)
+        return False

--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -1,0 +1,116 @@
+"""
+Structured JSON logging configuration for CaduTrack.
+
+Mirrors the format used by the other apollo-server services (free-games-notifier,
+apollo-server-dashboard) so a single Promtail pipeline can parse all of them.
+
+All log entries are emitted as single-line JSON objects with consistent fields:
+  - timestamp  : ISO 8601 with timezone offset (e.g. "2026-04-28T10:00:00-06:00")
+  - level      : log level string (INFO, WARNING, ERROR, DEBUG)
+  - logger     : logger name (e.g. "app.routers.products", "__main__")
+  - message    : the log message
+  - service    : always "cadutrack" — useful as a Loki label
+
+Promtail pipeline_stages example:
+  - json:
+      expressions:
+        level: level
+        message: message
+        service: service
+  - labels:
+      level:
+      service:
+"""
+
+import logging
+import logging.handlers
+import os
+from datetime import datetime
+
+import pytz
+
+try:
+    from pythonjsonlogger.json import JsonFormatter as _JsonFormatterBase  # v3+
+except ImportError:
+    from pythonjsonlogger.jsonlogger import JsonFormatter as _JsonFormatterBase  # v2
+
+SERVICE_NAME = "cadutrack"
+
+
+class _JsonFormatter(_JsonFormatterBase):
+    """JsonFormatter that adds standard fields and a timezone-aware timestamp."""
+
+    def __init__(self, *args, tz: str = "UTC", **kwargs):
+        super().__init__(*args, **kwargs)
+        try:
+            self._tz = pytz.timezone(tz)
+        except pytz.exceptions.UnknownTimeZoneError:
+            logging.getLogger(__name__).warning(
+                "Unknown timezone %r for log formatter — falling back to UTC.", tz
+            )
+            self._tz = pytz.utc
+
+    def add_fields(self, log_record: dict, record: logging.LogRecord, message_dict: dict):
+        super().add_fields(log_record, record, message_dict)
+
+        # Timezone-aware ISO 8601 timestamp
+        log_record["timestamp"] = (
+            datetime.fromtimestamp(record.created, tz=pytz.utc)
+            .astimezone(self._tz)
+            .isoformat()
+        )
+        log_record["level"] = record.levelname
+        log_record["logger"] = record.name
+        log_record["service"] = SERVICE_NAME
+
+        # Remove redundant / noisy fields added by the base formatter
+        for key in ("asctime", "name", "levelname"):
+            log_record.pop(key, None)
+
+
+def setup_logging(timezone: str = "UTC", log_file: str | None = None, level: str = "INFO") -> None:
+    """
+    Configure JSON structured logging for the application.
+
+    Should be called once at startup before any loggers are used.
+    Both the rotating file (when available) and stdout receive the same JSON format.
+
+    Unlike the containerised services, CaduTrack is also run bare-metal during
+    development, where /mnt/logs does not exist. The file handler is therefore
+    attached only when its directory is writable; stdout always works.
+
+    Args:
+        timezone: IANA timezone string for log timestamps (e.g. "America/Mexico_City").
+        log_file: Absolute path to the rotating log file, or None for stdout only.
+        level: Root log level name.
+    """
+    formatter = _JsonFormatter(fmt="%(message)s", tz=timezone)
+    log_level = logging.getLevelNamesMapping().get(level.upper(), logging.INFO)
+
+    handlers: list[logging.Handler] = []
+
+    if log_file:
+        try:
+            os.makedirs(os.path.dirname(log_file) or ".", exist_ok=True)
+            file_handler = logging.handlers.TimedRotatingFileHandler(
+                log_file, when="W1", interval=1, backupCount=4
+            )
+            file_handler.setLevel(log_level)
+            file_handler.setFormatter(formatter)
+            handlers.append(file_handler)
+        except OSError:
+            # Log directory unavailable (typical outside Docker) — stdout still covers us.
+            pass
+
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(log_level)
+    console_handler.setFormatter(formatter)
+    handlers.append(console_handler)
+
+    root = logging.getLogger()
+    root.setLevel(log_level)
+    # Only add handlers if none are configured yet (same behaviour as basicConfig without force).
+    # This prevents overriding pytest's log capture during test runs.
+    if not root.handlers:
+        for handler in handlers:
+            root.addHandler(handler)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,31 @@
-from fastapi import FastAPI
-from .routers import health
+import logging
 
-app = FastAPI()
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.config import settings
+from app.logging_config import setup_logging
+from app.routers import health
+
+# Configure structured logging before anything else emits a record.
+setup_logging(
+    timezone=settings.timezone,
+    log_file=settings.log_file or None,
+    level=settings.log_level,
+)
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="CaduTrack", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.cors_origin_list,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 app.include_router(health.router)
+
+logger.info("CaduTrack API started")

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,7 +1,21 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Response, status
+
+from app.db.session import check_connection
 
 router = APIRouter()
 
+
 @router.get("/health")
-async def health():
-    return {"status": "ok"}
+async def health(response: Response):
+    """Liveness/readiness probe.
+
+    Reports the database separately so monitoring can tell a live service with
+    an unreachable database apart from a service that is down entirely.
+    """
+    database_ok = check_connection()
+    if not database_ok:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    return {
+        "status": "ok" if database_ok else "degraded",
+        "database": "ok" if database_ok else "unavailable",
+    }

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+pythonpath = .
+markers =
+    integration: marks tests that require a running PostgreSQL instance

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+pytest>=7.4
+pytest-mock>=3.10
+httpx>=0.27
+ruff>=0.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,8 @@
 fastapi>=0.136,<1.0
 uvicorn[standard]>=0.44,<1.0
+sqlalchemy>=2.0,<3.0
+alembic>=1.16,<2.0
+psycopg[binary]>=3.2,<4.0
+pydantic-settings>=2.0,<3.0
+python-json-logger>=3.3,<4.0
+pytz>=2025.1

--- a/backend/ruff.toml
+++ b/backend/ruff.toml
@@ -1,0 +1,22 @@
+# Ruff linter configuration
+# Run locally: ruff check .
+# Run with auto-fix: ruff check --fix .
+
+line-length = 120
+
+[lint]
+# E/W = pycodestyle errors/warnings
+# F   = pyflakes (undefined names, unused imports, etc.)
+# I   = isort (import ordering)
+select = ["E", "W", "F", "I"]
+
+ignore = [
+    "E501",  # line too long — enforced by line-length above, but some strings are intentionally long
+]
+
+# Don't lint generated files or local scratch dirs
+exclude = [
+    "alembic/versions/",
+    "env/",
+    ".venv/",
+]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Shared pytest fixtures."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """FastAPI test client for the CaduTrack app."""
+    return TestClient(app)

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,66 @@
+"""Configuration and structured-logging tests."""
+
+import json
+import logging
+
+from app.config import Settings
+from app.logging_config import SERVICE_NAME, _JsonFormatter
+
+
+def test_database_url_is_built_from_parts():
+    settings = Settings(
+        db_host="apollo-server-db",
+        db_port=5432,
+        db_name="cadutrack",
+        db_user="julio",
+        db_password="s3cr3t",
+    )
+    assert settings.database_url == "postgresql+psycopg://julio:s3cr3t@apollo-server-db:5432/cadutrack"
+
+
+def test_database_url_escapes_special_characters():
+    settings = Settings(db_user="ju lio", db_password="p@ss/word")
+    assert "ju+lio:p%40ss%2Fword@" in settings.database_url
+
+
+def test_database_url_omits_empty_password():
+    settings = Settings(db_user="julio", db_password="")
+    assert "postgresql+psycopg://julio@" in settings.database_url
+
+
+def test_cors_origins_are_split_and_trimmed():
+    settings = Settings(cors_origins="http://localhost:5173, https://cadutrack.example.com ,")
+    assert settings.cors_origin_list == ["http://localhost:5173", "https://cadutrack.example.com"]
+
+
+def test_log_record_matches_the_shared_json_shape():
+    """Logs must carry the fields Promtail extracts for every apollo-server service."""
+    formatter = _JsonFormatter(fmt="%(message)s", tz="America/Mexico_City")
+    record = logging.LogRecord(
+        name="app.routers.products",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=1,
+        msg="something happened",
+        args=(),
+        exc_info=None,
+    )
+
+    payload = json.loads(formatter.format(record))
+
+    assert payload["level"] == "WARNING"
+    assert payload["logger"] == "app.routers.products"
+    assert payload["message"] == "something happened"
+    assert payload["service"] == SERVICE_NAME
+    assert payload["timestamp"].endswith(("-06:00", "-05:00"))
+    # Noisy duplicates from the base formatter must not leak through.
+    assert not {"asctime", "name", "levelname"} & payload.keys()
+
+
+def test_unknown_timezone_falls_back_to_utc():
+    formatter = _JsonFormatter(fmt="%(message)s", tz="Mars/Olympus_Mons")
+    record = logging.LogRecord(
+        name="app", level=logging.INFO, pathname=__file__, lineno=1,
+        msg="hi", args=(), exc_info=None,
+    )
+    assert json.loads(formatter.format(record))["timestamp"].endswith("+00:00")

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,22 @@
+"""Health endpoint tests."""
+
+from app import routers
+
+
+def test_health_reports_ok_when_database_answers(client, monkeypatch):
+    monkeypatch.setattr(routers.health, "check_connection", lambda: True)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "database": "ok"}
+
+
+def test_health_reports_degraded_when_database_is_unreachable(client, monkeypatch):
+    """A live API with a dead database must not look healthy to monitoring."""
+    monkeypatch.setattr(routers.health, "check_connection", lambda: False)
+
+    response = client.get("/health")
+
+    assert response.status_code == 503
+    assert response.json() == {"status": "degraded", "database": "unavailable"}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -18,6 +18,12 @@ export default defineConfig([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      // recommendedTypeChecked pulls in rules that need type information, so the
+      // parser has to build a TypeScript program for each linted file.
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
   },
 ])

--- a/readme.md
+++ b/readme.md
@@ -19,8 +19,8 @@ A food expiry tracker app to register purchased food items, their expiration dat
 | Layer      | Technology                              |
 |------------|-----------------------------------------|
 | Frontend   | React + Vite + TypeScript (PWA enabled) |
-| Backend    | FastAPI + PostgreSQL                    |
-| Migrations | yoyo-migrations (schema-per-API)        |
+| Backend    | FastAPI + SQLAlchemy + PostgreSQL       |
+| Migrations | Alembic (schema-per-service)            |
 | Alerts     | APScheduler + Telegram Bot API          |
 | Hosting    | Home server via Cloudflare Tunnel       |
 
@@ -59,6 +59,10 @@ cadutrack/
 | created_at | timestamp                         |
 | updated_at | timestamp                         |
 
+> CaduTrack owns the database `cadutrack` and the schema `cadutrack` inside the
+> shared `apollo-server-db` PostgreSQL instance. It does not run its own database
+> server. Alembic's version table lives in `public`.
+
 ### Expiry Status Logic
 
 | Status          | Condition                  |
@@ -73,12 +77,12 @@ cadutrack/
 
 | Phase   | Scope                        | Issues   |
 |---------|------------------------------|----------|
-| Phase 0 | Foundation                   | #1–#4    |
-| Phase 1 | Backend Core                 | #5–#10   |
-| Phase 2 | Frontend                     | #11–#16  |
-| Phase 3 | Telegram Alerts              | #17–#20  |
-| Phase 4 | PWA & Deployment             | #21–#26  |
-| Phase 5 | Enhancements / Backlog       | #27–#30  |
+| Phase 0 | Foundation                   | #1–#3, #38 |
+| Phase 1 | Backend Core                 | #8–#13   |
+| Phase 2 | Frontend                     | #14–#19  |
+| Phase 3 | Telegram Alerts              | #20–#23  |
+| Phase 4 | PWA & Deployment             | #24–#29, #37 |
+| Phase 5 | Enhancements / Backlog       | #30–#33, #36 |
 
 ---
 
@@ -87,14 +91,14 @@ cadutrack/
 This project follows a **branch-per-issue** strategy:
 
 ```
-feature/<issue-number>-<short-description>
+<type>-<issue-number>/<short-description>
 ```
 
 **Examples:**
 ```
-feature/5-database-migrations
-feature/11-product-list-ui
-feature/17-telegram-bot-setup
+feat-8/database-migrations
+feat-15/product-list-ui
+fix-21/expiry-alert-timezone
 ```
 
 Steps for each issue:
@@ -113,9 +117,9 @@ Steps for each issue:
 
 ```bash
 cd backend
-python -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
+python -m venv env
+source env/bin/activate
+pip install -r requirements-dev.txt
 ```
 
 Configure environment variables:
@@ -128,7 +132,7 @@ cp .env.example .env
 Run migrations:
 
 ```bash
-yoyo apply
+alembic upgrade head
 ```
 
 Start the server:
@@ -149,12 +153,20 @@ npm run dev
 
 ## Environment Variables
 
-| Variable              | Description                          |
-|-----------------------|--------------------------------------|
-| `DATABASE_URL`        | PostgreSQL connection string         |
-| `TELEGRAM_BOT_TOKEN`  | Token from @BotFather                |
-| `TELEGRAM_CHAT_ID`    | Target chat ID for alerts            |
-| `ALERT_DAYS_BEFORE`   | Days before expiry to trigger alert  |
+See [`backend/.env.example`](backend/.env.example) for the full documented list.
+
+| Variable              | Description                                        |
+|-----------------------|----------------------------------------------------|
+| `DB_HOST` / `DB_PORT` | Shared `apollo-server-db` host and port            |
+| `DB_NAME`             | Database owned by this service (`cadutrack`)       |
+| `DB_USER` / `DB_PASSWORD` | PostgreSQL credentials                         |
+| `DB_SCHEMA`           | Schema owned by this service (`cadutrack`)         |
+| `API_KEY`             | Protects mutating endpoints via `X-API-Key`        |
+| `TELEGRAM_BOT_TOKEN`  | Token from @BotFather                              |
+| `TELEGRAM_CHAT_ID`    | Target chat ID for alerts                          |
+| `ALERT_DAYS_AHEAD`    | Days before expiry to trigger alert                |
+| `TIMEZONE`            | IANA timezone for log timestamps and alert times   |
+| `LOG_FILE`            | Rotating JSON log path; empty means stdout only    |
 
 ---
 


### PR DESCRIPTION
Foundation the rest of Phase 1 depends on. Built to match the conventions already in use by `free-games-notifier`, so both services stay consistent on the home server.

## What's here

| Area | Change |
|---|---|
| Config | `app/config.py` — typed, env-driven settings; `database_url` built from `DB_*` parts. Full `.env.example`. |
| Logging | `app/logging_config.py` — the same single-line JSON format as free-games-notifier: `timestamp` (ISO 8601 + offset), `level`, `logger`, `message`, `service`. One Promtail pipeline parses both services. |
| Database | SQLAlchemy engine with `search_path` pinned to CaduTrack's own schema on the shared `apollo-server-db` instance; `Base` carries the schema and a constraint naming convention. |
| Migrations | Alembic wired to the same settings. Creates the service schema if missing; version table stays in `public`, matching the other services. |
| Health | `/health` now reports database reachability, so monitoring can tell a live API with a dead database apart from a service that is down. |
| CI | `tests.yml` — ruff + pytest for the backend, eslint + `tsc -b && vite build` for the frontend. |
| Tooling | `ruff.toml`, `pytest.ini`, `requirements-dev.txt` mirroring the house configuration. |

## Verification

- `alembic upgrade head` against the local `apollo-server-db` created schema `cadutrack` and `public.alembic_version`.
- `/health` returns `200 {"status":"ok","database":"ok"}` connected, `503 {"status":"degraded","database":"unavailable"}` with no database.
- 8 tests pass; `ruff check .` clean; frontend eslint and build pass.

## Deliberate deviations from free-games-notifier

- **`pydantic-settings` instead of hand-parsed `os.getenv`** — FastAPI already pulls in Pydantic, so typed settings and validation come free.
- **`psycopg` v3 instead of `psycopg2-binary`** — new project, no reason to start on the older driver.
- **Version ranges instead of pins** — keeps the decision made in this repo's "Simplified requirements" commit.
- **`LOG_FILE` is optional** — free-games-notifier hardcodes `/mnt/logs/notifier.log`, which fails outside Docker. Here the file handler is attached only when its directory is writable; stdout always works.
- **`ALERT_DAYS_AHEAD`** adopted as canonical (the readme's `ALERT_DAYS_BEFORE` was the outlier).

The health check logs a one-line reason rather than `logger.exception` — `/health` is polled continuously, so a full SQLAlchemy traceback per probe would flood Loki whenever the database is down.

## Readme corrections

Updated where it no longer matched reality: Alembic instead of yoyo-migrations, the shared-instance/schema-per-service model, the branch naming pattern actually in use, the environment variable table, and the roadmap issue ranges.

Closes #13
Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added database connectivity monitoring to the health check, including clear healthy and degraded responses.
  - Added configurable application settings for database access, security, alerts, logging, and cross-origin requests.
  - Added database migration support for safer schema updates.

- **Documentation**
  - Updated setup, environment configuration, development workflow, migration, and branching guidance.

- **Tests**
  - Added automated backend and frontend validation, including linting, builds, configuration checks, logging, and health-status coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->