### PR TITLE
feat: database bootstrap and compose.yaml (#52, #28)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,46 @@
+# =============================================================================
+# CaduTrack deployment environment
+# Copy this file to .env next to compose.yaml and fill in your values:
+#   cp .env.example .env
+#
+# The API container reads this whole file, so every variable documented in
+# backend/.env.example is valid here too. Only the ones you are likely to
+# change are listed below.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Database — the shared apollo-server-db instance
+# -----------------------------------------------------------------------------
+# CaduTrack owns the database named by DB_NAME and the schema inside it. The
+# database is created automatically on first start if it does not exist.
+#
+# DB_HOST defaults to the container name on apollo-server-network; leave it
+# unless PostgreSQL lives somewhere else.
+# DB_HOST=apollo-server-db
+# DB_PORT=5432
+DB_NAME=cadutrack
+DB_USER=postgres
+DB_PASSWORD=your_secure_password
+
+# -----------------------------------------------------------------------------
+# Host
+# -----------------------------------------------------------------------------
+# Port the web UI is published on. 8000 is free-games-notifier and 9902 is
+# apollo-server-dashboard, so CaduTrack defaults to 9903.
+FRONTEND_PORT=9903
+
+# Where the rotating JSON log is written on the host, for Promtail to collect.
+LOGS_PATH=./logs
+
+# -----------------------------------------------------------------------------
+# Observability
+# -----------------------------------------------------------------------------
+# IANA timezone for log timestamps, expiry calculations and alert scheduling.
+TIMEZONE=America/Mexico_City
+
+# Path of the log file inside the container. Must sit under the bind mount
+# above for Promtail to see it.
+LOG_FILE=/mnt/logs/cadutrack.log
+
+# Optional: root log level (DEBUG, INFO, WARNING, ERROR). Defaults to INFO.
+# LOG_LEVEL=INFO

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: cadutrack
+          POSTGRES_DB: cadutrack_test
         ports:
           - 5432:5432
         options: >-
@@ -39,7 +39,7 @@ jobs:
     env:
       DB_HOST: localhost
       DB_PORT: 5432
-      DB_NAME: cadutrack
+      DB_NAME: cadutrack_test
       DB_USER: postgres
       DB_PASSWORD: postgres
 

--- a/backend/app/db/bootstrap.py
+++ b/backend/app/db/bootstrap.py
@@ -1,0 +1,101 @@
+"""Create the service's database on first start.
+
+Alembic creates the schema; nothing creates the database that holds it. Without
+this the container crash-loops on a fresh server until someone runs
+CREATE DATABASE by hand.
+
+The maintenance database is only touched when it is actually needed: if the
+configured database already exists — the case on every start after the first —
+this connects to it, finds it healthy and returns. That keeps a least-privilege
+role viable, since the common path needs no rights beyond the app's own.
+"""
+
+import logging
+import sys
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import OperationalError, ProgrammingError
+
+from app.config import settings
+from app.logging_config import setup_logging
+
+logger = logging.getLogger("app.db.bootstrap")
+
+
+def _database_exists() -> bool:
+    """True when the configured database can be connected to."""
+    engine = create_engine(
+        settings.database_url,
+        connect_args={"connect_timeout": settings.db_connect_timeout},
+    )
+    try:
+        with engine.connect() as connection:
+            connection.execute(text("SELECT 1"))
+        return True
+    except OperationalError as exc:
+        # psycopg maps SQLSTATE 3D000 (invalid_catalog_name) to this; anything
+        # else is a genuine connection problem the caller should see.
+        if "3D000" in str(exc) or "does not exist" in str(exc):
+            return False
+        raise
+    finally:
+        engine.dispose()
+
+
+def _maintenance_url() -> str:
+    """The same connection, pointed at the default `postgres` database."""
+    return settings.database_url.rsplit("/", 1)[0] + "/postgres"
+
+
+def ensure_database_exists() -> None:
+    """Create the configured database if it is missing."""
+    if _database_exists():
+        logger.info("Database %r is present", settings.db_name)
+        return
+
+    logger.info("Database %r not found, creating it", settings.db_name)
+    engine = create_engine(
+        _maintenance_url(),
+        # CREATE DATABASE cannot run inside a transaction.
+        isolation_level="AUTOCOMMIT",
+        connect_args={"connect_timeout": settings.db_connect_timeout},
+    )
+    try:
+        with engine.connect() as connection:
+            connection.execute(text(f'CREATE DATABASE "{settings.db_name}"'))
+        logger.info("Created database %r", settings.db_name)
+    except ProgrammingError as exc:
+        message = str(exc)
+        if "already exists" in message or "42P04" in message:
+            # Another container won the race. Nothing to do.
+            logger.info("Database %r was created concurrently", settings.db_name)
+            return
+        if "permission denied" in message or "42501" in message:
+            logger.error(
+                "User %r may not create databases. Create it manually and restart:\n"
+                '    CREATE DATABASE "%s";',
+                settings.db_user,
+                settings.db_name,
+            )
+            raise SystemExit(1) from exc
+        raise
+    finally:
+        engine.dispose()
+
+
+def main() -> None:
+    """Entry point for `python -m app.db.bootstrap`."""
+    setup_logging(
+        timezone=settings.timezone,
+        log_file=settings.log_file or None,
+        level=settings.log_level,
+    )
+    try:
+        ensure_database_exists()
+    except OperationalError as exc:
+        logger.error("Could not reach the database server: %s", exc.__class__.__name__)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -7,6 +7,9 @@ if [ -d /mnt/logs ]; then
     chown -R appuser:appuser /mnt/logs
 fi
 
+echo "Ensuring the database exists…"
+gosu appuser python -m app.db.bootstrap
+
 echo "Applying database migrations…"
 gosu appuser alembic upgrade head
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,7 @@
 """Shared pytest fixtures."""
 
+import os
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -24,7 +26,22 @@ def db_session():
     from sqlalchemy import text
     from sqlalchemy.exc import SQLAlchemyError
 
+    from app.config import settings
     from app.db.session import SessionLocal, check_connection
+
+    # This fixture TRUNCATEs. Pointing it at a real database — a developer's
+    # own instance, or worse the server's — destroys data, and nothing in the
+    # command makes that obvious. Refuse loudly unless the target is clearly
+    # disposable.
+    if not settings.db_name.endswith("_test") and os.getenv("PYTEST_ALLOW_DESTRUCTIVE") != "1":
+        pytest.fail(
+            f"Refusing to TRUNCATE {settings.db_name!r}: integration tests wipe the "
+            "products and categories tables.\n"
+            "Point DB_NAME at a disposable database whose name ends in '_test' "
+            "(the API creates it on first start), or set PYTEST_ALLOW_DESTRUCTIVE=1 "
+            "if you really mean this one.",
+            pytrace=False,
+        )
 
     if not check_connection():
         pytest.skip("no reachable database")

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -1,0 +1,60 @@
+"""Database bootstrap tests."""
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from app.config import settings
+from app.db.bootstrap import _maintenance_url, ensure_database_exists
+
+THROWAWAY = "cadutrack_bootstrap_pytest"
+
+
+def test_maintenance_url_keeps_the_credentials_and_swaps_the_database():
+    url = _maintenance_url()
+    assert url.endswith("/postgres")
+    assert url.rsplit("/", 1)[0] == settings.database_url.rsplit("/", 1)[0]
+
+
+@pytest.fixture
+def maintenance_engine():
+    engine = create_engine(_maintenance_url(), isolation_level="AUTOCOMMIT")
+    try:
+        with engine.connect() as connection:
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{THROWAWAY}"'))
+        yield engine
+        with engine.connect() as connection:
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{THROWAWAY}"'))
+    finally:
+        engine.dispose()
+
+
+def _exists(engine, name: str) -> bool:
+    with engine.connect() as connection:
+        return (
+            connection.execute(
+                text("SELECT 1 FROM pg_database WHERE datname = :name"), {"name": name}
+            ).scalar()
+            is not None
+        )
+
+
+@pytest.mark.integration
+def test_creates_the_database_when_missing(maintenance_engine, monkeypatch):
+    monkeypatch.setattr(settings, "db_name", THROWAWAY)
+    assert not _exists(maintenance_engine, THROWAWAY)
+
+    ensure_database_exists()
+
+    assert _exists(maintenance_engine, THROWAWAY)
+
+
+@pytest.mark.integration
+def test_is_a_no_op_when_the_database_already_exists(maintenance_engine, monkeypatch):
+    """Every start after the first takes this path."""
+    monkeypatch.setattr(settings, "db_name", THROWAWAY)
+    ensure_database_exists()
+
+    # Must not raise, and must leave the database alone.
+    ensure_database_exists()
+
+    assert _exists(maintenance_engine, THROWAWAY)

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,47 @@
+services:
+  cadutrack:
+    # Pre-built image from GitHub Container Registry.
+    # To use it: docker compose pull && docker compose up -d
+    # Pin to a specific version for reproducible deployments:
+    # image: ghcr.io/juliomoralesb/cadutrack:0.1.0
+    image: ghcr.io/juliomoralesb/cadutrack:latest
+    # Build from source (local development / integration tests):
+    # docker compose up -d --build
+    # build:
+    #   context: ./frontend
+    container_name: cadutrack
+    ports:
+      - "${FRONTEND_PORT:-9903}:80"
+    restart: unless-stopped
+    depends_on:
+      - cadutrack-api
+    networks:
+      - apollo-server-network
+
+  cadutrack-api:
+    # Pin to a specific version for reproducible deployments:
+    # image: ghcr.io/juliomoralesb/cadutrack-api:0.1.0
+    image: ghcr.io/juliomoralesb/cadutrack-api:latest
+    # build:
+    #   context: ./backend
+    container_name: cadutrack-api
+    # No published port: only the frontend's nginx talks to the API, over the
+    # shared network. Nothing on the host can reach it directly.
+    env_file:
+      - .env
+    environment:
+      # Reach the shared PostgreSQL by container name on apollo-server-network,
+      # so the host port mapping is irrelevant here.
+      DB_HOST: ${DB_HOST:-apollo-server-db}
+      DB_PORT: ${DB_PORT:-5432}
+    restart: unless-stopped
+    volumes:
+      - type: bind
+        source: ${LOGS_PATH:-./logs}
+        target: /mnt/logs
+    networks:
+      - apollo-server-network
+
+networks:
+  apollo-server-network:
+    external: true

--- a/readme.md
+++ b/readme.md
@@ -133,15 +133,24 @@ cp .env.example .env
 # Edit .env with your database URL, Telegram bot token, etc.
 ```
 
-Run migrations and seed the default categories:
+Create the database, run migrations and seed the default categories:
 
 ```bash
+python -m app.db.bootstrap   # creates the database if it does not exist
 alembic upgrade head
 python -m app.seed
 ```
 
-The seed is idempotent — re-running it inserts only categories that are missing,
-so it is safe to run on every deploy.
+All three are idempotent and run automatically on container start, so this is
+only needed when running the API directly on the host.
+
+> **Running the tests wipes the database they point at.** The integration tests
+> `TRUNCATE` products and categories, so they refuse to run unless `DB_NAME`
+> ends in `_test`:
+>
+> ```bash
+> DB_NAME=cadutrack_test pytest
+> ```
 
 Start the server:
 


### PR DESCRIPTION
The deployable stack, plus the change that makes its first run work without a manual step.

## Creating the database on first start (#52)

Alembic creates the schema but not the database holding it, so a fresh server crash-looped until someone ran `CREATE DATABASE` by hand — undocumented, and with a cause that is not obvious from the logs. `free-games-notifier` has the same gap.

**You asked whether auto-creating is bad practice. It is not.** The real objection is least privilege: a role that can `CREATE DATABASE` can also `DROP` one. But CaduTrack already connects as the shared instance's superuser, so this grants nothing new.

The implementation keeps a restricted role viable anyway:

1. Try connecting to the configured database.
2. If that works — every start after the first — return. The `postgres` maintenance database is never touched.
3. Only when the database is genuinely missing, connect to `postgres` and create it.

Failure modes are handled rather than left raw: a concurrent creation is tolerated, and a role without `CREATEDB` gets a message naming the problem and the SQL to run, then exits non-zero so the entrypoint's `set -e` stops the container instead of continuing into a doomed migration.

**Verified all four paths against the real `apollo-server-db`:** creates a missing database; no-ops when it exists; a `NOCREATEDB` role works fine when the database exists (proving step 2 needs no elevated rights) and gets the actionable error when it does not; and an unreachable server exits 1.

## compose.yaml (#28)

Two services on `apollo-server-network`, no PostgreSQL of its own. Only `cadutrack` publishes a host port — 9903, since free-games-notifier has 8000 and apollo-server-dashboard has 9902. The API is reachable only from nginx.

**Verified exactly as Dockge would run it:** `docker compose pull` from GHCR, `docker compose up -d`, then — against a database that did not exist — the stack created it, applied migrations, seeded the 8 categories and came up healthy, serving the app on 9903 with the JSON log landing in the bind mount for Promtail.

## A hazard I hit, and fixed

**I truncated your local `cadutrack` database.** The `db_session` fixture `TRUNCATE`s products and categories before each test, and I ran the integration suite pointed at it. The lost rows were demo data I had seeded, and I have restored them — but the hazard is general: run `pytest` with the server's credentials and it wipes real data, with nothing in the command hinting at that.

The fixture now fails loudly unless `DB_NAME` ends in `_test`, with `PYTEST_ALLOW_DESTRUCTIVE=1` as an escape hatch. CI's throwaway database is renamed to `cadutrack_test` to match. Verified the guard fires against `cadutrack` and stays out of the way against `cadutrack_test`.

## Note on the published images

The compose file pulls `:latest`, which is `v0.1.0` and predates the bootstrap. The end-to-end run above used a locally built API image to exercise it; the local tag was discarded and the published image re-pulled afterwards. **A new tag is needed for the bootstrap to reach the server.**

55 backend tests pass, ruff clean. All test databases, roles and containers cleaned up; nothing left running.

Closes #52
Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)