### PR TITLE
ci: publish Docker images to GHCR on release (#48)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  # ─── Frontend image: the thing you actually visit ────────────────────────────
+  frontend:
+    name: Build and push frontend image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write  # required for provenance attestation
+      id-token: write      # required for OIDC token used by attestation signing
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/juliomoralesb/cadutrack
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend
+
+      - name: Generate provenance attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/juliomoralesb/cadutrack
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+  # ─── Backend image ───────────────────────────────────────────────────────────
+  backend:
+    name: Build and push backend image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/juliomoralesb/cadutrack-api
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Separate scope from the frontend, or the two jobs evict each
+          # other's layers from the shared Actions cache.
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,mode=max,scope=backend
+
+      - name: Generate provenance attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/juliomoralesb/cadutrack-api
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,37 @@ See [`backend/.env.example`](backend/.env.example) for the full documented list.
 
 ---
 
+## Releases
+
+Docker images are published to GHCR by `.github/workflows/release.yml`, which
+runs on version tags only:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+That builds and pushes two multi-arch images:
+
+| Image | Contents |
+|-------|----------|
+| `ghcr.io/juliomoralesb/cadutrack`     | Frontend — the Vite build served by nginx |
+| `ghcr.io/juliomoralesb/cadutrack-api` | Backend — FastAPI |
+
+Each tag publishes both `{version}` and `latest`.
+
+> **This repository is private, so the packages are created private too.**
+> Unlike `free-games-notifier` and `apollo-server-dashboard`, which are public
+> repos with public images, pulling these on the server needs one of:
+>
+> - Set each package to **public** once, under its GHCR package settings, or
+> - Authenticate on the server: `docker login ghcr.io -u JulioMoralesB` with a
+>   personal access token carrying `read:packages`.
+>
+> Without either, `docker compose pull` fails with `unauthorized`.
+
+---
+
 ## License
 
 MIT


### PR DESCRIPTION
The missing link between the Dockerfiles (#26, #27) and the compose file (#28). Ports the workflow shape from `apollo-server-dashboard/.github/workflows/release.yml`.

## What it does

One workflow, two jobs, triggered on `v*.*.*` tags:

| Job | Context | Image |
|---|---|---|
| frontend | `./frontend` | `ghcr.io/juliomoralesb/cadutrack` |
| backend | `./backend` | `ghcr.io/juliomoralesb/cadutrack-api` |

Both build `linux/amd64` and `linux/arm64`, tag `{version}` plus `latest` (skipped for prereleases), and push a provenance attestation to the registry.

The frontend takes the plain `cadutrack` name since it is the thing you actually visit, matching how `apollo-server-dashboard` / `-backend` are named.

**One deviation from the dashboard's workflow:** the two jobs use separate Actions cache scopes (`scope=frontend` / `scope=backend`). With a shared scope each build evicts the other's layers on every run, so the cache never helps.

## ⚠️ This repository is private — the packages will be too

`free-games-notifier` and `apollo-server-dashboard` are public repos, so their GHCR images are public and pull anonymously. **CaduTrack is private**, so the packages are created private, and `docker compose pull` on the server will fail with `unauthorized` until one of:

- each package is set to **public** once in its GHCR package settings, or
- the server authenticates: `docker login ghcr.io -u JulioMoralesB` with a PAT carrying `read:packages`

Documented in the readme alongside the release steps. This will bite at #28 otherwise.

## Verification

The workflow itself cannot run until a tag is pushed, so this PR does not exercise it. What I did check:

- The YAML parses, and both jobs resolve to the intended context, image name and platforms.
- Both Dockerfiles build and run correctly — verified end to end in #49, including the two containers talking to each other on `apollo-server-network` against the real database.

After merging, pushing `v0.1.0` is what actually produces the images.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)