### PR TITLE
feat: filters and sorting for the product list (#19)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -244,3 +244,50 @@
     align-items: flex-end;
   }
 }
+
+/* Filters */
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  padding-bottom: 0.875rem;
+}
+
+.filters__controls {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.625rem;
+}
+
+.filters__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.filters__field > span {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.filters__field select {
+  padding: 0.45rem 0.55rem;
+  font-size: 0.875rem;
+}
+
+.filters__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+@media (min-width: 30rem) {
+  .filters__controls {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}

--- a/frontend/src/components/ProductFilters.tsx
+++ b/frontend/src/components/ProductFilters.tsx
@@ -1,0 +1,109 @@
+import { LOCATION_LABELS, STATUS_LABELS } from '@/labels'
+import type { ProductFilters as Filters, SortKey } from '@/filters'
+import { hasActiveFilters } from '@/filters'
+import type { Category, ExpiryStatus, Location } from '@/services/types'
+
+interface ProductFiltersProps {
+  filters: Filters
+  sort: SortKey
+  categories: Category[]
+  /** Products matching the current filters, for the result count. */
+  shown: number
+  total: number
+  onChange: (filters: Filters) => void
+  onSortChange: (sort: SortKey) => void
+  onClear: () => void
+}
+
+/** Filter and sort controls for the product list. */
+export function ProductFilters({
+  filters,
+  sort,
+  categories,
+  shown,
+  total,
+  onChange,
+  onSortChange,
+  onClear,
+}: ProductFiltersProps) {
+  const active = hasActiveFilters(filters)
+
+  return (
+    <section className="filters" aria-label="Filtros">
+      <div className="filters__controls">
+        <label className="filters__field">
+          <span>Categoría</span>
+          <select
+            value={filters.categoryId === 'all' ? 'all' : String(filters.categoryId)}
+            onChange={(event) =>
+              onChange({
+                ...filters,
+                categoryId: event.target.value === 'all' ? 'all' : Number(event.target.value),
+              })
+            }
+          >
+            <option value="all">Todas</option>
+            {categories.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="filters__field">
+          <span>Ubicación</span>
+          <select
+            value={filters.location}
+            onChange={(event) =>
+              onChange({ ...filters, location: event.target.value as Location | 'all' })
+            }
+          >
+            <option value="all">Todas</option>
+            {Object.entries(LOCATION_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="filters__field">
+          <span>Estado</span>
+          <select
+            value={filters.status}
+            onChange={(event) =>
+              onChange({ ...filters, status: event.target.value as ExpiryStatus | 'all' })
+            }
+          >
+            <option value="all">Todos</option>
+            {Object.entries(STATUS_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="filters__field">
+          <span>Ordenar por</span>
+          <select value={sort} onChange={(event) => onSortChange(event.target.value as SortKey)}>
+            <option value="expiry">Caducidad</option>
+            <option value="name">Nombre</option>
+          </select>
+        </label>
+      </div>
+
+      {active && (
+        <div className="filters__summary">
+          <span>
+            {shown} de {total}
+          </span>
+          <button type="button" className="button--icon" onClick={onClear}>
+            Quitar filtros
+          </button>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/components/ProductForm.tsx
+++ b/frontend/src/components/ProductForm.tsx
@@ -1,15 +1,16 @@
 import { useMemo, useState, type FormEvent } from 'react'
 
 import { Modal } from '@/components/Modal'
-import { useCategories } from '@/hooks/useCategories'
 import { LOCATION_LABELS } from '@/labels'
 import { toErrorMessage } from '@/services/api'
 import { createProduct, replaceProduct } from '@/services/productsService'
-import type { Location, Product, ProductPayload } from '@/services/types'
+import type { Category, Location, Product, ProductPayload } from '@/services/types'
 
 interface ProductFormProps {
   /** Omit to create; pass a product to edit it. */
   product?: Product
+  /** Passed in rather than fetched here, so opening the form costs no request. */
+  categories: Category[]
   onSaved: () => void
   onCancel: () => void
 }
@@ -41,8 +42,7 @@ function initialState(product?: Product): FormState {
 }
 
 /** Create or edit a product. The same form serves both. */
-export function ProductForm({ product, onSaved, onCancel }: ProductFormProps) {
-  const categories = useCategories()
+export function ProductForm({ product, categories, onSaved, onCancel }: ProductFormProps) {
   const [form, setForm] = useState<FormState>(() => initialState(product))
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)

--- a/frontend/src/filters.test.ts
+++ b/frontend/src/filters.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import { NO_FILTERS, applyFilters, hasActiveFilters, sortProducts } from '@/filters'
+import type { Product } from '@/services/types'
+
+function product(overrides: Partial<Product> = {}): Product {
+  return {
+    id: 1,
+    name: 'Leche entera',
+    category_id: null,
+    quantity: '1.00',
+    unit: null,
+    expires_at: '2026-09-03',
+    location: 'fridge',
+    notes: null,
+    category: null,
+    created_at: '2026-08-29T00:00:00Z',
+    updated_at: '2026-08-29T00:00:00Z',
+    days_until_expiry: 5,
+    status: 'expiring_soon',
+    ...overrides,
+  }
+}
+
+const pantry = [
+  product({ id: 1, name: 'Yogur', category_id: 1, location: 'fridge', status: 'expired', days_until_expiry: -2 }),
+  product({ id: 2, name: 'Queso', category_id: 1, location: 'fridge', status: 'expiring_soon', days_until_expiry: 3 }),
+  product({ id: 3, name: 'Arroz', category_id: 2, location: 'pantry', status: 'fresh', days_until_expiry: 90 }),
+  product({ id: 4, name: 'Ñame', category_id: 2, location: 'freezer', status: 'fresh', days_until_expiry: 90 }),
+]
+
+const names = (products: Product[]) => products.map((p) => p.name)
+
+describe('applyFilters', () => {
+  it('returns everything when nothing is selected', () => {
+    expect(applyFilters(pantry, NO_FILTERS)).toHaveLength(4)
+  })
+
+  it('filters by category', () => {
+    expect(names(applyFilters(pantry, { ...NO_FILTERS, categoryId: 2 }))).toEqual(['Arroz', 'Ñame'])
+  })
+
+  it('filters by location', () => {
+    expect(names(applyFilters(pantry, { ...NO_FILTERS, location: 'freezer' }))).toEqual(['Ñame'])
+  })
+
+  it('filters by status', () => {
+    expect(names(applyFilters(pantry, { ...NO_FILTERS, status: 'expired' }))).toEqual(['Yogur'])
+  })
+
+  it('combines filters rather than replacing them', () => {
+    const result = applyFilters(pantry, { ...NO_FILTERS, categoryId: 2, location: 'pantry' })
+    expect(names(result)).toEqual(['Arroz'])
+  })
+
+  it('returns nothing when the combination matches nothing', () => {
+    expect(applyFilters(pantry, { ...NO_FILTERS, categoryId: 1, location: 'pantry' })).toEqual([])
+  })
+
+  it('matches uncategorised products only under "all"', () => {
+    const loose = [product({ id: 9, name: 'Sal', category_id: null })]
+    expect(applyFilters(loose, NO_FILTERS)).toHaveLength(1)
+    expect(applyFilters(loose, { ...NO_FILTERS, categoryId: 1 })).toEqual([])
+  })
+})
+
+describe('hasActiveFilters', () => {
+  it('is false for the default filters', () => {
+    expect(hasActiveFilters(NO_FILTERS)).toBe(false)
+  })
+
+  it.each([
+    ['categoryId', { ...NO_FILTERS, categoryId: 1 as const }],
+    ['location', { ...NO_FILTERS, location: 'fridge' as const }],
+    ['status', { ...NO_FILTERS, status: 'fresh' as const }],
+  ])('is true when %s is set', (_field, filters) => {
+    expect(hasActiveFilters(filters)).toBe(true)
+  })
+})
+
+describe('sortProducts', () => {
+  it('puts what expires soonest first', () => {
+    expect(names(sortProducts(pantry, 'expiry'))).toEqual(['Yogur', 'Queso', 'Arroz', 'Ñame'])
+  })
+
+  it('breaks expiry ties by name so the order is stable', () => {
+    // Arroz and Ñame both sit at 90 days.
+    const sorted = sortProducts([pantry[3], pantry[2]], 'expiry')
+    expect(names(sorted)).toEqual(['Arroz', 'Ñame'])
+  })
+
+  it('sorts by name using Spanish collation', () => {
+    // Ñ belongs between N and O, not after Z as a raw code-point sort gives.
+    expect(names(sortProducts(pantry, 'name'))).toEqual(['Arroz', 'Ñame', 'Queso', 'Yogur'])
+  })
+
+  it('does not mutate the input', () => {
+    const original = [...pantry]
+    sortProducts(pantry, 'name')
+    expect(pantry).toEqual(original)
+  })
+})

--- a/frontend/src/filters.ts
+++ b/frontend/src/filters.ts
@@ -1,0 +1,58 @@
+/**
+ * Filtering and sorting for the product list.
+ *
+ * Applied client-side rather than through the API's query parameters. A
+ * household pantry is tens of items, so filtering in the browser is instant and
+ * needs no round trip — and the status filter has no server-side equivalent
+ * anyway, since translating it to SQL would mean CURRENT_DATE in the database's
+ * timezone rather than the user's. The API's filters stay where they earn their
+ * keep: the daily alert query in #21.
+ */
+
+import type { ExpiryStatus, Location, Product } from '@/services/types'
+
+export interface ProductFilters {
+  categoryId: number | 'all'
+  location: Location | 'all'
+  status: ExpiryStatus | 'all'
+}
+
+export type SortKey = 'expiry' | 'name'
+
+export const NO_FILTERS: ProductFilters = {
+  categoryId: 'all',
+  location: 'all',
+  status: 'all',
+}
+
+export function hasActiveFilters(filters: ProductFilters): boolean {
+  return (
+    filters.categoryId !== 'all' || filters.location !== 'all' || filters.status !== 'all'
+  )
+}
+
+export function applyFilters(products: Product[], filters: ProductFilters): Product[] {
+  return products.filter((product) => {
+    if (filters.categoryId !== 'all' && product.category_id !== filters.categoryId) return false
+    if (filters.location !== 'all' && product.location !== filters.location) return false
+    if (filters.status !== 'all' && product.status !== filters.status) return false
+    return true
+  })
+}
+
+export function sortProducts(products: Product[], sort: SortKey): Product[] {
+  const sorted = [...products]
+
+  if (sort === 'name') {
+    // Locale-aware: otherwise "Ñame" sorts after "Zanahoria" and accented
+    // names land in the wrong place.
+    return sorted.sort((a, b) => a.name.localeCompare(b.name, 'es'))
+  }
+
+  // Soonest first, with name as the tiebreak so the order is stable across
+  // reloads when several things expire on the same day.
+  return sorted.sort(
+    (a, b) =>
+      a.days_until_expiry - b.days_until_expiry || a.name.localeCompare(b.name, 'es'),
+  )
+}

--- a/frontend/src/pages/ProductList.test.tsx
+++ b/frontend/src/pages/ProductList.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ProductList } from '@/pages/ProductList'
@@ -56,10 +56,12 @@ describe('ProductList', () => {
 
     render(<ProductList />)
 
-    expect(await screen.findByText('Leche entera')).toBeInTheDocument()
-    expect(screen.getByText('2 litros')).toBeInTheDocument()
-    expect(screen.getByText('Refrigerador')).toBeInTheDocument()
-    expect(screen.getByText('Caduca en 5 días')).toBeInTheDocument()
+    // Scoped to the list: the filter bar also renders "Refrigerador", as an option.
+    const list = within(await screen.findByRole('list'))
+    expect(list.getByText('Leche entera')).toBeInTheDocument()
+    expect(list.getByText('2 litros')).toBeInTheDocument()
+    expect(list.getByText('Refrigerador')).toBeInTheDocument()
+    expect(list.getByText('Caduca en 5 días')).toBeInTheDocument()
   })
 
   it('keeps the order the API returned rather than re-sorting', async () => {
@@ -199,14 +201,16 @@ describe('editing a product', () => {
     render(<ProductList />)
     fireEvent.click(await screen.findByRole('button', { name: 'Editar Yogur griego' }))
 
-    expect(screen.getByLabelText('Nombre')).toHaveValue('Yogur griego')
+    // Scoped to the dialog: the filter bar behind it also has a "Categoría" control.
+    const form = within(screen.getByRole('dialog'))
+    expect(form.getByLabelText('Nombre')).toHaveValue('Yogur griego')
     // "4.00" from the API must not show up as-is in a number field.
-    expect(screen.getByLabelText('Cantidad')).toHaveValue(4)
-    expect(screen.getByLabelText('Notas')).toHaveValue('abierto')
-    expect(screen.getByLabelText('Categoría')).toHaveValue('3')
+    expect(form.getByLabelText('Cantidad')).toHaveValue(4)
+    expect(form.getByLabelText('Notas')).toHaveValue('abierto')
+    expect(form.getByLabelText('Categoría')).toHaveValue('3')
 
-    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Yogur natural' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Guardar' }))
+    fireEvent.change(form.getByLabelText('Nombre'), { target: { value: 'Yogur natural' } })
+    fireEvent.click(form.getByRole('button', { name: 'Guardar' }))
 
     await waitFor(() => expect(mockedReplace).toHaveBeenCalledTimes(1))
     expect(mockedReplace).toHaveBeenCalledWith(7, expect.objectContaining({ name: 'Yogur natural' }))
@@ -253,5 +257,94 @@ describe('the overlay', () => {
     fireEvent.keyDown(document, { key: 'Escape' })
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})
+
+
+describe('filtering and sorting', () => {
+  const pantry = [
+    product({ id: 1, name: 'Yogur', location: 'fridge', status: 'expired', days_until_expiry: -2 }),
+    product({ id: 2, name: 'Arroz', location: 'pantry', status: 'fresh', days_until_expiry: 90 }),
+    product({ id: 3, name: 'Guisantes', location: 'freezer', status: 'fresh', days_until_expiry: 120 }),
+  ]
+
+  it('narrows the list by location', async () => {
+    mockedList.mockResolvedValue(pantry)
+
+    render(<ProductList />)
+    await screen.findByText('Yogur')
+
+    fireEvent.change(screen.getByLabelText('Ubicación'), { target: { value: 'pantry' } })
+
+    expect(screen.getAllByRole('heading', { level: 2 }).map((h) => h.textContent)).toEqual(['Arroz'])
+  })
+
+  it('narrows the list by status', async () => {
+    mockedList.mockResolvedValue(pantry)
+
+    render(<ProductList />)
+    await screen.findByText('Yogur')
+
+    fireEvent.change(screen.getByLabelText('Estado'), { target: { value: 'expired' } })
+
+    expect(screen.getAllByRole('heading', { level: 2 }).map((h) => h.textContent)).toEqual(['Yogur'])
+  })
+
+  it('combines filters instead of replacing them', async () => {
+    mockedList.mockResolvedValue(pantry)
+
+    render(<ProductList />)
+    await screen.findByText('Yogur')
+
+    fireEvent.change(screen.getByLabelText('Estado'), { target: { value: 'fresh' } })
+    fireEvent.change(screen.getByLabelText('Ubicación'), { target: { value: 'freezer' } })
+
+    expect(screen.getAllByRole('heading', { level: 2 }).map((h) => h.textContent)).toEqual(['Guisantes'])
+  })
+
+  it('reorders by name without refetching', async () => {
+    mockedList.mockResolvedValue(pantry)
+
+    render(<ProductList />)
+    await screen.findByText('Yogur')
+
+    fireEvent.change(screen.getByLabelText('Ordenar por'), { target: { value: 'name' } })
+
+    expect(screen.getAllByRole('heading', { level: 2 }).map((h) => h.textContent)).toEqual([
+      'Arroz',
+      'Guisantes',
+      'Yogur',
+    ])
+    // Filtering and sorting are local; the API is called once, on mount.
+    expect(mockedList).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows how many matched and restores everything on clear', async () => {
+    mockedList.mockResolvedValue(pantry)
+
+    render(<ProductList />)
+    await screen.findByText('Yogur')
+    // No count while nothing is filtered.
+    expect(screen.queryByText('1 de 3')).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Ubicación'), { target: { value: 'pantry' } })
+    expect(screen.getByText('1 de 3')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Quitar filtros' }))
+
+    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(3)
+  })
+
+  it('distinguishes "no matches" from an empty pantry', async () => {
+    mockedList.mockResolvedValue(pantry)
+
+    render(<ProductList />)
+    await screen.findByText('Yogur')
+
+    fireEvent.change(screen.getByLabelText('Estado'), { target: { value: 'expiring_soon' } })
+
+    expect(screen.getByText('Ningún producto coincide con los filtros.')).toBeInTheDocument()
+    // Telling someone with a full pantry to "add their first purchase" is wrong.
+    expect(screen.queryByText('Todavía no hay nada registrado.')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/ProductList.tsx
+++ b/frontend/src/pages/ProductList.tsx
@@ -1,8 +1,18 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { ProductCard } from '@/components/ProductCard'
+import { ProductFilters } from '@/components/ProductFilters'
 import { ProductForm } from '@/components/ProductForm'
+import {
+  NO_FILTERS,
+  applyFilters,
+  hasActiveFilters,
+  sortProducts,
+  type ProductFilters as Filters,
+  type SortKey,
+} from '@/filters'
+import { useCategories } from '@/hooks/useCategories'
 import { useProducts } from '@/hooks/useProducts'
 import { toErrorMessage } from '@/services/api'
 import { deleteProduct } from '@/services/productsService'
@@ -18,9 +28,17 @@ type Dialog =
 /** Main screen: everything in the house, soonest to expire first. */
 export function ProductList() {
   const { products, loading, error, reload } = useProducts()
+  const categories = useCategories()
   const [dialog, setDialog] = useState<Dialog>({ kind: 'none' })
   const [deleting, setDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [filters, setFilters] = useState<Filters>(NO_FILTERS)
+  const [sort, setSort] = useState<SortKey>('expiry')
+
+  const visible = useMemo(
+    () => sortProducts(applyFilters(products, filters), sort),
+    [products, filters, sort],
+  )
 
   const close = () => {
     setDialog({ kind: 'none' })
@@ -79,22 +97,56 @@ export function ProductList() {
       )}
 
       {!loading && !error && products.length > 0 && (
-        <ul className="product-list">
-          {products.map((product) => (
-            <ProductCard
-              key={product.id}
-              product={product}
-              onEdit={(target) => setDialog({ kind: 'edit', product: target })}
-              onDelete={(target) => setDialog({ kind: 'delete', product: target })}
-            />
-          ))}
-        </ul>
+        <>
+          <ProductFilters
+            filters={filters}
+            sort={sort}
+            categories={categories}
+            shown={visible.length}
+            total={products.length}
+            onChange={setFilters}
+            onSortChange={setSort}
+            onClear={() => setFilters(NO_FILTERS)}
+          />
+
+          {visible.length === 0 ? (
+            // Distinct from the empty pantry above: the user has products, just
+            // none matching. Telling them to "add their first purchase" here
+            // would be wrong and confusing.
+            <div className="state state--empty">
+              <p>Ningún producto coincide con los filtros.</p>
+              {hasActiveFilters(filters) && (
+                <button type="button" onClick={() => setFilters(NO_FILTERS)}>
+                  Quitar filtros
+                </button>
+              )}
+            </div>
+          ) : (
+            <ul className="product-list">
+              {visible.map((product) => (
+                <ProductCard
+                  key={product.id}
+                  product={product}
+                  onEdit={(target) => setDialog({ kind: 'edit', product: target })}
+                  onDelete={(target) => setDialog({ kind: 'delete', product: target })}
+                />
+              ))}
+            </ul>
+          )}
+        </>
       )}
 
-      {dialog.kind === 'create' && <ProductForm onSaved={handleSaved} onCancel={close} />}
+      {dialog.kind === 'create' && (
+        <ProductForm categories={categories} onSaved={handleSaved} onCancel={close} />
+      )}
 
       {dialog.kind === 'edit' && (
-        <ProductForm product={dialog.product} onSaved={handleSaved} onCancel={close} />
+        <ProductForm
+          product={dialog.product}
+          categories={categories}
+          onSaved={handleSaved}
+          onCancel={close}
+        />
       )}
 
       {dialog.kind === 'delete' && (


### PR DESCRIPTION
Filter by category, location and status; sort by expiry or name. Closes out Phase 2.

## Behaviour

- Filters **combine** rather than replace each other — freezer + fresh shows only what is both.
- A count (`2 de 7`) and a *Quitar filtros* button appear only once something is filtered.
- **"Ningún producto coincide con los filtros" is a distinct state from an empty pantry.** Telling someone with a full fridge to "add their first purchase" would be wrong, so the two empty states say different things.
- Name sorting is locale-aware (`localeCompare(…, 'es')`), so *Ñame* lands between N and O rather than after Z.
- Expiry sorting breaks ties by name, so two things expiring the same day keep a stable order across reloads.

## Why client-side

Filtering and sorting happen in the browser, not through the API's query parameters. Three reasons:

1. A household pantry is tens of items. Filtering locally is instant; a round trip per dropdown change would be slower and add loading states for no benefit.
2. **The status filter has no server-side equivalent.** Translating it to SQL means `CURRENT_DATE`, which is the database server's timezone — the exact bug avoided in #12. Keeping it in the client keeps one definition of "today".
3. Sorting by name is not a server-side option either, so a mixed approach would split the logic across two places for nothing.

The API's `category_id` / `location` / `expires_before` filters are not wasted — they are what the daily alert query in #21 needs.

## Verification

Checked in the browser against the live backend: location filter narrowed 7 → 2 with the count reading `2 de 7`; combining status and location composed correctly; name sort produced the right alphabetical order; a combination matching nothing (expired + alacena) showed the no-match state and *not* the empty-pantry copy; *Quitar filtros* restored all 7.

49 tests pass — 15 new unit tests on the filter and sort functions, 6 new UI tests driving the controls, including one asserting the API is called exactly once so the local-only behaviour cannot silently regress into refetching. Lint and build clean.

## One thing I did not fix here

Adding the filter bar made two controls share the name *Categoría* — one in the filters, one in the form — which is only unambiguous because the form sits in a dialog. That is fine visually, but the modal does not currently make the background inert, so the filter controls behind it are still reachable by keyboard. Out of scope for this issue; worth a follow-up.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)