### PR TITLE
feat: containerise the backend and frontend (#26, #27)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,9 @@
+env/
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+tests/
+.env
+logs/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+# Run as a non-root user, matching apollo-server-dashboard's backend image.
+# gosu lets the entrypoint drop privileges after any root-only setup.
+RUN groupadd --system --gid 1000 appuser \
+    && useradd --system --no-create-home --shell /bin/false --uid 1000 --gid 1000 appuser \
+    && apt-get update && apt-get install -y --no-install-recommends gosu \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN chmod +x /app/entrypoint.sh
+
+# CaduTrack's port: free-games-notifier already owns 8000 on the host.
+EXPOSE 8001
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+# The log directory is a bind mount owned by the host user, so fix ownership
+# before dropping privileges — appuser cannot write to it otherwise.
+if [ -d /mnt/logs ]; then
+    chown -R appuser:appuser /mnt/logs
+fi
+
+echo "Applying database migrations…"
+gosu appuser alembic upgrade head
+
+# Idempotent by design: inserts only the default categories that are missing,
+# so running it on every start costs one query and changes nothing.
+echo "Seeding default categories…"
+gosu appuser python -m app.seed
+
+echo "Starting CaduTrack API on ${API_HOST:-0.0.0.0}:${API_PORT:-8001}…"
+exec gosu appuser uvicorn app.main:app \
+    --host "${API_HOST:-0.0.0.0}" \
+    --port "${API_PORT:-8001}"

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.env.*
+*.log

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,20 @@
+# Stage 1: build the Vite app
+FROM node:20-slim AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# Stage 2: serve the static build with nginx
+FROM nginx:alpine
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Proxy API calls to the backend container.
+    #
+    # The trailing slash on proxy_pass is load-bearing: it strips the /api/
+    # prefix, because the API serves /products, not /api/products. Without it
+    # every request 404s. This mirrors the rewrite the Vite dev server does.
+    location ^~ /api/ {
+        proxy_pass http://cadutrack-api:8001/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # Serve the SPA — fall back to index.html so a refresh on any path works.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
Both Dockerfiles in one PR, since the only meaningful test of either is running them together.

## Backend

`python:3.13-slim`, running as a non-root `appuser` via `gosu` — same shape as `apollo-server-dashboard/backend/Dockerfile`. The entrypoint:

1. `alembic upgrade head`
2. `python -m app.seed` — safe on every start, the seed is idempotent by design
3. `uvicorn` on 8001

It also `chown`s `/mnt/logs` before dropping privileges: that path is a host bind mount, and `appuser` cannot write the rotating JSON log otherwise.

## Frontend

Multi-stage Vite build served by `nginx:alpine`, with `try_files … /index.html` so a refresh on any path works.

**The `proxy_pass` trailing slash is load-bearing.** The API serves `/products`, not `/api/products`, so nginx has to strip the prefix:

```nginx
location ^~ /api/ {
    proxy_pass http://cadutrack-api:8001/;   # trailing slash strips /api/
}
```

Without it every request 404s. This mirrors the rewrite the Vite dev server already does, and differs from `apollo-server-dashboard`, whose backend routes (`/services`, `/config`) need no stripping — worth flagging since that repo is otherwise the template here.

## Verified by actually running them

Built both images and ran them together on the real `apollo-server-network`, talking to the real `apollo-server-db`:

| Check | Result |
|---|---|
| Entrypoint | Migrations applied, seed ran and reported "already present", uvicorn started |
| Process user | uid 1000 (`appuser`), not root |
| Structured log | Written to the `/mnt/logs` bind mount in the shared JSON format, with the `America/Mexico_City` offset |
| `GET /api/health` via nginx | `{"status":"ok","database":"ok"}` |
| `GET /api/products` via nginx | 7 products |
| SPA fallback | `/` and `/cualquier-ruta` both 200 |
| Writes through the proxy | POST 201, PUT 200 (quantity updated), DELETE 204 |
| Backend port isolation | `localhost:8001` unreachable from the host — only nginx can reach it |
| App in the browser on `:9903` | Renders fully, no console errors |

Images: API 351MB, frontend 93.1MB. Test containers and images removed afterwards; nothing left running.

## Next

These images are not published anywhere yet — that is #48, which has to land before the `compose.yaml` in #28 can pull anything.

Closes #26
Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added containerized deployment for the backend API and frontend application.
  * Frontend is served through Nginx with single-page application routing support.
  * API requests are automatically routed from the frontend to the backend service.
  * Backend startup now applies database migrations and seeds default categories automatically.
  * Added configurable API host and port settings with sensible defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->