### PR TITLE
feat: seed the default category list (#9)

### DIFF
--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -1,0 +1,78 @@
+"""Seed the default category list.
+
+Idempotent: running it repeatedly inserts nothing new, so it is safe to call on
+every deploy. Categories the user has since renamed or deleted are left alone —
+only names that are absent get inserted.
+
+Run it after applying migrations:
+
+    alembic upgrade head
+    python -m app.seed
+"""
+
+import logging
+
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+
+from app.db.session import SessionLocal
+from app.logging_config import setup_logging
+from app.models import Category
+
+# Explicit rather than __name__: running this as `python -m app.seed` would
+# otherwise label every line "__main__" in Loki.
+logger = logging.getLogger("app.seed")
+
+# Spanish, because these are user-facing labels the user edits directly.
+# Unlike Product.location, category names are data rather than keys.
+DEFAULT_CATEGORIES: tuple[str, ...] = (
+    "Lácteos",
+    "Carnes",
+    "Verduras",
+    "Frutas",
+    "Cereales",
+    "Bebidas",
+    "Snacks",
+    "Congelados",
+    "Otros",
+)
+
+
+def seed_categories(session: Session) -> int:
+    """Insert any missing default categories and return how many were added.
+
+    Uses ON CONFLICT DO NOTHING against the unique name constraint rather than
+    a read-then-write, so concurrent runs cannot race each other into an error.
+    """
+    statement = (
+        insert(Category)
+        .values([{"name": name} for name in DEFAULT_CATEGORIES])
+        .on_conflict_do_nothing(index_elements=["name"])
+        .returning(Category.name)
+    )
+    inserted = session.execute(statement).scalars().all()
+    session.commit()
+
+    if inserted:
+        logger.info("Seeded %d default categories: %s", len(inserted), ", ".join(inserted))
+    else:
+        logger.info("Default categories already present, nothing to seed")
+
+    return len(inserted)
+
+
+def main() -> None:
+    """Entry point for `python -m app.seed`."""
+    from app.config import settings
+
+    setup_logging(
+        timezone=settings.timezone,
+        log_file=settings.log_file or None,
+        level=settings.log_level,
+    )
+    with SessionLocal() as session:
+        seed_categories(session)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,3 +10,26 @@ from app.main import app
 def client() -> TestClient:
     """FastAPI test client for the CaduTrack app."""
     return TestClient(app)
+
+
+@pytest.fixture
+def db_session():
+    """Session against a live database, skipping when one is not reachable.
+
+    Used by tests marked `integration`; CI excludes that marker.
+    """
+    from sqlalchemy.exc import SQLAlchemyError
+
+    from app.db.session import SessionLocal, check_connection
+
+    if not check_connection():
+        pytest.skip("no reachable database")
+
+    session = SessionLocal()
+    try:
+        yield session
+    except SQLAlchemyError:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -1,0 +1,47 @@
+"""Tests for the default category seed."""
+
+import pytest
+from sqlalchemy import delete, select
+
+from app.models import Category
+from app.seed import DEFAULT_CATEGORIES, seed_categories
+
+
+def test_default_categories_have_no_duplicates():
+    """A duplicate would be silently swallowed by ON CONFLICT DO NOTHING."""
+    assert len(set(DEFAULT_CATEGORIES)) == len(DEFAULT_CATEGORIES)
+
+
+def test_default_categories_are_in_spanish():
+    """Category names are user-facing labels, and the UI is Spanish."""
+    english_leftovers = {"Dairy", "Meat", "Vegetables", "Fruits", "Grains", "Beverages", "Frozen", "Other"}
+    assert not english_leftovers & set(DEFAULT_CATEGORIES)
+    assert "Lácteos" in DEFAULT_CATEGORIES
+
+
+@pytest.mark.integration
+def test_seeding_twice_inserts_nothing_the_second_time(db_session):
+    """The script runs on every deploy, so it must be idempotent."""
+    db_session.execute(delete(Category))
+    db_session.commit()
+
+    assert seed_categories(db_session) == len(DEFAULT_CATEGORIES)
+    assert seed_categories(db_session) == 0
+
+    names = set(db_session.execute(select(Category.name)).scalars())
+    assert names == set(DEFAULT_CATEGORIES)
+
+
+@pytest.mark.integration
+def test_seeding_fills_only_the_missing_categories(db_session):
+    """Deleting one category and re-seeding must not duplicate the others."""
+    db_session.execute(delete(Category))
+    db_session.commit()
+    seed_categories(db_session)
+
+    db_session.execute(delete(Category).where(Category.name == "Snacks"))
+    db_session.commit()
+
+    assert seed_categories(db_session) == 1
+    names = list(db_session.execute(select(Category.name)).scalars())
+    assert len(names) == len(set(names)) == len(DEFAULT_CATEGORIES)

--- a/readme.md
+++ b/readme.md
@@ -129,11 +129,15 @@ cp .env.example .env
 # Edit .env with your database URL, Telegram bot token, etc.
 ```
 
-Run migrations:
+Run migrations and seed the default categories:
 
 ```bash
 alembic upgrade head
+python -m app.seed
 ```
+
+The seed is idempotent — re-running it inserts only categories that are missing,
+so it is safe to run on every deploy.
 
 Start the server:
 


### PR DESCRIPTION
Adds `python -m app.seed`, documented in the readme as the step after `alembic upgrade head`.

## Categories

Spanish, per the language decision for this project — these are user-facing labels the user edits directly, unlike `Product.location`, which stores language-neutral keys:

`Lácteos` · `Carnes` · `Verduras` · `Frutas` · `Cereales` · `Bebidas` · `Snacks` · `Congelados` · `Otros`

## Idempotency

A seed that can only run once is a seed you cannot put in a deploy script, so this one uses `ON CONFLICT DO NOTHING` against `uq_categories_name` rather than a read-then-write. Two consequences worth knowing:

- Running it repeatedly inserts nothing new — safe on every deploy.
- Concurrent runs cannot race each other into an integrity error, which a check-then-insert would allow.
- Categories the user renamed or deleted are **not** resurrected as edits, but a deleted *default* name will come back on the next run, since the script only knows names. That is the trade-off for making it re-runnable.

## Verification

Against the local `apollo-server-db`: first run inserted 9, second run inserted 0 and logged "already present". Deleting one category and re-seeding inserted exactly 1, leaving no duplicates. 19 tests pass (17 without a database, matching what CI runs), ruff clean.

Also fixed the logger name: running the module as `python -m app.seed` made every line show up as `__main__` in Loki, so it is now set explicitly to `app.seed`.

## One thing worth your call

**`Congelados` overlaps with `location = 'freezer'`.** Frozen is a storage state, not a food category — a bag of frozen peas is arguably `Verduras` stored in the freezer. Keeping it means some products will be categorised by where they live instead of what they are, which will make the category filter in #19 less useful.

I kept it because it was in the issue's list and dropping items from your spec is your call, not mine. If you agree it is redundant, removing it is a one-line change to `DEFAULT_CATEGORIES`.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)