### PR TITLE
feat: product form and delete confirmation (#17, #18)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -113,3 +113,125 @@
     white-space: nowrap;
   }
 }
+
+.list-header {
+  display: flex;
+  justify-content: flex-end;
+  padding-bottom: 0.875rem;
+}
+
+.product-card__side {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.product-card__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.button--icon {
+  padding: 0.3rem 0.6rem;
+  font-size: 0.8125rem;
+  border-radius: 0.375rem;
+}
+
+/* Overlay */
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 0;
+  background: rgb(0 0 0 / 45%);
+}
+
+.modal__panel {
+  width: 100%;
+  max-width: 30rem;
+  max-height: 92dvh;
+  overflow-y: auto;
+  padding: 1.25rem;
+  background: var(--surface);
+  /* Bottom sheet on a phone; a centred card once there is room. */
+  border-radius: 1rem 1rem 0 0;
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 1rem;
+}
+
+.modal__header h2 {
+  font-size: 1.125rem;
+}
+
+.modal__close {
+  padding: 0.1rem 0.55rem;
+  font-size: 1.25rem;
+  line-height: 1.4;
+}
+
+/* Form */
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.form__field > span {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.form__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.form__error,
+.confirm__message {
+  font-size: 0.875rem;
+}
+
+.form__error {
+  color: var(--danger);
+}
+
+.form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.625rem;
+  padding-top: 0.375rem;
+}
+
+@media (min-width: 30rem) {
+  .modal {
+    align-items: center;
+    padding: 1.5rem;
+  }
+
+  .modal__panel {
+    border-radius: 1rem;
+  }
+
+  .product-card__side {
+    align-items: flex-end;
+  }
+}

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,34 @@
+import { Modal } from '@/components/Modal'
+
+interface ConfirmDialogProps {
+  title: string
+  message: string
+  confirmLabel: string
+  busy?: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+/** Confirmation before something irreversible. */
+export function ConfirmDialog({
+  title,
+  message,
+  confirmLabel,
+  busy = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <Modal title={title} onClose={onCancel}>
+      <p className="confirm__message">{message}</p>
+      <div className="form__actions">
+        <button type="button" onClick={onCancel} disabled={busy}>
+          Cancelar
+        </button>
+        <button type="button" className="button--danger" onClick={onConfirm} disabled={busy}>
+          {busy ? 'Eliminando…' : confirmLabel}
+        </button>
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef, type ReactNode } from 'react'
+
+interface ModalProps {
+  title: string
+  onClose: () => void
+  children: ReactNode
+}
+
+/**
+ * Overlay shell for the form and the delete confirmation.
+ *
+ * Hand-rolled rather than using <dialog>: showModal() is unevenly supported in
+ * jsdom, and a modal that cannot be tested is a modal that quietly breaks.
+ */
+export function Modal({ title, onClose, children }: ModalProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    // Stop the list behind the overlay from scrolling under the user's thumb.
+    document.body.style.overflow = 'hidden'
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.body.style.overflow = ''
+    }
+  }, [onClose])
+
+  useEffect(() => {
+    // Move focus into the panel so keyboard and screen reader users land here.
+    panelRef.current?.focus()
+  }, [])
+
+  return (
+    <div className="modal" onClick={onClose}>
+      <div
+        ref={panelRef}
+        className="modal__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        tabIndex={-1}
+        // The backdrop closes on click; clicks inside the panel must not.
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="modal__header">
+          <h2>{title}</h2>
+          <button type="button" className="modal__close" onClick={onClose} aria-label="Cerrar">
+            ×
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -3,10 +3,12 @@ import type { Product } from '@/services/types'
 
 interface ProductCardProps {
   product: Product
+  onEdit: (product: Product) => void
+  onDelete: (product: Product) => void
 }
 
 /** One product row: what it is, how much, where, and how urgent. */
-export function ProductCard({ product }: ProductCardProps) {
+export function ProductCard({ product, onEdit, onDelete }: ProductCardProps) {
   return (
     <li className={`product-card product-card--${product.status}`}>
       <div className="product-card__main">
@@ -20,9 +22,30 @@ export function ProductCard({ product }: ProductCardProps) {
         </p>
         {product.notes && <p className="product-card__notes">{product.notes}</p>}
       </div>
-      <p className="product-card__expiry">
-        <time dateTime={product.expires_at}>{expiryPhrase(product.days_until_expiry)}</time>
-      </p>
+
+      <div className="product-card__side">
+        <p className="product-card__expiry">
+          <time dateTime={product.expires_at}>{expiryPhrase(product.days_until_expiry)}</time>
+        </p>
+        <div className="product-card__actions">
+          <button
+            type="button"
+            className="button--icon"
+            onClick={() => onEdit(product)}
+            aria-label={`Editar ${product.name}`}
+          >
+            Editar
+          </button>
+          <button
+            type="button"
+            className="button--icon button--danger-text"
+            onClick={() => onDelete(product)}
+            aria-label={`Eliminar ${product.name}`}
+          >
+            Eliminar
+          </button>
+        </div>
+      </div>
     </li>
   )
 }

--- a/frontend/src/components/ProductForm.tsx
+++ b/frontend/src/components/ProductForm.tsx
@@ -1,0 +1,210 @@
+import { useMemo, useState, type FormEvent } from 'react'
+
+import { Modal } from '@/components/Modal'
+import { useCategories } from '@/hooks/useCategories'
+import { LOCATION_LABELS } from '@/labels'
+import { toErrorMessage } from '@/services/api'
+import { createProduct, replaceProduct } from '@/services/productsService'
+import type { Location, Product, ProductPayload } from '@/services/types'
+
+interface ProductFormProps {
+  /** Omit to create; pass a product to edit it. */
+  product?: Product
+  onSaved: () => void
+  onCancel: () => void
+}
+
+/** Common units, offered as suggestions without restricting what can be typed. */
+const UNIT_SUGGESTIONS = ['piezas', 'kg', 'g', 'litros', 'ml', 'bolsa', 'paquete', 'lata']
+
+interface FormState {
+  name: string
+  category_id: string
+  quantity: string
+  unit: string
+  expires_at: string
+  location: Location
+  notes: string
+}
+
+function initialState(product?: Product): FormState {
+  return {
+    name: product?.name ?? '',
+    category_id: product?.category_id?.toString() ?? '',
+    // Strip the trailing zeros the API sends so the field is not "2.00".
+    quantity: product ? product.quantity.replace(/\.?0+$/, '') : '1',
+    unit: product?.unit ?? '',
+    expires_at: product?.expires_at ?? '',
+    location: product?.location ?? 'fridge',
+    notes: product?.notes ?? '',
+  }
+}
+
+/** Create or edit a product. The same form serves both. */
+export function ProductForm({ product, onSaved, onCancel }: ProductFormProps) {
+  const categories = useCategories()
+  const [form, setForm] = useState<FormState>(() => initialState(product))
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const isEdit = product !== undefined
+
+  // Categories arrive asynchronously. Until they do, a select whose value has
+  // no matching option falls back to "Sin categoría" — and saving in that
+  // window would silently strip the product's category. Seeding its own
+  // category keeps the value valid from the first paint.
+  const options = useMemo(() => {
+    const own = product?.category
+    if (own && !categories.some((category) => category.id === own.id)) {
+      return [own, ...categories]
+    }
+    return categories
+  }, [categories, product])
+
+  const update = <K extends keyof FormState>(field: K, value: FormState[K]) =>
+    setForm((current) => ({ ...current, [field]: value }))
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault()
+    setSaving(true)
+    setError(null)
+
+    const payload: ProductPayload = {
+      name: form.name.trim(),
+      category_id: form.category_id === '' ? null : Number(form.category_id),
+      quantity: form.quantity,
+      unit: form.unit.trim() === '' ? null : form.unit.trim(),
+      expires_at: form.expires_at,
+      location: form.location,
+      notes: form.notes.trim() === '' ? null : form.notes.trim(),
+    }
+
+    void (async () => {
+      try {
+        if (product) {
+          await replaceProduct(product.id, payload)
+        } else {
+          await createProduct(payload)
+        }
+        onSaved()
+      } catch (caught) {
+        setError(toErrorMessage(caught))
+      } finally {
+        setSaving(false)
+      }
+    })()
+  }
+
+  return (
+    <Modal title={isEdit ? 'Editar producto' : 'Agregar producto'} onClose={onCancel}>
+      <form className="form" onSubmit={handleSubmit}>
+        <label className="form__field">
+          <span>Nombre</span>
+          <input
+            type="text"
+            value={form.name}
+            onChange={(event) => update('name', event.target.value)}
+            required
+            maxLength={255}
+            autoFocus
+          />
+        </label>
+
+        <label className="form__field">
+          <span>Caduca el</span>
+          <input
+            type="date"
+            value={form.expires_at}
+            onChange={(event) => update('expires_at', event.target.value)}
+            required
+          />
+        </label>
+
+        <label className="form__field">
+          <span>Dónde está</span>
+          <select
+            value={form.location}
+            onChange={(event) => update('location', event.target.value as Location)}
+          >
+            {Object.entries(LOCATION_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="form__field">
+          <span>Categoría</span>
+          <select
+            value={form.category_id}
+            onChange={(event) => update('category_id', event.target.value)}
+          >
+            <option value="">Sin categoría</option>
+            {options.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="form__row">
+          <label className="form__field">
+            <span>Cantidad</span>
+            <input
+              type="number"
+              value={form.quantity}
+              onChange={(event) => update('quantity', event.target.value)}
+              min="0.01"
+              step="0.01"
+              required
+            />
+          </label>
+
+          <label className="form__field">
+            <span>Unidad</span>
+            <input
+              type="text"
+              value={form.unit}
+              onChange={(event) => update('unit', event.target.value)}
+              list="unit-suggestions"
+              maxLength={50}
+              placeholder="piezas"
+            />
+            <datalist id="unit-suggestions">
+              {UNIT_SUGGESTIONS.map((unit) => (
+                <option key={unit} value={unit} />
+              ))}
+            </datalist>
+          </label>
+        </div>
+
+        <label className="form__field">
+          <span>Notas</span>
+          <textarea
+            value={form.notes}
+            onChange={(event) => update('notes', event.target.value)}
+            rows={2}
+            placeholder="abierto, congelado…"
+          />
+        </label>
+
+        {error && (
+          <p className="form__error" role="alert">
+            {error}
+          </p>
+        )}
+
+        <div className="form__actions">
+          <button type="button" onClick={onCancel} disabled={saving}>
+            Cancelar
+          </button>
+          <button type="submit" className="button--primary" disabled={saving}>
+            {saving ? 'Guardando…' : 'Guardar'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  )
+}

--- a/frontend/src/hooks/useCategories.ts
+++ b/frontend/src/hooks/useCategories.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react'
+
+import { listCategories } from '@/services/categoriesService'
+import type { Category } from '@/services/types'
+
+/**
+ * Categories for the form's select.
+ *
+ * A failure here is not worth blocking on: the category field is optional, so
+ * the form stays usable with an empty list.
+ */
+export function useCategories(): Category[] {
+  const [categories, setCategories] = useState<Category[]>([])
+
+  useEffect(() => {
+    let active = true
+    void (async () => {
+      try {
+        const data = await listCategories()
+        if (active) setCategories(data)
+      } catch {
+        if (active) setCategories([])
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [])
+
+  return categories
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,6 +5,7 @@
   --text-muted: #5f6b5a;
   --border: #dfe3db;
   --accent: #3f7d3a;
+  --danger: #b03434;
   /* Neutral until #16 assigns a colour per expiry status. */
   --status-fresh: var(--border);
   --status-expiring-soon: var(--border);
@@ -25,6 +26,7 @@
     --text-muted: #a3ac9c;
     --border: #333a2d;
     --accent: #8fc98a;
+    --danger: #e08585;
   }
 }
 
@@ -63,4 +65,51 @@ button {
 
 button:hover {
   border-color: var(--accent);
+}
+
+button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.button--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+  font-weight: 600;
+}
+
+.button--danger {
+  background: var(--danger);
+  border-color: var(--danger);
+  color: #fff;
+  font-weight: 600;
+}
+
+.button--danger-text {
+  color: var(--danger);
+}
+
+input,
+select,
+textarea {
+  font: inherit;
+  width: 100%;
+  padding: 0.6rem 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--surface);
+  color: var(--text);
+}
+
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+textarea {
+  resize: vertical;
 }

--- a/frontend/src/pages/ProductList.test.tsx
+++ b/frontend/src/pages/ProductList.test.tsx
@@ -1,15 +1,28 @@
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ProductList } from '@/pages/ProductList'
 import type { Product } from '@/services/types'
 
 vi.mock('@/services/productsService', () => ({
   listProducts: vi.fn(),
+  createProduct: vi.fn(),
+  replaceProduct: vi.fn(),
+  deleteProduct: vi.fn(),
 }))
 
-const { listProducts } = await import('@/services/productsService')
-const mockedList = vi.mocked(listProducts)
+vi.mock('@/services/categoriesService', () => ({
+  listCategories: vi.fn(),
+}))
+
+const products = await import('@/services/productsService')
+const categories = await import('@/services/categoriesService')
+
+const mockedList = vi.mocked(products.listProducts)
+const mockedCreate = vi.mocked(products.createProduct)
+const mockedReplace = vi.mocked(products.replaceProduct)
+const mockedDelete = vi.mocked(products.deleteProduct)
+const mockedCategories = vi.mocked(categories.listCategories)
 
 function product(overrides: Partial<Product> = {}): Product {
   return {
@@ -29,6 +42,13 @@ function product(overrides: Partial<Product> = {}): Product {
     ...overrides,
   }
 }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockedCategories.mockResolvedValue([
+    { id: 3, name: 'Lácteos', created_at: '2026-08-29T00:00:00Z' },
+  ])
+})
 
 describe('ProductList', () => {
   it('renders each product with its details', async () => {
@@ -51,7 +71,8 @@ describe('ProductList', () => {
 
     render(<ProductList />)
 
-    const names = (await screen.findAllByRole('heading', { level: 2 })).map((h) => h.textContent)
+    await screen.findByText('Yogur')
+    const names = screen.getAllByRole('heading', { level: 2 }).map((h) => h.textContent)
     expect(names).toEqual(['Yogur', 'Queso', 'Arroz'])
   })
 
@@ -87,5 +108,146 @@ describe('ProductList', () => {
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
     expect(screen.getByRole('button', { name: 'Reintentar' })).toBeInTheDocument()
+  })
+})
+
+describe('creating a product', () => {
+  it('sends the form and reloads the list', async () => {
+    mockedList.mockResolvedValue([])
+    mockedCreate.mockResolvedValue(product())
+
+    render(<ProductList />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Agregar producto' }))
+
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Huevos' } })
+    fireEvent.change(screen.getByLabelText('Caduca el'), { target: { value: '2026-09-10' } })
+    fireEvent.change(screen.getByLabelText('Cantidad'), { target: { value: '12' } })
+    fireEvent.change(screen.getByLabelText('Unidad'), { target: { value: 'piezas' } })
+    fireEvent.change(screen.getByLabelText('Dónde está'), { target: { value: 'fridge' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1))
+    expect(mockedCreate).toHaveBeenCalledWith({
+      name: 'Huevos',
+      category_id: null,
+      quantity: '12',
+      unit: 'piezas',
+      expires_at: '2026-09-10',
+      location: 'fridge',
+      notes: null,
+    })
+    // Two calls: the initial load and the reload after saving.
+    await waitFor(() => expect(mockedList).toHaveBeenCalledTimes(2))
+  })
+
+  it('sends empty optional fields as null rather than empty strings', async () => {
+    mockedList.mockResolvedValue([])
+    mockedCreate.mockResolvedValue(product())
+
+    render(<ProductList />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Agregar producto' }))
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Sal' } })
+    fireEvent.change(screen.getByLabelText('Caduca el'), { target: { value: '2027-01-01' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1))
+    expect(mockedCreate.mock.calls[0][0]).toMatchObject({ unit: null, notes: null, category_id: null })
+  })
+
+  it('keeps the form open and explains why when saving fails', async () => {
+    mockedList.mockResolvedValue([])
+    const { AxiosError, AxiosHeaders } = await import('axios')
+    const failure = new AxiosError('Request failed')
+    failure.response = {
+      data: { detail: 'Category 9999 does not exist' },
+      status: 422,
+      statusText: '',
+      headers: new AxiosHeaders(),
+      config: { headers: new AxiosHeaders() },
+    }
+    mockedCreate.mockRejectedValue(failure)
+
+    render(<ProductList />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Agregar producto' }))
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Huevos' } })
+    fireEvent.change(screen.getByLabelText('Caduca el'), { target: { value: '2026-09-10' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Category 9999 does not exist')
+    expect(screen.getByLabelText('Nombre')).toHaveValue('Huevos')
+  })
+})
+
+describe('editing a product', () => {
+  it('opens prefilled with the product and replaces it on save', async () => {
+    const existing = product({
+      id: 7,
+      name: 'Yogur griego',
+      quantity: '4.00',
+      unit: 'piezas',
+      notes: 'abierto',
+      category_id: 3,
+      category: { id: 3, name: 'Lácteos', created_at: '2026-08-29T00:00:00Z' },
+    })
+    mockedList.mockResolvedValue([existing])
+    mockedReplace.mockResolvedValue(existing)
+
+    render(<ProductList />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Editar Yogur griego' }))
+
+    expect(screen.getByLabelText('Nombre')).toHaveValue('Yogur griego')
+    // "4.00" from the API must not show up as-is in a number field.
+    expect(screen.getByLabelText('Cantidad')).toHaveValue(4)
+    expect(screen.getByLabelText('Notas')).toHaveValue('abierto')
+    expect(screen.getByLabelText('Categoría')).toHaveValue('3')
+
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Yogur natural' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => expect(mockedReplace).toHaveBeenCalledTimes(1))
+    expect(mockedReplace).toHaveBeenCalledWith(7, expect.objectContaining({ name: 'Yogur natural' }))
+  })
+})
+
+describe('deleting a product', () => {
+  it('asks before deleting and does nothing on cancel', async () => {
+    mockedList.mockResolvedValue([product()])
+
+    render(<ProductList />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Eliminar Leche entera' }))
+
+    expect(screen.getByText(/¿Seguro que quieres eliminar "Leche entera"\?/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(mockedDelete).not.toHaveBeenCalled()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('deletes and reloads once confirmed', async () => {
+    mockedList.mockResolvedValue([product()])
+    mockedDelete.mockResolvedValue(undefined)
+
+    render(<ProductList />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Eliminar Leche entera' }))
+    // Exactly "Eliminar" — the card's button is labelled "Eliminar Leche entera".
+    fireEvent.click(screen.getByRole('button', { name: 'Eliminar' }))
+
+    await waitFor(() => expect(mockedDelete).toHaveBeenCalledWith(1))
+    await waitFor(() => expect(mockedList).toHaveBeenCalledTimes(2))
+  })
+})
+
+describe('the overlay', () => {
+  it('closes on Escape', async () => {
+    mockedList.mockResolvedValue([])
+
+    render(<ProductList />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Agregar producto' }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/ProductList.tsx
+++ b/frontend/src/pages/ProductList.tsx
@@ -1,39 +1,115 @@
+import { useState } from 'react'
+
+import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { ProductCard } from '@/components/ProductCard'
+import { ProductForm } from '@/components/ProductForm'
 import { useProducts } from '@/hooks/useProducts'
+import { toErrorMessage } from '@/services/api'
+import { deleteProduct } from '@/services/productsService'
+import type { Product } from '@/services/types'
+
+/** What the screen is currently doing, beyond showing the list. */
+type Dialog =
+  | { kind: 'none' }
+  | { kind: 'create' }
+  | { kind: 'edit'; product: Product }
+  | { kind: 'delete'; product: Product }
 
 /** Main screen: everything in the house, soonest to expire first. */
 export function ProductList() {
   const { products, loading, error, reload } = useProducts()
+  const [dialog, setDialog] = useState<Dialog>({ kind: 'none' })
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
 
-  if (loading) {
-    return <p className="state state--loading">Cargando…</p>
+  const close = () => {
+    setDialog({ kind: 'none' })
+    setDeleteError(null)
   }
 
-  if (error) {
-    return (
-      <div className="state state--error" role="alert">
-        <p>{error}</p>
-        <button type="button" onClick={reload}>
-          Reintentar
-        </button>
-      </div>
-    )
+  const handleSaved = () => {
+    close()
+    reload()
   }
 
-  if (products.length === 0) {
-    return (
-      <div className="state state--empty">
-        <p>Todavía no hay nada registrado.</p>
-        <p className="state__hint">Agrega tu primera compra para empezar a seguirle la pista.</p>
-      </div>
-    )
+  const handleDelete = (product: Product) => {
+    setDeleting(true)
+    setDeleteError(null)
+    void (async () => {
+      try {
+        await deleteProduct(product.id)
+        close()
+        reload()
+      } catch (caught) {
+        setDeleteError(toErrorMessage(caught))
+      } finally {
+        setDeleting(false)
+      }
+    })()
   }
 
   return (
-    <ul className="product-list">
-      {products.map((product) => (
-        <ProductCard key={product.id} product={product} />
-      ))}
-    </ul>
+    <>
+      <div className="list-header">
+        <button
+          type="button"
+          className="button--primary"
+          onClick={() => setDialog({ kind: 'create' })}
+        >
+          Agregar producto
+        </button>
+      </div>
+
+      {loading && <p className="state state--loading">Cargando…</p>}
+
+      {!loading && error && (
+        <div className="state state--error" role="alert">
+          <p>{error}</p>
+          <button type="button" onClick={reload}>
+            Reintentar
+          </button>
+        </div>
+      )}
+
+      {!loading && !error && products.length === 0 && (
+        <div className="state state--empty">
+          <p>Todavía no hay nada registrado.</p>
+          <p className="state__hint">Agrega tu primera compra para empezar a seguirle la pista.</p>
+        </div>
+      )}
+
+      {!loading && !error && products.length > 0 && (
+        <ul className="product-list">
+          {products.map((product) => (
+            <ProductCard
+              key={product.id}
+              product={product}
+              onEdit={(target) => setDialog({ kind: 'edit', product: target })}
+              onDelete={(target) => setDialog({ kind: 'delete', product: target })}
+            />
+          ))}
+        </ul>
+      )}
+
+      {dialog.kind === 'create' && <ProductForm onSaved={handleSaved} onCancel={close} />}
+
+      {dialog.kind === 'edit' && (
+        <ProductForm product={dialog.product} onSaved={handleSaved} onCancel={close} />
+      )}
+
+      {dialog.kind === 'delete' && (
+        <ConfirmDialog
+          title="Eliminar producto"
+          message={
+            deleteError ??
+            `¿Seguro que quieres eliminar "${dialog.product.name}"? Esta acción no se puede deshacer.`
+          }
+          confirmLabel="Eliminar"
+          busy={deleting}
+          onConfirm={() => handleDelete(dialog.product)}
+          onCancel={close}
+        />
+      )}
+    </>
   )
 }


### PR DESCRIPTION
The app can now be fed without Swagger. Add, edit and delete all work from the UI.

## Form (#17)

One component serves both create and edit. Fields: nombre, caduca el, dónde está, categoría, cantidad, unidad, notas — with a datalist of common units (`piezas`, `kg`, `litros`…) that still accepts anything typed.

Presented as a modal: a bottom sheet on a phone, a centred card from 30rem up. Empty optional fields are sent as `null` rather than empty strings, so `PUT` clears them the way the API expects rather than storing `""`.

## Delete (#18)

A confirmation naming the product, since there is no undo. Cancelling is a genuine no-op — verified by asserting the API was never called, not just that the dialog closed.

## A bug the tests caught

**The category select could silently strip a product's category.** Categories load asynchronously; until they arrive, a `<select>` whose value has no matching option falls back to *Sin categoría*. Opening *Editar* and saving inside that window would have wiped the category. The form now seeds the product's own category as an option, so the value is valid from the first paint.

This is why the test asserting `Categoría` is prefilled failed on first run — I kept the assertion and fixed the code rather than the other way round.

## On not using `<dialog>`

The overlay is hand-rolled. `showModal()` is unevenly supported in jsdom, and a modal that cannot be tested is a modal that quietly breaks. It still does the things that matter: Escape closes it, backdrop clicks close it, focus moves into the panel, and the list behind stops scrolling under your thumb.

## Verified against the live backend

Not just the mocked tests — the full round trip in the browser:

| Action | Result |
|---|---|
| Create "Huevos de rancho" | Persisted with the right category, quantity, unit and notes; modal closed; list reloaded 7 → 8 |
| Open edit | Prefilled correctly — quantity shows `12`, not the API's `12.00`; category preselected; title switches to "Editar producto" |
| Save edit | Quantity 12 → 6, notes cleared by omission, `updated_at` advanced past `created_at` (the database trigger fired) |
| Delete → Cancelar | 8 products before, 8 after — nothing happened |
| Delete → Eliminar | 8 → 7, dialog closed, card gone |

26 frontend tests pass, lint clean, build clean.

One process note: the build caught a type error in the test file (`exact` is not a `ByRoleOptions` key) that vitest happily ran past, since vitest does not type-check. Worth remembering that `npm run build` is the real gate on test-file types.

Closes #17
Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added product creation and editing through a modal form.
  * Added product deletion with confirmation and progress feedback.
  * Added edit and delete actions to product cards.
  * Added accessible modals with Escape-key dismissal and responsive layouts.
  * Added category selection, validation, and product form controls.

* **Bug Fixes**
  * Improved handling and display of save, delete, loading, and empty-list states.

* **Style**
  * Added consistent button, form, focus, validation, and light/dark theme styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->