### PR TITLE
docs: signpost which .env.example is for which job

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,13 @@
 # =============================================================================
-# CaduTrack deployment environment
-# Copy this file to .env next to compose.yaml and fill in your values:
+# CaduTrack deployment environment  —  THIS IS THE ONE FOR DEPLOYING
+#
+# Use this file when running the stack with compose.yaml (Dockge, or
+# `docker compose up -d`). Copy it next to compose.yaml and fill in your values:
 #   cp .env.example .env
+#
+# Do NOT copy backend/.env.example here. That file is for running the API
+# directly on your machine, and its DB_HOST=localhost would make the container
+# look for PostgreSQL inside itself.
 #
 # The API container reads this whole file, so every variable documented in
 # backend/.env.example is valid here too. Only the ones you are likely to

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,12 @@
 # =============================================================================
-# CaduTrack Environment Variables
-# Copy this file to .env and fill in your actual values
+# CaduTrack API environment  —  FOR RUNNING THE API DIRECTLY ON YOUR MACHINE
+#
+# Copy this file to backend/.env and fill in your actual values:
 #   cp .env.example .env
+#
+# Deploying with Docker instead? Use the .env.example at the repository root.
+# The DB_HOST below points at localhost, which is wrong inside a container —
+# there the database is reached by its container name.
 # =============================================================================
 
 # -----------------------------------------------------------------------------
@@ -47,10 +52,11 @@ DB_PASSWORD=your_secure_password
 # -----------------------------------------------------------------------------
 # Expiry alerts (Telegram)
 # -----------------------------------------------------------------------------
-# Token from @BotFather. Leave empty to disable alerts entirely.
-TELEGRAM_BOT_TOKEN=your_telegram_bot_token
+# Token from @BotFather. Leave unset to disable alerts entirely — a placeholder
+# value would read as "configured" and fail in a confusing way.
+# TELEGRAM_BOT_TOKEN=your_telegram_bot_token
 # Target chat that receives the daily digest.
-TELEGRAM_CHAT_ID=your_telegram_chat_id
+# TELEGRAM_CHAT_ID=your_telegram_chat_id
 
 # Optional: products expiring within this many days are included in the alert.
 # Defaults to 7.

--- a/readme.md
+++ b/readme.md
@@ -173,7 +173,20 @@ npm run dev
 
 ## Environment Variables
 
-See [`backend/.env.example`](backend/.env.example) for the full documented list.
+There are two `.env.example` files, and they are not interchangeable:
+
+| File | Use it for |
+|------|------------|
+| [`.env.example`](.env.example) (repo root) | **Deploying** with `compose.yaml` — Dockge or `docker compose up -d` |
+| [`backend/.env.example`](backend/.env.example) | Running the API **directly on your machine**, without Docker |
+
+The root file omits `DB_HOST` on purpose: `compose.yaml` points the container at
+`apollo-server-db` over the shared network. The backend file sets it to
+`localhost`, which is correct on your machine and wrong inside a container — so
+do not copy that one to the root.
+
+See [`backend/.env.example`](backend/.env.example) for the full documented list
+of settings; every one of them is valid in either file.
 
 | Variable              | Description                                        |
 |-----------------------|----------------------------------------------------|


### PR DESCRIPTION
Two files named `.env.example` with no indication of which one a deployer wants. Picking wrong is not a harmless mistake.

## The failure it prevents

`backend/.env.example` sets `DB_HOST=localhost`. Copy it next to `compose.yaml` and the API container looks for PostgreSQL inside itself, fails, and the error points at the database rather than at the file you copied.

Verified with `docker compose config`:

| Copied file | Resolved `DB_HOST` |
|---|---|
| `backend/.env.example` | `localhost` — broken in a container |
| `.env.example` (root) | `apollo-server-db` — correct |

## What changed

Each file now states at the top what it is for and points at the other:

- **`.env.example`** (root) — "THIS IS THE ONE FOR DEPLOYING", with an explicit warning not to copy the backend one here and why.
- **`backend/.env.example`** — "FOR RUNNING THE API DIRECTLY ON YOUR MACHINE", noting its `DB_HOST` is wrong inside a container.

The readme gains a table making the same distinction, and explains why the root file omits `DB_HOST` at all.

## Also

Commented out `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` in the backend file. They were the only placeholder values there left uncommented, so a copied file carries a literal `your_telegram_bot_token`. Harmless today since nothing reads them, but once #22 lands a non-empty token reads as *configured* and fails confusingly, where an unset one simply leaves alerts off.

No behaviour change — documentation and commented defaults only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)