### PR TITLE
feat: colour-code products by expiry status (#16)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -38,16 +38,22 @@
   border-radius: 0.625rem;
 }
 
+/* Each status sets one variable; the stripe and the expiry text both read it,
+   so a status can never be half-coloured. */
 .product-card--fresh {
-  border-left-color: var(--status-fresh);
+  --status-color: var(--status-fresh);
 }
 
 .product-card--expiring_soon {
-  border-left-color: var(--status-expiring-soon);
+  --status-color: var(--status-expiring-soon);
 }
 
 .product-card--expired {
-  border-left-color: var(--status-expired);
+  --status-color: var(--status-expired);
+}
+
+.product-card {
+  border-left-color: var(--status-color, var(--border));
 }
 
 .product-card__name {
@@ -75,6 +81,9 @@
 .product-card__expiry {
   font-size: 0.875rem;
   font-weight: 600;
+  /* Colour reinforces the wording, it does not replace it — "Caducó hace 2
+     días" still reads correctly to anyone who cannot distinguish the hues. */
+  color: var(--status-color, var(--text));
 }
 
 .state {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,10 +6,14 @@
   --border: #dfe3db;
   --accent: #3f7d3a;
   --danger: #b03434;
-  /* Neutral until #16 assigns a colour per expiry status. */
-  --status-fresh: var(--border);
-  --status-expiring-soon: var(--border);
-  --status-expired: var(--border);
+  /* Text sitting on an --accent or --danger fill. It flips with the theme:
+     the dark palette lightens those fills, so white text on them is unreadable. */
+  --on-fill: #ffffff;
+  /* Expiry status. These are used for text as well as the card stripe, so they
+     are picked for contrast against --surface, not for maximum saturation. */
+  --status-fresh: #2f7d32;
+  --status-expiring-soon: #9a6206;
+  --status-expired: #b03434;
 
   font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   line-height: 1.5;
@@ -27,6 +31,10 @@
     --border: #333a2d;
     --accent: #8fc98a;
     --danger: #e08585;
+    --on-fill: #14170f;
+    --status-fresh: #7fbf7a;
+    --status-expiring-soon: #e0a33a;
+    --status-expired: #e08585;
   }
 }
 
@@ -75,14 +83,14 @@ button:disabled {
 .button--primary {
   background: var(--accent);
   border-color: var(--accent);
-  color: #fff;
+  color: var(--on-fill);
   font-weight: 600;
 }
 
 .button--danger {
   background: var(--danger);
   border-color: var(--danger);
-  color: #fff;
+  color: var(--on-fill);
   font-weight: 600;
 }
 

--- a/frontend/src/pages/ProductList.test.tsx
+++ b/frontend/src/pages/ProductList.test.tsx
@@ -76,13 +76,17 @@ describe('ProductList', () => {
     expect(names).toEqual(['Yogur', 'Queso', 'Arroz'])
   })
 
-  it('marks each card with its status so the list can be scanned', async () => {
-    mockedList.mockResolvedValue([product({ status: 'expired', days_until_expiry: -2 })])
+  it.each([
+    ['fresh' as const, 90],
+    ['expiring_soon' as const, 3],
+    ['expired' as const, -2],
+  ])('marks a %s card so the list can be scanned by colour', async (status, days) => {
+    mockedList.mockResolvedValue([product({ status, days_until_expiry: days })])
 
     render(<ProductList />)
 
     const card = (await screen.findByText('Leche entera')).closest('li')
-    expect(card).toHaveClass('product-card--expired')
+    expect(card).toHaveClass(`product-card--${status}`)
   })
 
   it('labels a product with no category instead of leaving a gap', async () => {


### PR DESCRIPTION
Green for fresh, amber for expiring soon, red for expired — on the card's left stripe and on the expiry text.

## How it is wired

Each status class sets a single `--status-color`; the stripe and the text both read it. A card can never end up half-coloured, and adding a status later means adding one variable rather than hunting for every place a colour is applied.

**Colour reinforces the wording, it does not replace it.** "Caducó hace 3 días" and "Caduca mañana" already say everything the colour says, so the list stays readable to anyone who cannot distinguish the hues. The values are chosen for contrast against `--surface` in both themes rather than for saturation.

## A contrast bug this made visible

`--accent` and `--danger` lighten in the dark palette, but the primary and danger buttons hardcoded `color: #fff`. In dark mode "Agregar producto" was white text on light green — close to unreadable, and the confirm dialog's "Eliminar" had the same problem. Both now use an `--on-fill` token that flips with the theme (white on light, near-black on dark).

This only showed up by looking at the rendered page in dark mode; nothing in the test suite or the build would have caught it.

## On the thresholds in the issue

The description says *expiring soon (1–7 days)* and *expired (≤0)*. That predates #12, where you decided a product expiring **today** should be yellow rather than red. The colours key off the `status` the backend computes, so they follow that decision automatically — no thresholds are duplicated in the frontend.

## Verification

Checked in the browser against the live backend, with all three statuses on screen at once, in light and dark. 28 tests pass — the status-class test is now parameterised across all three statuses rather than only checking `expired`. Lint and build clean.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved product status cards with consistent colors for status indicators and expiry text.
  - Enhanced light and dark theme contrast for primary and danger buttons.
  - Added theme-aware colors for expiry statuses.

- **Tests**
  - Expanded coverage for fresh, expiring-soon, and expired product statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->