### PR TITLE
fix: stop writing a log file nobody reads (#57)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,18 +35,15 @@ DB_PASSWORD=your_secure_password
 # apollo-server-dashboard, so CaduTrack defaults to 9903.
 FRONTEND_PORT=9903
 
-# Where the rotating JSON log is written on the host, for Promtail to collect.
-LOGS_PATH=./logs
-
 # -----------------------------------------------------------------------------
 # Observability
 # -----------------------------------------------------------------------------
 # IANA timezone for log timestamps, expiry calculations and alert scheduling.
 TIMEZONE=America/Mexico_City
 
-# Path of the log file inside the container. Must sit under the bind mount
-# above for Promtail to see it.
-LOG_FILE=/mnt/logs/cadutrack.log
-
 # Optional: root log level (DEBUG, INFO, WARNING, ERROR). Defaults to INFO.
 # LOG_LEVEL=INFO
+
+# LOG_FILE is deliberately unset. The container logs to stdout, which the host's
+# log pipeline already collects; writing a file as well would store every line a
+# second time for no reader. See https://server-documentation.apollox10.com

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -76,13 +76,7 @@ DB_PASSWORD=your_secure_password
 # Optional: root log level (DEBUG, INFO, WARNING, ERROR). Defaults to INFO.
 # LOG_LEVEL=INFO
 
-# Optional: absolute path to the rotating JSON log file, read by Promtail.
-# Leave empty to log to stdout only (the right choice outside Docker).
-# In the container this is /mnt/logs/cadutrack.log.
-# LOG_FILE=/mnt/logs/cadutrack.log
-
-# =============================================================================
-# Docker volume paths (used by compose.yaml bind mounts)
-# Relative paths are resolved from the directory where you run docker compose.
-# =============================================================================
-LOGS_PATH=./logs
+# Optional: absolute path to a rotating JSON log file, in addition to stdout.
+# Useful when running on a machine that does not collect stdout itself. Leave
+# empty — the default — in Docker, where the host already collects stdout.
+# LOG_FILE=/var/log/cadutrack/cadutrack.log

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -50,7 +50,8 @@ def check_connection() -> bool:
         return True
     except SQLAlchemyError as exc:
         # /health is polled continuously, so log a one-line reason rather than a
-        # full traceback — otherwise every probe floods Loki while the DB is down.
+        # full traceback — otherwise every probe floods the log store while the
+        # database is down.
         logger.error("Database health check failed: %s", exc.__class__.__name__)
         logger.debug("Database health check traceback", exc_info=exc)
         return False

--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -1,25 +1,30 @@
 """
 Structured JSON logging configuration for CaduTrack.
 
-Mirrors the format used by the other apollo-server services (free-games-notifier,
-apollo-server-dashboard) so a single Promtail pipeline can parse all of them.
+Every entry is a single-line JSON object with consistent fields:
+  - timestamp : ISO 8601 with timezone offset (e.g. "2026-04-28T10:00:00-06:00")
+  - level     : log level string (INFO, WARNING, ERROR, DEBUG)
+  - logger    : logger name (e.g. "app.routers.products")
+  - message   : the log message
+  - service   : always "cadutrack"
 
-All log entries are emitted as single-line JSON objects with consistent fields:
-  - timestamp  : ISO 8601 with timezone offset (e.g. "2026-04-28T10:00:00-06:00")
-  - level      : log level string (INFO, WARNING, ERROR, DEBUG)
-  - logger     : logger name (e.g. "app.routers.products", "__main__")
-  - message    : the log message
-  - service    : always "cadutrack" — useful as a Loki label
+That shape is a **contract**, not a integration with one particular tool: the
+home server's log pipeline promotes any JSON payload it receives into real,
+queryable fields, with no per-service configuration. Emitting this format is the
+whole of what CaduTrack has to do to be searchable and filterable by severity.
 
-Promtail pipeline_stages example:
-  - json:
-      expressions:
-        level: level
-        message: message
-        service: service
-  - labels:
-      level:
-      service:
+Deliberately not documented here: which collector and which store consume it.
+That has already changed once — this file previously carried a Promtail config
+example for a stack retired nineteen days before the file was written — and
+naming the tool is exactly what goes stale. The current pipeline is described in
+the server documentation, and that is where to look:
+
+    https://server-documentation.apollox10.com
+
+One consequence worth knowing, because it looks like a bug: Python's logging
+writes to stderr by default, so a container runtime that infers severity from
+the stream marks every line, including INFO, as an error. Severity lives in the
+`level` field above, never in the stream.
 """
 
 import logging

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -20,7 +20,7 @@ from app.logging_config import setup_logging
 from app.models import Category
 
 # Explicit rather than __name__: running this as `python -m app.seed` would
-# otherwise label every line "__main__" in Loki.
+# otherwise label every line "__main__" in the logs.
 logger = logging.getLogger("app.seed")
 
 # Spanish, because these are user-facing labels the user edits directly.

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -34,7 +34,7 @@ def test_cors_origins_are_split_and_trimmed():
 
 
 def test_log_record_matches_the_shared_json_shape():
-    """Logs must carry the fields Promtail extracts for every apollo-server service."""
+    """Logs must carry the fields the shared structured-log contract promotes."""
     formatter = _JsonFormatter(fmt="%(message)s", tz="America/Mexico_City")
     record = logging.LogRecord(
         name="app.routers.products",

--- a/compose.yaml
+++ b/compose.yaml
@@ -35,10 +35,8 @@ services:
       DB_HOST: ${DB_HOST:-apollo-server-db}
       DB_PORT: ${DB_PORT:-5432}
     restart: unless-stopped
-    volumes:
-      - type: bind
-        source: ${LOGS_PATH:-./logs}
-        target: /mnt/logs
+    # No log volume: the container writes only to stdout, which the host's log
+    # pipeline collects. See https://server-documentation.apollox10.com
     networks:
       - apollo-server-network
 

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,22 @@ A food expiry tracker app to register purchased food items, their expiration dat
 
 ---
 
+## Where this runs
+
+CaduTrack is deployed on a home server whose architecture — the shared PostgreSQL
+instance, the Docker network, how logs are collected, how services are exposed —
+is documented in one place:
+
+**[server-documentation.apollox10.com](https://server-documentation.apollox10.com)**
+
+Read it before changing anything infrastructure-shaped: logging, deployment,
+networking or the database. Those decisions live there, not here, and this
+repository does not find out when one of them changes. It has already happened:
+the logging setup in this repo was built around a collector that had been retired
+weeks earlier, because the repo still described it.
+
+---
+
 ## Repository Structure
 
 ```


### PR DESCRIPTION
CaduTrack was writing its JSON log twice: once to stdout, and once to a rotating file on a bind mount with no consumer.

## What was wrong

The deployment shipped `LOG_FILE=/mnt/logs/cadutrack.log` uncommented, with a matching bind mount in `compose.yaml`. Both were written "so Promtail can pick up the rotating JSON log".

**Promtail was deleted on 2026-08-10**, along with the rest of the Loki stack. VM 101's Docker daemon logs to journald and Vector reads the journal, so the working path is stdout → journald → Vector → OpenObserve. The file was a second copy, rotated weekly and kept four deep, that nothing ever read.

Not a capacity problem at ~11 MB/day. A misleading one: a `logs/` directory that looks like it feeds something.

## What changed

- `LOG_FILE` and `LOGS_PATH` gone from the deployment `.env.example`; the `/mnt/logs` bind mount gone from `compose.yaml`.
- The `log_file` setting and its handler **stay**, defaulting off — they are genuinely useful when running the API on a machine that does not collect stdout. The docs no longer imply anything reads the file.
- Nine references to the retired stack corrected across code and config, including a full Promtail `pipeline_stages` block in the `logging_config.py` docstring and a test asserting "the fields Promtail extracts".

Those now describe **the contract** — emit single-line JSON with `timestamp`, `level`, `logger`, `message`, `service` — instead of naming a collector. Naming the collector is precisely what expired.

## Verification

Built the image and ran it against the real `apollo-server-db`, deliberately mounting `/mnt/logs` to prove the point:

- JSON lines still on stdout, unchanged shape, correct timezone offset
- **The mounted directory stayed empty** — no file written
- `docker compose config` resolves with no volume mounts at all
- 55 backend tests pass, ruff clean

## The wider point

The readme now points at [server-documentation.apollox10.com](https://server-documentation.apollox10.com) for anything infrastructure-shaped.

That is ADR 008's own prescription rather than my idea. This repository does not find out when an infrastructure decision changes, so work done from the repo alone reproduces the retired architecture confidently and in good faith. The ADR records two prior instances; **this was the third, and I wrote it** — the logging setup here was built around a collector retired nineteen days earlier, because this repo still described it.

Correcting the artifact is the small half. The pointer is the half that stops a fourth.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)