### PR TITLE
feat: add expiry status to the products response (#12)

### DIFF
--- a/backend/app/expiry.py
+++ b/backend/app/expiry.py
@@ -1,0 +1,51 @@
+"""Expiry status calculation.
+
+Single source of truth for the fresh / expiring_soon / expired thresholds, so
+the API response, the daily alert and any future filter agree.
+"""
+
+from datetime import date, datetime
+from enum import StrEnum
+from zoneinfo import ZoneInfo
+
+from app.config import settings
+
+# A product is "expiring soon" from this many days out, inclusive.
+EXPIRING_SOON_DAYS = 7
+
+
+class ExpiryStatus(StrEnum):
+    """How urgent a product is."""
+
+    FRESH = "fresh"
+    EXPIRING_SOON = "expiring_soon"
+    EXPIRED = "expired"
+
+
+def today() -> date:
+    """Today's date in the configured timezone.
+
+    Not date.today(): the host's local date can be a day off from the user's
+    around midnight, which would mark food expired while it is still good.
+    An unknown TIMEZONE raises here rather than silently using UTC — quietly
+    doing expiry maths in the wrong zone is worse than a startup failure.
+    """
+    return datetime.now(ZoneInfo(settings.timezone)).date()
+
+
+def days_until_expiry(expires_at: date, reference: date | None = None) -> int:
+    """Whole days from the reference date until expiry. Negative once expired."""
+    return (expires_at - (reference or today())).days
+
+
+def expiry_status(days: int) -> ExpiryStatus:
+    """Bucket a day count.
+
+    A product expiring today counts as expiring soon, not expired — it is still
+    edible, and the point is to prompt the user to use it.
+    """
+    if days < 0:
+        return ExpiryStatus.EXPIRED
+    if days <= EXPIRING_SOON_DAYS:
+        return ExpiryStatus.EXPIRING_SOON
+    return ExpiryStatus.FRESH

--- a/backend/app/schemas/product.py
+++ b/backend/app/schemas/product.py
@@ -3,8 +3,9 @@
 from datetime import date, datetime
 from decimal import Decimal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
+from app.expiry import ExpiryStatus, days_until_expiry, expiry_status
 from app.models import Location
 from app.schemas.category import CategoryRead
 
@@ -44,3 +45,15 @@ class ProductRead(ProductBase):
     category: CategoryRead | None = None
     created_at: datetime
     updated_at: datetime
+
+    @computed_field
+    @property
+    def days_until_expiry(self) -> int:
+        """Whole days left. Negative once the product has expired."""
+        return days_until_expiry(self.expires_at)
+
+    @computed_field
+    @property
+    def status(self) -> ExpiryStatus:
+        """fresh / expiring_soon / expired, for the colour coding in #16."""
+        return expiry_status(self.days_until_expiry)

--- a/backend/tests/test_expiry.py
+++ b/backend/tests/test_expiry.py
@@ -1,0 +1,55 @@
+"""Expiry status calculation tests."""
+
+from datetime import date, timedelta
+
+import pytest
+
+from app.config import settings
+from app.expiry import EXPIRING_SOON_DAYS, ExpiryStatus, days_until_expiry, expiry_status, today
+
+
+@pytest.mark.parametrize(
+    "days,expected",
+    [
+        (-30, ExpiryStatus.EXPIRED),
+        (-1, ExpiryStatus.EXPIRED),
+        (0, ExpiryStatus.EXPIRING_SOON),
+        (1, ExpiryStatus.EXPIRING_SOON),
+        (7, ExpiryStatus.EXPIRING_SOON),
+        (8, ExpiryStatus.FRESH),
+        (365, ExpiryStatus.FRESH),
+    ],
+)
+def test_status_buckets(days, expected):
+    assert expiry_status(days) == expected
+
+
+def test_expiring_today_is_not_yet_expired():
+    """Food that expires today is still edible — the point is to prompt use."""
+    assert expiry_status(0) == ExpiryStatus.EXPIRING_SOON
+
+
+def test_the_boundary_is_inclusive():
+    assert expiry_status(EXPIRING_SOON_DAYS) == ExpiryStatus.EXPIRING_SOON
+    assert expiry_status(EXPIRING_SOON_DAYS + 1) == ExpiryStatus.FRESH
+
+
+def test_days_until_expiry_counts_from_the_reference_date():
+    reference = date(2026, 8, 29)
+    assert days_until_expiry(date(2026, 9, 5), reference) == 7
+    assert days_until_expiry(reference, reference) == 0
+    assert days_until_expiry(date(2026, 8, 27), reference) == -2
+
+
+def test_today_honours_the_configured_timezone(monkeypatch):
+    """Guards against someone swapping in date.today().
+
+    Kiritimati (UTC+14) and Niue (UTC-11) are 25 hours apart, so their dates
+    always differ — whatever the host's own timezone happens to be.
+    """
+    monkeypatch.setattr(settings, "timezone", "Pacific/Kiritimati")
+    ahead = today()
+    monkeypatch.setattr(settings, "timezone", "Pacific/Niue")
+    behind = today()
+
+    assert ahead - behind == timedelta(days=1)

--- a/backend/tests/test_products_api.py
+++ b/backend/tests/test_products_api.py
@@ -137,3 +137,34 @@ def test_delete_removes_the_product(api_client):
 def test_missing_product_is_404(api_client, method, path):
     kwargs = {"json": _product()} if method == "put" else {}
     assert getattr(api_client, method)(path, **kwargs).status_code == 404
+
+
+def test_response_carries_days_until_expiry_and_status(api_client):
+    """What the colour coding in #16 reads off each row."""
+    from app.expiry import today
+
+    reference = today()
+    cases = {
+        "Yogur": (-2, "expired"),
+        "Leche": (0, "expiring_soon"),
+        "Jamón": (7, "expiring_soon"),
+        "Arroz": (8, "fresh"),
+    }
+    for name, (offset, _) in cases.items():
+        api_client.post("/products", json=_product(name=name, expires_at=str(reference + timedelta(days=offset))))
+
+    for product in api_client.get("/products").json():
+        offset, expected_status = cases[product["name"]]
+        assert product["days_until_expiry"] == offset
+        assert product["status"] == expected_status
+
+
+def test_a_product_expiring_today_is_not_shown_as_expired(api_client):
+    """Explicitly: today is yellow, not red."""
+    from app.expiry import today
+
+    api_client.post("/products", json=_product(expires_at=str(today())))
+
+    product = api_client.get("/products").json()[0]
+    assert product["days_until_expiry"] == 0
+    assert product["status"] == "expiring_soon"

--- a/readme.md
+++ b/readme.md
@@ -68,8 +68,12 @@ cadutrack/
 | Status          | Condition                  |
 |-----------------|----------------------------|
 | `fresh`         | `days_until_expiry > 7`    |
-| `expiring_soon` | `days_until_expiry` 1–7    |
-| `expired`       | `days_until_expiry <= 0`   |
+| `expiring_soon` | `days_until_expiry` 0–7    |
+| `expired`       | `days_until_expiry < 0`    |
+
+A product expiring **today** counts as `expiring_soon`, not `expired` — it is
+still edible, and the point is to prompt the user to use it. "Today" is
+evaluated in `TIMEZONE`, not the host's local zone.
 
 ---
 


### PR DESCRIPTION
Every product in the API response now carries `days_until_expiry` and `status` — what the colour coding in #16 reads off each row.

```json
{ "name": "Leche entera", "expires_at": "2026-08-29", "days_until_expiry": 0, "status": "expiring_soon" }
```

## Buckets

| Status | Condition |
|---|---|
| `fresh` | `days_until_expiry > 7` |
| `expiring_soon` | `days_until_expiry` 0–7 |
| `expired` | `days_until_expiry < 0` |

**A product expiring today is `expiring_soon`, not `expired`**, per your call. It is still edible, and the point of the app is to prompt you to use it rather than to tell you it is too late. The readme had day 0 in the expired bucket; corrected there too.

## Timezone

"Today" is evaluated in `TIMEZONE`, not the host's local zone. Around midnight the two disagree, and the wrong one would mark food expired while it is still good. An unknown `TIMEZONE` raises rather than silently falling back to UTC — quietly doing expiry maths in the wrong zone is worse than a loud failure.

## Where the logic lives

All of it is in `app/expiry.py`: the threshold constant, the `ExpiryStatus` enum, and the two functions. The daily alert query (#21) and the status filter (#19) will both need these rules, and a second copy is how they drift apart.

Deliberately **not** implemented as a SQLAlchemy `hybrid_property` with a SQL expression. The obvious SQL form uses `CURRENT_DATE`, which is the database server's zone, not the user's — reintroducing exactly the bug avoided above. When #19 needs to filter by status, the clean translation is status → `expires_at` date ranges computed in Python, which stays correct and needs no new rules.

## Verification

52 tests pass, ruff clean. Boundary coverage at −1, 0, 7 and 8 days, both as unit tests and end-to-end through the API.

The timezone test compares `today()` under Pacific/Kiritimati (UTC+14) and Pacific/Niue (UTC−11) — 25 hours apart, so their dates always differ regardless of the host's zone, making it deterministic rather than flaky. Confirmed it actually fails by temporarily swapping the implementation for `date.today()`.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)