### PR TITLE
feat: route uvicorn and alembic through the JSON formatter (#55)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -8,7 +8,6 @@ shared apollo-server-db instance.
 import logging
 import os
 import sys
-from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config, pool, text
 
@@ -19,17 +18,23 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from app.config import settings  # noqa: E402
 from app.db.base import Base  # noqa: E402
+from app.logging_config import setup_logging  # noqa: E402
 from app.models import *  # noqa: E402,F401,F403  — registers models on Base.metadata
 
 # Alembic Config object, providing access to values from alembic.ini
 alembic_config = context.config
 
-# Interpret the config file for Python logging only when running from the
-# Alembic CLI (i.e., logging has not been set up yet by the service).
-# When invoked programmatically the root logger already has handlers, so we
-# skip fileConfig to avoid clobbering the service's structured logging.
-if alembic_config.config_file_name is not None and not logging.root.handlers:
-    fileConfig(alembic_config.config_file_name)
+# Configure the service's JSON logging before Alembic would install its own.
+# Running `alembic upgrade head` from the CLI previously fell through to
+# fileConfig and emitted plain text, so migrations — the lines that matter most
+# when a deploy goes wrong — were the least queryable output the service
+# produced.
+if not logging.root.handlers:
+    setup_logging(
+        timezone=settings.timezone,
+        log_file=settings.log_file or None,
+        level=settings.log_level,
+    )
 
 # Models declare their schema via Base.metadata, so autogenerate can diff them.
 target_metadata = Base.metadata

--- a/backend/app/__main__.py
+++ b/backend/app/__main__.py
@@ -1,0 +1,34 @@
+"""Run the API server.
+
+Started this way rather than via the `uvicorn` CLI so logging is configured
+before uvicorn is, and so uvicorn can be told not to install its own handlers.
+The CLI applies its dictConfig before importing the application, which is why
+its output stayed plain text no matter what the app did afterwards.
+"""
+
+from app.config import settings
+from app.logging_config import setup_logging
+
+
+def main() -> None:
+    setup_logging(
+        timezone=settings.timezone,
+        log_file=settings.log_file or None,
+        level=settings.log_level,
+    )
+
+    import uvicorn
+
+    uvicorn.run(
+        "app.main:app",
+        host=settings.api_host,
+        port=settings.api_port,
+        # log_config=None leaves the loggers alone, so uvicorn's records
+        # propagate to the root handler set up above.
+        log_config=None,
+        access_log=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -68,9 +68,64 @@ class _JsonFormatter(_JsonFormatterBase):
         log_record["logger"] = record.name
         log_record["service"] = SERVICE_NAME
 
-        # Remove redundant / noisy fields added by the base formatter
-        for key in ("asctime", "name", "levelname"):
+        # Remove redundant / noisy fields. asctime/name/levelname duplicate the
+        # canonical ones above; color_message is uvicorn's ANSI-escaped copy of
+        # the same text, which is unreadable in a log store.
+        for key in ("asctime", "name", "levelname", "color_message"):
             log_record.pop(key, None)
+
+
+class _AccessLogFilter(logging.Filter):
+    """Give uvicorn's access lines a real severity and queryable fields.
+
+    Uvicorn logs every request at INFO, so a 500 is indistinguishable from a
+    200 when filtering by level — which is precisely what you reach for during
+    an incident. The status code is in the record's args:
+
+        '%s - "%s %s HTTP/%s" %d' % (client, method, path, version, status)
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        args = record.args
+        if not isinstance(args, tuple) or len(args) != 5:
+            # Not the access record shape we know; leave it untouched rather
+            # than guessing.
+            return True
+
+        client_addr, method, path, _http_version, status = args
+        if not isinstance(status, int):
+            return True
+
+        if status >= 500:
+            record.levelno, record.levelname = logging.ERROR, "ERROR"
+        elif status >= 400:
+            record.levelno, record.levelname = logging.WARNING, "WARNING"
+
+        record.http_status = status
+        record.http_method = method
+        # Query string dropped: it is already in the message, and as a separate
+        # field it would fragment grouping by endpoint.
+        record.http_path = str(path).split("?", 1)[0]
+        record.http_client = client_addr
+        return True
+
+
+def configure_framework_loggers() -> None:
+    """Make uvicorn's and alembic's loggers use our handlers.
+
+    Both ship their own handlers and formatters, which is how roughly half of
+    this service's output — every request line, startup message and migration —
+    used to leave as plain text while the application's own lines were JSON.
+
+    Clearing their handlers and letting them propagate puts everything through
+    the root handler configured above, so one format covers the whole stream.
+    """
+    for name in ("uvicorn", "uvicorn.error", "uvicorn.access", "alembic", "alembic.runtime.migration"):
+        logger = logging.getLogger(name)
+        logger.handlers.clear()
+        logger.propagate = True
+
+    logging.getLogger("uvicorn.access").addFilter(_AccessLogFilter())
 
 
 def setup_logging(timezone: str = "UTC", log_file: str | None = None, level: str = "INFO") -> None:
@@ -119,3 +174,5 @@ def setup_logging(timezone: str = "UTC", log_file: str | None = None, level: str
     if not root.handlers:
         for handler in handlers:
             root.addHandler(handler)
+
+    configure_framework_loggers()

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -7,18 +7,16 @@ if [ -d /mnt/logs ]; then
     chown -R appuser:appuser /mnt/logs
 fi
 
-echo "Ensuring the database exists…"
+# Each step logs its own progress as JSON. Plain `echo` announcements were
+# removed deliberately: they were the last non-JSON lines in the stream, and a
+# stream that is "JSON except for a few lines" needs a parser for the
+# exceptions.
 gosu appuser python -m app.db.bootstrap
 
-echo "Applying database migrations…"
 gosu appuser alembic upgrade head
 
 # Idempotent by design: inserts only the default categories that are missing,
 # so running it on every start costs one query and changes nothing.
-echo "Seeding default categories…"
 gosu appuser python -m app.seed
 
-echo "Starting CaduTrack API on ${API_HOST:-0.0.0.0}:${API_PORT:-8001}…"
-exec gosu appuser uvicorn app.main:app \
-    --host "${API_HOST:-0.0.0.0}" \
-    --port "${API_PORT:-8001}"
+exec gosu appuser python -m app

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -3,8 +3,10 @@
 import json
 import logging
 
+import pytest
+
 from app.config import Settings
-from app.logging_config import SERVICE_NAME, _JsonFormatter
+from app.logging_config import SERVICE_NAME, _AccessLogFilter, _JsonFormatter, configure_framework_loggers
 
 
 def test_database_url_is_built_from_parts():
@@ -64,3 +66,78 @@ def test_unknown_timezone_falls_back_to_utc():
         msg="hi", args=(), exc_info=None,
     )
     assert json.loads(formatter.format(record))["timestamp"].endswith("+00:00")
+
+
+def _access_record(status: int, path: str = "/products") -> logging.LogRecord:
+    """A record shaped like the one uvicorn's access logger emits."""
+    return logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=("172.19.0.7:36330", "GET", path, "1.1", status),
+        exc_info=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [(200, "INFO"), (201, "INFO"), (304, "INFO"), (404, "WARNING"), (422, "WARNING"), (500, "ERROR"), (503, "ERROR")],
+)
+def test_access_log_severity_follows_the_status_code(status, expected):
+    """Uvicorn logs every request at INFO, so a 500 would hide among the 200s."""
+    record = _access_record(status)
+
+    _AccessLogFilter().filter(record)
+
+    assert record.levelname == expected
+
+
+def test_access_log_gains_queryable_fields():
+    record = _access_record(200, "/products?location=pantry&category_id=3")
+
+    _AccessLogFilter().filter(record)
+
+    assert record.http_status == 200
+    assert record.http_method == "GET"
+    # Query string dropped so grouping by endpoint is not fragmented.
+    assert record.http_path == "/products"
+
+
+def test_access_filter_leaves_unfamiliar_records_alone():
+    """Guard against mangling records if uvicorn changes its access log shape."""
+    record = logging.LogRecord(
+        name="uvicorn.access", level=logging.INFO, pathname=__file__, lineno=1,
+        msg="something else entirely", args=(), exc_info=None,
+    )
+
+    _AccessLogFilter().filter(record)
+
+    assert record.levelname == "INFO"
+    assert not hasattr(record, "http_status")
+
+
+def test_uvicorn_and_alembic_loggers_route_through_our_handlers():
+    """Half the output used to leave as plain text because these had their own."""
+    for name in ("uvicorn", "uvicorn.access", "alembic"):
+        logging.getLogger(name).addHandler(logging.StreamHandler())
+
+    configure_framework_loggers()
+
+    for name in ("uvicorn", "uvicorn.error", "uvicorn.access", "alembic"):
+        logger = logging.getLogger(name)
+        assert logger.handlers == [], f"{name} still has its own handler"
+        assert logger.propagate is True, f"{name} does not propagate"
+
+
+def test_the_ansi_copy_uvicorn_attaches_is_dropped():
+    """uvicorn passes color_message with escape codes; it is noise in a log store."""
+    formatter = _JsonFormatter(fmt="%(message)s")
+    record = logging.LogRecord(
+        name="uvicorn.error", level=logging.INFO, pathname=__file__, lineno=1,
+        msg="Started server process [1]", args=(), exc_info=None,
+    )
+    record.color_message = "Started server process [\x1b[36m%d\x1b[0m]"
+
+    assert "color_message" not in json.loads(formatter.format(record))


### PR DESCRIPTION
Roughly half this service's output left as plain text — every request line, every startup message, every migration. Those are exactly the lines you want during an incident, and they were the ones `level = 'ERROR'` could not find.

## Why the app configuring its own logger was never enough

Both frameworks install their own handlers, out of reach of anything the application does afterwards:

- **uvicorn's CLI applies its dictConfig before importing the app.** The server now starts via `python -m app`, which configures logging first, then passes `log_config=None` so uvicorn leaves the loggers alone and its records propagate to the root handler.
- **`alembic/env.py` fell through to `fileConfig`** when run from the CLI. It now calls `setup_logging` instead.

## Access lines had no real severity

Uvicorn logs every request at INFO, so a 500 sat indistinguishable among the 200s. A filter maps the status code onto the level — `>=500` ERROR, `>=400` WARNING — and promotes the parts worth querying:

```json
{"message": "172.19.0.5:60638 - \"GET /products/9999 HTTP/1.1\" 404",
 "http_status": 404, "http_method": "GET", "http_path": "/products/9999",
 "level": "WARNING", "logger": "uvicorn.access", "service": "cadutrack"}
```

`http_path` drops the query string so grouping by endpoint is not fragmented across every filter combination. It stays in `message`, where uvicorn already put it — nothing new is exposed.

The filter leaves records alone if uvicorn ever changes its access-log shape, rather than guessing at the tuple. There is a test for that.

## Also

- **`color_message` dropped** — uvicorn attaches an ANSI-escaped duplicate of the text via `extra`, which the JSON formatter was faithfully shipping, escape codes and all.
- **The entrypoint's `echo` announcements removed.** They were the last non-JSON lines, and a stream that is "JSON except for a few lines" still needs a parser for the exceptions. Each step already logs its own progress.

## Verification

A container from a cold start, then two requests through it:

| | |
|---|---|
| Lines emitted | 13 |
| Lines parsing as JSON | **13** |
| Distinct loggers | `app.db.bootstrap`, `alembic.runtime.migration`, `app.seed`, `app.main`, `uvicorn.error`, `uvicorn.access` |
| `GET /products` → | `INFO`, `http_status: 200` |
| `GET /products/9999` → | `WARNING`, `http_status: 404` |

66 backend tests pass, ruff clean. Severity mapping is unit-tested across 200/201/304/404/422/500/503.

All test databases dropped and containers removed; the local `cadutrack` database and its 7 rows are untouched.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)