### PR TITLE
feat: CRUD endpoints for categories and products (#10, #11)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  # ─── Backend: lint + unit tests ──────────────────────────────────────────────
+  # ─── Backend: lint + tests against a real PostgreSQL ─────────────────────────
   backend:
     runs-on: ubuntu-latest
     permissions:
@@ -18,6 +18,30 @@ jobs:
     defaults:
       run:
         working-directory: backend
+
+    # A throwaway PostgreSQL so the integration tests exercise the real schema,
+    # triggers and constraints rather than being skipped.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: cadutrack
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_NAME: cadutrack
+      DB_USER: postgres
+      DB_PASSWORD: postgres
 
     steps:
       - name: Checkout code
@@ -43,8 +67,11 @@ jobs:
       - name: Lint (ruff)
         run: ruff check . --output-format github
 
+      - name: Apply migrations
+        run: alembic upgrade head
+
       - name: Run tests
-        run: pytest tests/ -v --tb=short -m "not integration"
+        run: pytest tests/ -v --tb=short
 
   # ─── Frontend: TypeScript type-check + build ─────────────────────────────────
   frontend:

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -3,7 +3,7 @@
 import logging
 from collections.abc import Generator
 
-from sqlalchemy import create_engine, event, text
+from sqlalchemy import create_engine, text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -15,19 +15,15 @@ engine = create_engine(
     settings.database_url,
     pool_pre_ping=True,
     future=True,
-    connect_args={"connect_timeout": settings.db_connect_timeout},
+    connect_args={
+        "connect_timeout": settings.db_connect_timeout,
+        # Pin the schema at connection setup rather than with a SET statement.
+        # apollo-server-db is shared, so we never rely on the default
+        # search_path — and a SET issued from a "connect" event runs inside a
+        # transaction that SQLAlchemy later rolls back, silently losing it.
+        "options": f"-c search_path={settings.db_schema},public",
+    },
 )
-
-
-@event.listens_for(engine, "connect")
-def _set_search_path(dbapi_connection, connection_record):
-    """Pin every new connection to CaduTrack's schema.
-
-    The apollo-server-db instance is shared across services, so we never rely on
-    the default search_path.
-    """
-    with dbapi_connection.cursor() as cursor:
-        cursor.execute(f'SET search_path TO "{settings.db_schema}", public')
 
 
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.logging_config import setup_logging
-from app.routers import health
+from app.routers import categories, health, products
 
 # Configure structured logging before anything else emits a record.
 setup_logging(
@@ -27,5 +27,7 @@ app.add_middleware(
 )
 
 app.include_router(health.router)
+app.include_router(categories.router)
+app.include_router(products.router)
 
 logger.info("CaduTrack API started")

--- a/backend/app/routers/categories.py
+++ b/backend/app/routers/categories.py
@@ -1,0 +1,57 @@
+"""Category CRUD endpoints."""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.models import Category
+from app.schemas.category import CategoryCreate, CategoryRead
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/categories", tags=["categories"])
+
+
+@router.get("", response_model=list[CategoryRead])
+def list_categories(db: Session = Depends(get_db)) -> list[Category]:
+    """List every category, alphabetically."""
+    return list(db.execute(select(Category).order_by(Category.name)).scalars())
+
+
+@router.post("", response_model=CategoryRead, status_code=status.HTTP_201_CREATED)
+def create_category(payload: CategoryCreate, db: Session = Depends(get_db)) -> Category:
+    """Create a category. Names are unique."""
+    category = Category(name=payload.name)
+    db.add(category)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A category named {payload.name!r} already exists",
+        ) from None
+    db.refresh(category)
+    logger.info("Created category %s (%s)", category.id, category.name)
+    return category
+
+
+@router.delete("/{category_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_category(category_id: int, db: Session = Depends(get_db)) -> Response:
+    """Delete a category.
+
+    Its products are kept and become uncategorised — the food is still in the
+    fridge even if the label is gone.
+    """
+    category = db.get(Category, category_id)
+    if category is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
+
+    db.delete(category)
+    db.commit()
+    logger.info("Deleted category %s (%s)", category_id, category.name)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/routers/products.py
+++ b/backend/app/routers/products.py
@@ -1,0 +1,119 @@
+"""Product CRUD endpoints."""
+
+import logging
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from app.db.session import get_db
+from app.models import Category, Location, Product
+from app.schemas.product import ProductCreate, ProductRead, ProductUpdate
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/products", tags=["products"])
+
+
+def _get_or_404(db: Session, product_id: int) -> Product:
+    product = db.get(Product, product_id)
+    if product is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    return product
+
+
+def _validate_category(db: Session, category_id: int | None) -> None:
+    """Reject an unknown category with a readable error.
+
+    Left to the database this would surface as a foreign key violation, which
+    tells the client nothing useful.
+    """
+    if category_id is None:
+        return
+    if db.get(Category, category_id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Category {category_id} does not exist",
+        )
+
+
+@router.get("", response_model=list[ProductRead])
+def list_products(
+    db: Session = Depends(get_db),
+    category_id: int | None = Query(default=None, description="Only products in this category"),
+    location: Location | None = Query(default=None, description="Only products stored here"),
+    expires_before: date | None = Query(
+        default=None, description="Only products expiring strictly before this date"
+    ),
+) -> list[Product]:
+    """List products, soonest to expire first.
+
+    Ordering is the point of the app: what is about to go off has to be at the
+    top without the client having to sort.
+    """
+    statement = (
+        select(Product)
+        # Without this the category of every row is a separate query.
+        .options(selectinload(Product.category))
+        .order_by(Product.expires_at, Product.name)
+    )
+
+    if category_id is not None:
+        statement = statement.where(Product.category_id == category_id)
+    if location is not None:
+        statement = statement.where(Product.location == location.value)
+    if expires_before is not None:
+        statement = statement.where(Product.expires_at < expires_before)
+
+    return list(db.execute(statement).scalars())
+
+
+@router.get("/{product_id}", response_model=ProductRead)
+def get_product(product_id: int, db: Session = Depends(get_db)) -> Product:
+    """Fetch a single product."""
+    return _get_or_404(db, product_id)
+
+
+@router.post("", response_model=ProductRead, status_code=status.HTTP_201_CREATED)
+def create_product(payload: ProductCreate, db: Session = Depends(get_db)) -> Product:
+    """Create a product."""
+    _validate_category(db, payload.category_id)
+
+    product = Product(**payload.model_dump())
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    logger.info("Created product %s (%s) expiring %s", product.id, product.name, product.expires_at)
+    return product
+
+
+@router.put("/{product_id}", response_model=ProductRead)
+def replace_product(
+    product_id: int, payload: ProductUpdate, db: Session = Depends(get_db)
+) -> Product:
+    """Replace a product. Omitted optional fields are cleared, per PUT semantics."""
+    product = _get_or_404(db, product_id)
+    _validate_category(db, payload.category_id)
+
+    for field, value in payload.model_dump().items():
+        setattr(product, field, value)
+
+    db.commit()
+    # updated_at is set by a database trigger, so the in-session value is stale
+    # until we read it back.
+    db.refresh(product)
+    logger.info("Updated product %s (%s)", product.id, product.name)
+    return product
+
+
+@router.delete("/{product_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_product(product_id: int, db: Session = Depends(get_db)) -> Response:
+    """Delete a product."""
+    product = _get_or_404(db, product_id)
+    name = product.name
+
+    db.delete(product)
+    db.commit()
+    logger.info("Deleted product %s (%s)", product_id, name)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/schemas/category.py
+++ b/backend/app/schemas/category.py
@@ -1,0 +1,21 @@
+"""Category request and response schemas."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CategoryCreate(BaseModel):
+    """Payload for creating a category."""
+
+    name: str = Field(min_length=1, max_length=100)
+
+
+class CategoryRead(BaseModel):
+    """A category as returned by the API."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    created_at: datetime

--- a/backend/app/schemas/product.py
+++ b/backend/app/schemas/product.py
@@ -1,0 +1,46 @@
+"""Product request and response schemas."""
+
+from datetime import date, datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models import Location
+from app.schemas.category import CategoryRead
+
+
+class ProductBase(BaseModel):
+    """Fields a client may set on a product."""
+
+    name: str = Field(min_length=1, max_length=255)
+    category_id: int | None = None
+    # gt=0 mirrors ck_products_quantity_positive, so a bad value is rejected
+    # with a readable 422 instead of a database integrity error.
+    quantity: Decimal = Field(default=Decimal(1), gt=0, max_digits=10, decimal_places=2)
+    unit: str | None = Field(default=None, max_length=50)
+    expires_at: date
+    location: Location
+    notes: str | None = None
+
+
+class ProductCreate(ProductBase):
+    """Payload for creating a product."""
+
+
+class ProductUpdate(ProductBase):
+    """Payload for replacing a product.
+
+    PUT semantics: every field is sent, and omitted optional fields are cleared.
+    """
+
+
+class ProductRead(ProductBase):
+    """A product as returned by the API."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    # Nested so the list view can show the category name without a second call.
+    category: CategoryRead | None = None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -25,6 +25,10 @@ logger = logging.getLogger("app.seed")
 
 # Spanish, because these are user-facing labels the user edits directly.
 # Unlike Product.location, category names are data rather than keys.
+#
+# Deliberately no "Congelados": frozen is a storage state, already covered by
+# Product.location == "freezer". Frozen peas are Verduras that live in the
+# freezer, and categorising them by location would weaken the category filter.
 DEFAULT_CATEGORIES: tuple[str, ...] = (
     "Lácteos",
     "Carnes",
@@ -33,7 +37,6 @@ DEFAULT_CATEGORIES: tuple[str, ...] = (
     "Cereales",
     "Bebidas",
     "Snacks",
-    "Congelados",
     "Otros",
 )
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,7 +8,7 @@ from app.main import app
 
 @pytest.fixture
 def client() -> TestClient:
-    """FastAPI test client for the CaduTrack app."""
+    """FastAPI test client with no database wiring."""
     return TestClient(app)
 
 
@@ -16,8 +16,12 @@ def client() -> TestClient:
 def db_session():
     """Session against a live database, skipping when one is not reachable.
 
-    Used by tests marked `integration`; CI excludes that marker.
+    Tables are emptied before each test rather than after, so a failing test
+    leaves its rows behind for inspection.
+
+    Used by tests marked `integration`.
     """
+    from sqlalchemy import text
     from sqlalchemy.exc import SQLAlchemyError
 
     from app.db.session import SessionLocal, check_connection
@@ -26,6 +30,8 @@ def db_session():
         pytest.skip("no reachable database")
 
     session = SessionLocal()
+    session.execute(text("TRUNCATE products, categories RESTART IDENTITY CASCADE"))
+    session.commit()
     try:
         yield session
     except SQLAlchemyError:
@@ -33,3 +39,13 @@ def db_session():
         raise
     finally:
         session.close()
+
+
+@pytest.fixture
+def api_client(db_session) -> TestClient:
+    """Test client whose requests share the test's database session."""
+    from app.db.session import get_db
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    yield TestClient(app)
+    app.dependency_overrides.clear()

--- a/backend/tests/test_categories_api.py
+++ b/backend/tests/test_categories_api.py
@@ -1,0 +1,55 @@
+"""Category endpoint tests."""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_create_and_list_categories(api_client):
+    created = api_client.post("/categories", json={"name": "Lácteos"})
+    assert created.status_code == 201
+    assert created.json()["name"] == "Lácteos"
+
+    api_client.post("/categories", json={"name": "Bebidas"})
+
+    listed = api_client.get("/categories")
+    assert listed.status_code == 200
+    # Alphabetical, not insertion order.
+    assert [c["name"] for c in listed.json()] == ["Bebidas", "Lácteos"]
+
+
+def test_duplicate_category_name_is_rejected(api_client):
+    api_client.post("/categories", json={"name": "Carnes"})
+    duplicate = api_client.post("/categories", json={"name": "Carnes"})
+
+    assert duplicate.status_code == 409
+    assert "already exists" in duplicate.json()["detail"]
+
+
+def test_blank_category_name_is_rejected(api_client):
+    assert api_client.post("/categories", json={"name": ""}).status_code == 422
+
+
+def test_deleting_a_category_keeps_its_products(api_client):
+    """Deleting a label must not delete food the user still has."""
+    category_id = api_client.post("/categories", json={"name": "Verduras"}).json()["id"]
+    api_client.post(
+        "/products",
+        json={
+            "name": "Espinacas",
+            "category_id": category_id,
+            "expires_at": "2026-12-01",
+            "location": "fridge",
+        },
+    )
+
+    assert api_client.delete(f"/categories/{category_id}").status_code == 204
+
+    products = api_client.get("/products").json()
+    assert len(products) == 1
+    assert products[0]["category_id"] is None
+    assert products[0]["category"] is None
+
+
+def test_deleting_a_missing_category_is_404(api_client):
+    assert api_client.delete("/categories/9999").status_code == 404

--- a/backend/tests/test_products_api.py
+++ b/backend/tests/test_products_api.py
@@ -1,0 +1,139 @@
+"""Product endpoint tests."""
+
+from datetime import date, timedelta
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _product(**overrides) -> dict:
+    payload = {
+        "name": "Leche entera",
+        "quantity": "2.00",
+        "unit": "litros",
+        "expires_at": str(date.today() + timedelta(days=5)),
+        "location": "fridge",
+        "notes": "abierto",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_create_returns_the_stored_product(api_client):
+    response = api_client.post("/products", json=_product())
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["name"] == "Leche entera"
+    assert body["location"] == "fridge"
+    assert body["quantity"] == "2.00"
+    assert body["id"] > 0
+
+
+def test_products_are_listed_soonest_to_expire_first(api_client):
+    """The whole point of the app is that what is about to go off is on top."""
+    today = date.today()
+    for days, name in ((30, "Arroz"), (2, "Yogur"), (10, "Queso")):
+        api_client.post("/products", json=_product(name=name, expires_at=str(today + timedelta(days=days))))
+
+    names = [p["name"] for p in api_client.get("/products").json()]
+    assert names == ["Yogur", "Queso", "Arroz"]
+
+
+def test_list_embeds_the_category(api_client):
+    category_id = api_client.post("/categories", json={"name": "Lácteos"}).json()["id"]
+    api_client.post("/products", json=_product(category_id=category_id))
+
+    product = api_client.get("/products").json()[0]
+    assert product["category"]["name"] == "Lácteos"
+
+
+def test_filters_narrow_the_list(api_client):
+    today = date.today()
+    dairy = api_client.post("/categories", json={"name": "Lácteos"}).json()["id"]
+    api_client.post("/products", json=_product(name="Yogur", category_id=dairy, location="fridge",
+                                               expires_at=str(today + timedelta(days=3))))
+    api_client.post("/products", json=_product(name="Arroz", location="pantry",
+                                               expires_at=str(today + timedelta(days=200))))
+    api_client.post("/products", json=_product(name="Guisantes", location="freezer",
+                                               expires_at=str(today + timedelta(days=100))))
+
+    by_location = api_client.get("/products", params={"location": "pantry"}).json()
+    assert [p["name"] for p in by_location] == ["Arroz"]
+
+    by_category = api_client.get("/products", params={"category_id": dairy}).json()
+    assert [p["name"] for p in by_category] == ["Yogur"]
+
+    expiring = api_client.get(
+        "/products", params={"expires_before": str(today + timedelta(days=7))}
+    ).json()
+    assert [p["name"] for p in expiring] == ["Yogur"]
+
+
+def test_filters_combine(api_client):
+    today = date.today()
+    api_client.post("/products", json=_product(name="Yogur", location="fridge",
+                                               expires_at=str(today + timedelta(days=3))))
+    api_client.post("/products", json=_product(name="Leche", location="fridge",
+                                               expires_at=str(today + timedelta(days=90))))
+
+    result = api_client.get(
+        "/products",
+        params={"location": "fridge", "expires_before": str(today + timedelta(days=7))},
+    ).json()
+    assert [p["name"] for p in result] == ["Yogur"]
+
+
+def test_unknown_location_is_rejected(api_client):
+    assert api_client.post("/products", json=_product(location="garage")).status_code == 422
+
+
+def test_non_positive_quantity_is_rejected(api_client):
+    """Caught by the schema, so the client gets a readable error not a DB failure."""
+    response = api_client.post("/products", json=_product(quantity="0"))
+    assert response.status_code == 422
+    assert "quantity" in str(response.json())
+
+
+def test_unknown_category_is_rejected_with_a_useful_message(api_client):
+    response = api_client.post("/products", json=_product(category_id=9999))
+    assert response.status_code == 422
+    assert "9999" in response.json()["detail"]
+
+
+def test_replacing_a_product_clears_omitted_fields(api_client):
+    """PUT is a full replace: notes left out of the payload must not survive."""
+    product_id = api_client.post("/products", json=_product(notes="abierto")).json()["id"]
+
+    payload = _product(name="Leche desnatada", quantity="1.00")
+    del payload["notes"]
+    replaced = api_client.put(f"/products/{product_id}", json=payload)
+
+    assert replaced.status_code == 200
+    body = replaced.json()
+    assert body["name"] == "Leche desnatada"
+    assert body["quantity"] == "1.00"
+    assert body["notes"] is None
+
+
+def test_replacing_bumps_updated_at(api_client):
+    """updated_at comes from a database trigger, so it must be read back."""
+    created = api_client.post("/products", json=_product()).json()
+    updated = api_client.put(f"/products/{created['id']}", json=_product(name="Leche fresca")).json()
+
+    assert updated["updated_at"] > created["updated_at"]
+
+
+def test_delete_removes_the_product(api_client):
+    product_id = api_client.post("/products", json=_product()).json()["id"]
+
+    assert api_client.delete(f"/products/{product_id}").status_code == 204
+    assert api_client.get(f"/products/{product_id}").status_code == 404
+    assert api_client.get("/products").json() == []
+
+
+@pytest.mark.parametrize("method,path", [("get", "/products/9999"), ("put", "/products/9999"), ("delete", "/products/9999")])
+def test_missing_product_is_404(api_client, method, path):
+    kwargs = {"json": _product()} if method == "put" else {}
+    assert getattr(api_client, method)(path, **kwargs).status_code == 404

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -19,6 +19,15 @@ def test_default_categories_are_in_spanish():
     assert "Lácteos" in DEFAULT_CATEGORIES
 
 
+def test_no_category_duplicates_a_storage_location():
+    """Storage state belongs in Product.location, not in the category list.
+
+    A "Congelados" category would compete with location == "freezer" and make
+    the category filter describe where food is rather than what it is.
+    """
+    assert "Congelados" not in DEFAULT_CATEGORIES
+
+
 @pytest.mark.integration
 def test_seeding_twice_inserts_nothing_the_second_time(db_session):
     """The script runs on every deploy, so it must be idempotent."""


### PR DESCRIPTION
Both CRUD issues in one PR, since the product endpoints need categories to exist to be worth testing.

## Endpoints

| Method | Path | Notes |
|---|---|---|
| `GET` | `/categories` | Alphabetical |
| `POST` | `/categories` | 409 on duplicate name |
| `DELETE` | `/categories/{id}` | Products survive, uncategorised |
| `GET` | `/products` | Soonest to expire first; filters `category_id`, `location`, `expires_before` |
| `GET` | `/products/{id}` | |
| `POST` | `/products` | |
| `PUT` | `/products/{id}` | Full replace |
| `DELETE` | `/products/{id}` | |

## Decisions worth flagging

- **The product list is ordered by expiry, not by id.** That ordering is the entire point of the app, so it belongs in the API rather than being every client's job.
- **The category is embedded in each product**, loaded with `selectinload`, so #15 can show the category name without N+1 queries or a second round trip.
- **Deleting a category does not delete its products.** They become uncategorised — the food is still in the fridge even if the label is gone.
- **Validation is duplicated deliberately.** `quantity > 0` exists both as a Pydantic constraint and a database CHECK: the schema gives the client a readable 422, the CHECK stops anything else writing bad data.
- **An unknown `category_id` returns a 422 naming the id** instead of surfacing as an opaque foreign key violation.
- **`PUT` is a true replace**, so a field omitted from the payload is cleared rather than left alone. A partial-update `PATCH` can follow if the frontend wants one.
- **Products are re-read after `PUT`**, because `updated_at` is set by the database trigger and the in-session value would otherwise be stale.

## A bug this uncovered in the #13 foundation

`SET search_path` was issued from a SQLAlchemy `"connect"` event, which runs inside a transaction that SQLAlchemy then rolls back — **the search_path has never actually been applied**. It went unnoticed because `Base.metadata` schema-qualifies every ORM statement; only raw SQL saw it, and the first raw SQL in the test suite failed with `relation "products" does not exist`.

Now passed as `options=-c search_path=...` in `connect_args`, applied at connection establishment where no transaction can undo it. Verified: `SHOW search_path` returns `cadutrack,public` and an unqualified `SELECT ... FROM products` works.

## CI now runs a real database

The backend job gets a `postgres:16` service and applies migrations before pytest, so the integration tests exercise the actual schema, triggers and constraints instead of being skipped. Without this the entire CRUD layer would have had zero CI coverage.

## Also here

`Congelados` removed from the default categories, per your call on #41 — frozen is a storage state already covered by `location == 'freezer'`, and having both would file frozen peas by where they live instead of what they are. A test now guards against a category re-introducing a storage location.

## Verification

39 tests pass locally against `apollo-server-db`, ruff clean, no warnings. Coverage includes expiry ordering, each filter and their combination, the 409 on duplicate names, products surviving category deletion, `PUT` clearing omitted fields, `updated_at` advancing on replace, and 404s on every missing-product path.

Closes #10
Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)