### PR TITLE
feat: send the expiry alert on a daily schedule (#20)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,6 @@
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -6,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
 from app.logging_config import setup_logging
 from app.routers import alerts, categories, health, products
+from app.scheduler import shutdown_scheduler, start_scheduler
 
 # Configure structured logging before anything else emits a record.
 setup_logging(
@@ -16,7 +19,18 @@ setup_logging(
 
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="CaduTrack", version="0.1.0")
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    """Run the daily alert job for as long as the API is up."""
+    start_scheduler()
+    try:
+        yield
+    finally:
+        shutdown_scheduler()
+
+
+app = FastAPI(title="CaduTrack", version="0.1.0", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -1,0 +1,96 @@
+"""Daily scheduling of the expiry alert.
+
+Runs inside the API process, per #20. That is fine for a single container and
+is what the deployment runs today — but it does mean a second replica would
+send a second alert. If CaduTrack is ever scaled out, this has to move to a
+single external trigger calling POST /alerts/trigger instead.
+"""
+
+import logging
+from datetime import time
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from app.alerts import send_expiry_alert
+from app.config import settings
+from app.db.session import SessionLocal
+from app.telegram import is_configured
+
+logger = logging.getLogger(__name__)
+
+_scheduler: BackgroundScheduler | None = None
+
+JOB_ID = "daily-expiry-alert"
+
+
+def parse_alert_time(value: str) -> time:
+    """Parse ALERT_TIME as HH:MM.
+
+    Raises rather than falling back to a default: a typo that silently moves the
+    alert to midnight is worse than a container that refuses to start.
+    """
+    try:
+        hour, minute = (int(part) for part in value.split(":", 1))
+        return time(hour=hour, minute=minute)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"ALERT_TIME must be HH:MM, got {value!r}") from exc
+
+
+def run_daily_alert() -> None:
+    """The scheduled job.
+
+    Owns its own session: the request-scoped dependency does not exist here, and
+    a session held open between daily runs would go stale.
+    """
+    try:
+        with SessionLocal() as session:
+            send_expiry_alert(session)
+    except Exception:
+        # A job that raises is dropped by APScheduler with only its own warning.
+        # Log it as ours so the failure is visible under this service's name.
+        logger.exception("Daily expiry alert failed")
+
+
+def start_scheduler() -> BackgroundScheduler | None:
+    """Start the daily job. Returns None when there is nothing to schedule."""
+    global _scheduler
+
+    if not is_configured():
+        # Scheduling it anyway would raise TelegramNotConfigured once a day,
+        # for ever, in a background thread nobody is reading.
+        logger.info("Telegram is not configured, daily expiry alert not scheduled")
+        return None
+
+    alert_time = parse_alert_time(settings.alert_time)
+
+    # Threaded rather than asyncio: send_expiry_alert does blocking database and
+    # HTTP work, which on the event loop would stall every request in flight.
+    scheduler = BackgroundScheduler(timezone=settings.timezone)
+    scheduler.add_job(
+        run_daily_alert,
+        trigger=CronTrigger(hour=alert_time.hour, minute=alert_time.minute, timezone=settings.timezone),
+        id=JOB_ID,
+        # A restart spanning the alert time should still deliver, but an hour
+        # late at most — a digest arriving at midnight helps nobody.
+        misfire_grace_time=3600,
+        # Several missed runs collapse into one rather than firing a burst.
+        coalesce=True,
+        max_instances=1,
+    )
+    scheduler.start()
+    _scheduler = scheduler
+
+    logger.info(
+        "Daily expiry alert scheduled for %s %s", settings.alert_time, settings.timezone
+    )
+    return scheduler
+
+
+def shutdown_scheduler() -> None:
+    """Stop the scheduler, if one is running."""
+    global _scheduler
+    if _scheduler is not None:
+        _scheduler.shutdown(wait=False)
+        _scheduler = None
+        logger.info("Daily expiry alert scheduler stopped")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ fastapi>=0.136,<1.0
 uvicorn[standard]>=0.44,<1.0
 sqlalchemy>=2.0,<3.0
 alembic>=1.16,<2.0
+apscheduler>=3.10,<4.0
 psycopg[binary]>=3.2,<4.0
 pydantic-settings>=2.0,<3.0
 httpx>=0.27,<1.0

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1,0 +1,89 @@
+"""Daily alert scheduler tests."""
+
+from datetime import time
+from unittest.mock import patch
+
+import pytest
+
+from app.config import settings
+from app.scheduler import JOB_ID, parse_alert_time, run_daily_alert, shutdown_scheduler, start_scheduler
+
+
+@pytest.fixture(autouse=True)
+def stop_scheduler():
+    """Never leave a background thread running between tests."""
+    yield
+    shutdown_scheduler()
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [("08:00", time(8, 0)), ("00:00", time(0, 0)), ("23:59", time(23, 59)), ("7:05", time(7, 5))],
+)
+def test_parses_valid_times(value, expected):
+    assert parse_alert_time(value) == expected
+
+
+@pytest.mark.parametrize("value", ["8am", "08", "", "25:00", "08:61", "08:00:00"])
+def test_rejects_an_unusable_time(value):
+    """A typo that silently moves the alert to midnight is worse than a crash."""
+    with pytest.raises(ValueError):
+        parse_alert_time(value)
+
+
+def test_nothing_is_scheduled_without_telegram(monkeypatch):
+    """Otherwise the job raises once a day forever, in a thread nobody reads."""
+    monkeypatch.setattr(settings, "telegram_bot_token", "")
+    monkeypatch.setattr(settings, "telegram_chat_id", "")
+
+    assert start_scheduler() is None
+
+
+def test_the_job_is_registered_at_the_configured_time(monkeypatch):
+    monkeypatch.setattr(settings, "telegram_bot_token", "token")
+    monkeypatch.setattr(settings, "telegram_chat_id", "chat")
+    monkeypatch.setattr(settings, "alert_time", "06:30")
+    monkeypatch.setattr(settings, "timezone", "America/Mexico_City")
+
+    scheduler = start_scheduler()
+
+    job = scheduler.get_job(JOB_ID)
+    assert job is not None
+    assert job.next_run_time.hour == 6
+    assert job.next_run_time.minute == 30
+    # Scheduled in the configured zone, not the host's.
+    assert "Mexico_City" in str(job.next_run_time.tzinfo)
+
+
+def test_a_bad_time_stops_startup_rather_than_guessing(monkeypatch):
+    monkeypatch.setattr(settings, "telegram_bot_token", "token")
+    monkeypatch.setattr(settings, "telegram_chat_id", "chat")
+    monkeypatch.setattr(settings, "alert_time", "media noche")
+
+    with pytest.raises(ValueError):
+        start_scheduler()
+
+
+def test_missed_runs_collapse_instead_of_firing_a_burst(monkeypatch):
+    """A container down for a day should deliver once on return, not repeatedly."""
+    monkeypatch.setattr(settings, "telegram_bot_token", "token")
+    monkeypatch.setattr(settings, "telegram_chat_id", "chat")
+
+    job = start_scheduler().get_job(JOB_ID)
+
+    assert job.coalesce is True
+    assert job.max_instances == 1
+    assert job.misfire_grace_time == 3600
+
+
+def test_a_failing_send_does_not_escape_the_job():
+    """APScheduler drops a raising job with only its own warning."""
+    with patch("app.scheduler.send_expiry_alert", side_effect=RuntimeError("telegram down")):
+        run_daily_alert()  # must not raise
+
+
+def test_the_job_sends_the_alert():
+    with patch("app.scheduler.send_expiry_alert") as send:
+        run_daily_alert()
+
+    send.assert_called_once()


### PR DESCRIPTION
Closes Phase 3. The alert now fires on its own at `ALERT_TIME`, in the configured timezone.

## Verified by watching it fire

Scheduled a minute ahead and waited, touching nothing:

```
ahora:      18:13:15
programado: 18:14

*** SE DISPARÓ SOLO a las 18:14:00 ***

CaduTrack — 5 productos por revisar

Refrigerador
🔴 Leche entera — caducó hace 3 días
🔴 Yogur griego — caducó ayer
...
```

The log line `next run at: 2026-08-31 18:14:00 CST` confirms it rolled to tomorrow rather than being one-shot.

## Choices behind it

- **Threaded, not asyncio.** `send_expiry_alert` does blocking database and HTTP work; on the event loop it would stall every request in flight.
- **Nothing is scheduled when Telegram is unconfigured.** Scheduling anyway would raise once a day, forever, in a background thread nobody reads.
- **An unparseable `ALERT_TIME` stops startup** rather than falling back to a default. A typo that silently moves the alert to midnight is worse than a container that refuses to start.
- **`misfire_grace_time` one hour, `coalesce` on.** A restart spanning the alert time still delivers; a container down for a day sends one digest on return rather than a burst, and never at 3am.
- **The job owns its session and swallows its own exceptions**, because APScheduler drops a raising job with only its own warning — the failure would otherwise be invisible under this service's name.

## Known limitation, recorded in the module

The scheduler lives in the API process, so **a second replica would send a second alert**. That is fine for the single container deployed today, but if CaduTrack is ever scaled out this has to become one external trigger calling `POST /alerts/trigger`.

## The three tradeoffs I flagged, resolved as defaults

None of these needs code to change — they are all environment or behaviour you can revisit:

| Question | Where it landed | How to change it |
|---|---|---|
| Repeats the same products daily? | Yes. No dedup state; deleting or consuming the product is what stops it | Would need a new issue — dedup means new state |
| What time? | `08:00`, the existing default | `ALERT_TIME` in `.env` |
| Scheduler in or out of the API? | In, as #20 specified | Noted above if that changes |

94 backend tests pass, ruff clean. Scheduler tests cover time parsing (including four malformed forms), the unconfigured case, the registered job's time and timezone, the misfire settings, and that a failing send does not escape the job.

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)