### PR TITLE
feat: expiry alert query, Telegram sender and manual trigger (#21, #22, #23)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,27 @@ DB_PASSWORD=your_secure_password
 FRONTEND_PORT=9903
 
 # -----------------------------------------------------------------------------
+# Expiry alerts (Telegram)
+# -----------------------------------------------------------------------------
+# Leave both unset to disable alerts; the app runs fine without them and
+# POST /alerts/trigger returns a clear 503 rather than failing silently.
+#
+# Use a bot dedicated to CaduTrack rather than the one already used for Proxmox
+# and UPS alerts. Two reasons: the token then still lives in exactly one place
+# each — the principle the UPS runbook settled on — and revoking CaduTrack's bot
+# cannot take infrastructure alerting down with it. It also keeps "your milk
+# expires tomorrow" out of the conversation where a degraded pool is reported.
+#
+# Create one by messaging @BotFather with /newbot, then message the new bot and
+# read the chat id from:
+#   curl -s "https://api.telegram.org/bot<TOKEN>/getUpdates"
+# TELEGRAM_BOT_TOKEN=123456789:AAE...
+# TELEGRAM_CHAT_ID=987654321
+
+# Optional: products expiring within this many days are included. Defaults to 7.
+# ALERT_DAYS_AHEAD=7
+
+# -----------------------------------------------------------------------------
 # Observability
 # -----------------------------------------------------------------------------
 # IANA timezone for log timestamps, expiry calculations and alert scheduling.

--- a/backend/app/alerts.py
+++ b/backend/app/alerts.py
@@ -1,0 +1,93 @@
+"""The daily expiry alert: what to say, and to whom.
+
+Delivery lives in app/telegram.py. Keeping the two apart means the message can
+be asserted in tests without a network call, which is most of what can go wrong.
+"""
+
+import logging
+from collections import defaultdict
+from datetime import date, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from app.config import settings
+from app.expiry import expiry_status, today
+from app.labels import LOCATION_LABELS, expiry_phrase
+from app.models import Product
+from app.telegram import escape, send_message
+
+logger = logging.getLogger(__name__)
+
+
+def products_needing_attention(
+    session: Session, days_ahead: int | None = None, reference: date | None = None
+) -> list[Product]:
+    """Products already expired or expiring within the next `days_ahead` days.
+
+    Expired items are included deliberately. They are the ones most worth acting
+    on, and the action — eat it or bin it and delete the row — is the same one
+    that stops them reappearing tomorrow.
+    """
+    horizon = (reference or today()) + timedelta(days=days_ahead or settings.alert_days_ahead)
+
+    statement = (
+        select(Product)
+        .options(selectinload(Product.category))
+        .where(Product.expires_at <= horizon)
+        .order_by(Product.expires_at, Product.name)
+    )
+    return list(session.execute(statement).scalars())
+
+
+def group_by_location(products: list[Product]) -> dict[str, list[Product]]:
+    """Group products by storage location, preserving the expiry ordering."""
+    grouped: dict[str, list[Product]] = defaultdict(list)
+    for product in products:
+        grouped[product.location].append(product)
+    return dict(grouped)
+
+
+def format_alert(products: list[Product], reference: date | None = None) -> str:
+    """Render the Telegram message body.
+
+    Grouped by location because that is how the food is actually visited: you
+    open the fridge once, not once per product.
+    """
+    reference = reference or today()
+    grouped = group_by_location(products)
+
+    noun = "producto" if len(products) == 1 else "productos"
+    lines = [f"<b>CaduTrack</b> — {len(products)} {noun} por revisar", ""]
+
+    # Stable order regardless of what happens to be in the fridge today.
+    for location in ("fridge", "freezer", "pantry"):
+        in_location = grouped.get(location)
+        if not in_location:
+            continue
+
+        lines.append(f"<b>{escape(LOCATION_LABELS[location])}</b>")
+        for product in in_location:
+            days = (product.expires_at - reference).days
+            marker = "🔴" if expiry_status(days) == "expired" else "🟡"
+            lines.append(f"{marker} {escape(product.name)} — {escape(expiry_phrase(days))}")
+        lines.append("")
+
+    return "\n".join(lines).strip()
+
+
+def send_expiry_alert(session: Session, reference: date | None = None) -> int:
+    """Send the daily alert. Returns how many products it covered.
+
+    Sends nothing when there is nothing to report: a daily "all good" message
+    trains you to ignore the channel, and then the one that matters is ignored
+    too.
+    """
+    products = products_needing_attention(session, reference=reference)
+
+    if not products:
+        logger.info("Nothing expiring within %s days, no alert sent", settings.alert_days_ahead)
+        return 0
+
+    send_message(format_alert(products, reference=reference))
+    return len(products)

--- a/backend/app/labels.py
+++ b/backend/app/labels.py
@@ -1,0 +1,25 @@
+"""Spanish labels for the language-neutral keys the database stores.
+
+Mirrors frontend/src/labels.ts. Duplicated rather than shared because the two
+runtimes cannot import each other, and the alert has to speak the same Spanish
+the UI does — seeing "fridge" in a notification from an app that says
+"Refrigerador" everywhere else would read as a bug.
+"""
+
+LOCATION_LABELS: dict[str, str] = {
+    "fridge": "Refrigerador",
+    "freezer": "Congelador",
+    "pantry": "Alacena",
+}
+
+
+def expiry_phrase(days_until_expiry: int) -> str:
+    """Phrase a day count the way a person would say it."""
+    if days_until_expiry < 0:
+        days = abs(days_until_expiry)
+        return "caducó ayer" if days == 1 else f"caducó hace {days} días"
+    if days_until_expiry == 0:
+        return "caduca hoy"
+    if days_until_expiry == 1:
+        return "caduca mañana"
+    return f"caduca en {days_until_expiry} días"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.logging_config import setup_logging
-from app.routers import categories, health, products
+from app.routers import alerts, categories, health, products
 
 # Configure structured logging before anything else emits a record.
 setup_logging(
@@ -29,5 +29,6 @@ app.add_middleware(
 app.include_router(health.router)
 app.include_router(categories.router)
 app.include_router(products.router)
+app.include_router(alerts.router)
 
 logger.info("CaduTrack API started")

--- a/backend/app/routers/alerts.py
+++ b/backend/app/routers/alerts.py
@@ -1,0 +1,35 @@
+"""Manual alert trigger."""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.alerts import send_expiry_alert
+from app.db.session import get_db
+from app.telegram import TelegramNotConfigured
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/alerts", tags=["alerts"])
+
+
+@router.post("/trigger")
+def trigger_alert(db: Session = Depends(get_db)) -> dict[str, object]:
+    """Send the expiry alert now, without waiting for the daily schedule.
+
+    Exists for testing the delivery path — a scheduled job that has never run is
+    a job nobody knows is broken.
+    """
+    try:
+        count = send_expiry_alert(db)
+    except TelegramNotConfigured as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
+        ) from exc
+
+    return {
+        "sent": count > 0,
+        "products": count,
+        "detail": "Alerta enviada" if count else "No hay productos por caducar",
+    }

--- a/backend/app/telegram.py
+++ b/backend/app/telegram.py
@@ -1,0 +1,68 @@
+"""Telegram delivery.
+
+Only knows how to send a message. What to say and when to say it lives in
+app/alerts.py, so the formatting can be tested without a network call.
+"""
+
+import html
+import logging
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+API_BASE = "https://api.telegram.org"
+TIMEOUT_SECONDS = 10
+
+
+class TelegramNotConfigured(RuntimeError):
+    """Raised when a send is attempted without a token and chat id."""
+
+
+def is_configured() -> bool:
+    """True when both the token and the chat id are set."""
+    return bool(settings.telegram_bot_token and settings.telegram_chat_id)
+
+
+def escape(text: str) -> str:
+    """Escape text for Telegram's HTML parse mode.
+
+    Product names are user input: an apostrophe or an ampersand in one would
+    otherwise make Telegram reject the whole message.
+    """
+    return html.escape(text, quote=False)
+
+
+def send_message(text: str) -> None:
+    """Send a message to the configured chat.
+
+    Raises rather than returning a flag: a caller that ignores the result would
+    report a delivered alert that never arrived.
+    """
+    if not is_configured():
+        raise TelegramNotConfigured(
+            "TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID must both be set to send alerts"
+        )
+
+    response = httpx.post(
+        f"{API_BASE}/bot{settings.telegram_bot_token}/sendMessage",
+        json={
+            "chat_id": settings.telegram_chat_id,
+            "text": text,
+            "parse_mode": "HTML",
+            "disable_web_page_preview": True,
+        },
+        timeout=TIMEOUT_SECONDS,
+    )
+    # The token is in the URL, so never log the request itself.
+    if response.status_code != httpx.codes.OK:
+        logger.error(
+            "Telegram rejected the message: HTTP %s %s",
+            response.status_code,
+            response.json().get("description", "") if response.text else "",
+        )
+        response.raise_for_status()
+
+    logger.info("Expiry alert delivered to Telegram")

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,5 +1,4 @@
 -r requirements.txt
 pytest>=7.4
 pytest-mock>=3.10
-httpx>=0.27
 ruff>=0.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,5 +4,6 @@ sqlalchemy>=2.0,<3.0
 alembic>=1.16,<2.0
 psycopg[binary]>=3.2,<4.0
 pydantic-settings>=2.0,<3.0
+httpx>=0.27,<1.0
 python-json-logger>=3.3,<4.0
 pytz>=2025.1

--- a/backend/tests/test_alerts.py
+++ b/backend/tests/test_alerts.py
@@ -1,0 +1,147 @@
+"""Expiry alert tests."""
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from app.alerts import format_alert, group_by_location, products_needing_attention, send_expiry_alert
+from app.models import Product
+from app.telegram import TelegramNotConfigured, escape
+
+REFERENCE = date(2026, 9, 1)
+
+
+def _product(name: str, days: int, location: str = "fridge") -> Product:
+    return Product(
+        id=abs(hash(name)) % 10000,
+        name=name,
+        quantity=1,
+        expires_at=REFERENCE + timedelta(days=days),
+        location=location,
+    )
+
+
+def test_groups_by_location_keeping_the_expiry_order():
+    products = [
+        _product("Yogur", -1, "fridge"),
+        _product("Arroz", 3, "pantry"),
+        _product("Leche", 2, "fridge"),
+    ]
+
+    grouped = group_by_location(products)
+
+    assert [p.name for p in grouped["fridge"]] == ["Yogur", "Leche"]
+    assert [p.name for p in grouped["pantry"]] == ["Arroz"]
+
+
+def test_message_uses_spanish_labels_and_phrasing():
+    message = format_alert([_product("Leche entera", 0, "fridge")], reference=REFERENCE)
+
+    assert "Refrigerador" in message
+    assert "caduca hoy" in message
+    # Never the stored key.
+    assert "fridge" not in message
+
+
+def test_expired_and_expiring_are_visually_distinct():
+    message = format_alert(
+        [_product("Yogur", -2, "fridge"), _product("Leche", 3, "fridge")], reference=REFERENCE
+    )
+
+    expired_line = next(line for line in message.splitlines() if "Yogur" in line)
+    expiring_line = next(line for line in message.splitlines() if "Leche" in line)
+    assert expired_line.startswith("🔴")
+    assert expiring_line.startswith("🟡")
+
+
+def test_locations_appear_in_a_stable_order():
+    """Otherwise the message reshuffles daily and stops being skimmable."""
+    message = format_alert(
+        [_product("Arroz", 1, "pantry"), _product("Guisantes", 1, "freezer"), _product("Leche", 1, "fridge")],
+        reference=REFERENCE,
+    )
+
+    order = [message.index(label) for label in ("Refrigerador", "Congelador", "Alacena")]
+    assert order == sorted(order)
+
+
+def test_product_names_are_escaped():
+    """A name with an ampersand would otherwise make Telegram reject the message."""
+    message = format_alert([_product("Pan & mantequilla", 1)], reference=REFERENCE)
+
+    assert "Pan &amp; mantequilla" in message
+    assert "Pan & mantequilla" not in message
+
+
+def test_the_count_is_written_as_spanish_not_as_a_template():
+    one = format_alert([_product("Leche", 1)], reference=REFERENCE)
+    many = format_alert([_product("Leche", 1), _product("Pan", 2)], reference=REFERENCE)
+
+    assert "1 producto por revisar" in one
+    assert "2 productos por revisar" in many
+
+
+def test_escape_leaves_ordinary_text_alone():
+    assert escape("Leche entera") == "Leche entera"
+
+
+@pytest.mark.integration
+def test_query_covers_expired_and_upcoming_but_not_the_distant_future(db_session):
+    reference = date(2026, 9, 1)
+    for name, days in [("Caducado", -5), ("Hoy", 0), ("Limite", 7), ("Fuera", 8)]:
+        db_session.add(_product(name, days))
+    db_session.commit()
+
+    found = products_needing_attention(db_session, days_ahead=7, reference=reference)
+
+    assert [p.name for p in found] == ["Caducado", "Hoy", "Limite"]
+
+
+@pytest.mark.integration
+def test_nothing_to_report_sends_nothing(db_session):
+    """A daily "all good" message trains you to ignore the channel."""
+    db_session.add(_product("Lejano", 90))
+    db_session.commit()
+
+    with patch("app.alerts.send_message") as send:
+        assert send_expiry_alert(db_session, reference=REFERENCE) == 0
+
+    send.assert_not_called()
+
+
+@pytest.mark.integration
+def test_sends_when_there_is_something_to_report(db_session):
+    db_session.add(_product("Leche", 1))
+    db_session.commit()
+
+    with patch("app.alerts.send_message") as send:
+        assert send_expiry_alert(db_session, reference=REFERENCE) == 1
+
+    send.assert_called_once()
+    assert "Leche" in send.call_args[0][0]
+
+
+@pytest.mark.integration
+def test_trigger_endpoint_reports_what_it_sent(api_client, db_session):
+    db_session.add(_product("Leche", 1))
+    db_session.commit()
+
+    with patch("app.alerts.send_message"):
+        response = api_client.post("/alerts/trigger")
+
+    assert response.status_code == 200
+    assert response.json() == {"sent": True, "products": 1, "detail": "Alerta enviada"}
+
+
+@pytest.mark.integration
+def test_trigger_endpoint_says_so_when_telegram_is_unconfigured(api_client, db_session):
+    """Better a clear 503 than a silent success that delivered nothing."""
+    db_session.add(_product("Leche", 1))
+    db_session.commit()
+
+    with patch("app.alerts.send_message", side_effect=TelegramNotConfigured("not configured")):
+        response = api_client.post("/alerts/trigger")
+
+    assert response.status_code == 503
+    assert "not configured" in response.json()["detail"]


### PR DESCRIPTION
The daily digest, plus `POST /alerts/trigger` to fire it on demand — a scheduled job that has never run is a job nobody knows is broken. The scheduler itself is #20, next.

## What it sends

```
CaduTrack — 5 productos por revisar

Refrigerador
🔴 Leche entera — caducó hace 3 días
🔴 Yogur griego — caducó ayer
🟡 Espinacas — caduca en 4 días
🟡 Jamón serrano — caduca en 6 días

Congelador
🟡 Pechuga de pollo — caduca mañana
```

## Decisions worth flagging

- **Expired products are included**, not only upcoming ones. They are the most worth acting on, and the action — eat it, or bin it and delete the row — is the same one that stops them reappearing tomorrow. The alternative risks a permanently stale entry nagging forever, so this is a real tradeoff, resolved toward "the thing you should act on is visible".
- **Nothing is sent when there is nothing to report.** A daily "all good" trains you to ignore the channel, and then the one that matters is ignored too. That failure mode is exactly what killed the Grafana alerts, per ADR 008.
- **Grouped by location**, because that is how food is actually visited: you open the fridge once, not once per product. The order is fixed rather than data-driven, so the message stays skimmable instead of reshuffling daily.
- **Names are HTML-escaped.** "Pan & mantequilla" would otherwise make Telegram reject the whole message.
- **`send_message` raises rather than returning a flag**, so no caller can report a delivered alert that never arrived. The endpoint turns that into a 503 with the reason.
- **Delivery is separate from wording.** `app/telegram.py` only knows how to send; `app/alerts.py` decides what to say. That is what makes the message assertable in tests without a network call.

## Use a dedicated bot — a note from the server wiki

You already have a Telegram bot, used by Proxmox and the UPS alerts, with its token in your password manager. The UPS runbook explicitly rejected posting to Telegram from the script because it would mean *"a second copy of the bot token"*.

So `.env.example` recommends a **separate bot for CaduTrack**. Each token then still lives in exactly one place, revoking CaduTrack's cannot take infrastructure alerting down with it, and "your milk expires tomorrow" stays out of the conversation where a degraded pool is reported.

No code depends on the choice — the sender reads whatever token and chat it is given.

## Verification

Beyond the 78 passing tests, the real HTTP path was exercised against a local server standing in for Telegram:

- Correct URL shape (`/bot<token>/sendMessage`), `parse_mode: HTML`, `disable_web_page_preview`, the chat id as configured.
- Then end to end: the real API, real products from the database, `POST /alerts/trigger` → `200 {"sent": true, "products": 5}` and the message above arriving at the receiving server.

Tests cover the Spanish phrasing and labels, the expired/expiring markers, stable location order, escaping, correct pluralisation, the horizon boundary (day 7 in, day 8 out), the silent case, and the 503 when Telegram is unconfigured.

`httpx` moves from a dev dependency to a runtime one.

Closes #21
Closes #22
Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)