### PR TITLE
fix: stop httpx writing the Telegram bot token to the logs (#64)

### DIFF
--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -111,14 +111,13 @@ class _AccessLogFilter(logging.Filter):
 
 
 def configure_framework_loggers() -> None:
-    """Make uvicorn's and alembic's loggers use our handlers.
+    """Make uvicorn's and alembic's loggers use our handlers, and quieten httpx.
 
-    Both ship their own handlers and formatters, which is how roughly half of
-    this service's output — every request line, startup message and migration —
-    used to leave as plain text while the application's own lines were JSON.
-
-    Clearing their handlers and letting them propagate puts everything through
-    the root handler configured above, so one format covers the whole stream.
+    uvicorn and alembic ship their own handlers and formatters, which is how
+    roughly half of this service's output — every request line, startup message
+    and migration — used to leave as plain text while the application's own
+    lines were JSON. Clearing their handlers and letting them propagate puts
+    everything through the root handler configured above.
     """
     for name in ("uvicorn", "uvicorn.error", "uvicorn.access", "alembic", "alembic.runtime.migration"):
         logger = logging.getLogger(name)
@@ -126,6 +125,13 @@ def configure_framework_loggers() -> None:
         logger.propagate = True
 
     logging.getLogger("uvicorn.access").addFilter(_AccessLogFilter())
+
+    # httpx logs every request at INFO, including the full URL. The Telegram Bot
+    # API puts the token in the path, so that line published the bot credential
+    # to the log store on every alert. Nothing in it is worth keeping: the app
+    # already logs its own delivery result, without the URL.
+    for name in ("httpx", "httpcore"):
+        logging.getLogger(name).setLevel(logging.WARNING)
 
 
 def setup_logging(timezone: str = "UTC", log_file: str | None = None, level: str = "INFO") -> None:

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,5 +1,6 @@
 """Configuration and structured-logging tests."""
 
+import io
 import json
 import logging
 
@@ -141,3 +142,50 @@ def test_the_ansi_copy_uvicorn_attaches_is_dropped():
     record.color_message = "Started server process [\x1b[36m%d\x1b[0m]"
 
     assert "color_message" not in json.loads(formatter.format(record))
+
+
+def test_the_http_client_cannot_publish_the_bot_token():
+    """Regression guard for #64.
+
+    httpx logs every request URL at INFO, and the Telegram Bot API carries the
+    token in the path — so a delivered alert used to write the credential into
+    the log store. Nothing in this service's own code had to be wrong for that
+    to happen, which is why it needs a test rather than care.
+
+    Captured through a handler attached here rather than via capsys: the real
+    handler holds the stderr it was given at setup, which pytest's capture does
+    not intercept — an earlier version of this test passed with the fix removed.
+    """
+    configure_framework_loggers()
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(_JsonFormatter(fmt="%(message)s"))
+    root = logging.getLogger()
+    root.addHandler(handler)
+    previous_level = root.level
+    root.setLevel(logging.DEBUG)
+
+    fake_token = "8670436717:AAG67gC_ue0EdBGryoKJN4oY6nILucfRMrM"
+    try:
+        logging.getLogger("httpx").info(
+            'HTTP Request: POST https://api.telegram.org/bot%s/sendMessage "HTTP/1.1 200 OK"',
+            fake_token,
+        )
+        logging.getLogger("httpcore").info("connect_tcp.started host='api.telegram.org'")
+    finally:
+        root.removeHandler(handler)
+        root.setLevel(previous_level)
+
+    assert fake_token not in stream.getvalue()
+    # The mechanism, asserted directly: the record is never created at all.
+    assert not logging.getLogger("httpx").isEnabledFor(logging.INFO)
+
+
+def test_a_real_problem_from_the_http_client_still_gets_through():
+    """Silencing INFO must not silence failures."""
+    configure_framework_loggers()
+
+    assert logging.getLogger("httpx").isEnabledFor(logging.WARNING)
+    assert logging.getLogger("httpx").isEnabledFor(logging.ERROR)


### PR DESCRIPTION
**The bot token was being published to the log store on every alert.** Found in production logs on the first day alerts ran.

```
{"message": "HTTP Request: POST https://api.telegram.org/bot<FULL_TOKEN>/sendMessage \"HTTP/1.1 200 OK\"",
 "level": "INFO", "logger": "httpx", "service": "cadutrack"}
```

`httpx` logs every request at INFO including the full URL, and the Telegram Bot API carries the token in the path. So the credential reached journald, OpenObserve, and any backup or export of either.

## Why review did not catch it

`app/telegram.py` already carried the comment *"The token is in the URL, so never log the request itself"*, and its own logging honours it — reporting only a status code, never the URL. **Nothing in this service's code had to be wrong.** The leak came entirely from a dependency's logger doing something the application never asked for, and #55 had routed every logger through the same handler precisely so nothing would be missed.

## The fix

`httpx` and `httpcore` are raised to WARNING. Their per-request INFO lines carry nothing the app does not already log — `Expiry alert delivered to Telegram` covers the success case — and genuine failures still get through, which is asserted.

## The test needed fixing too

The first version used `capsys` and **passed with the fix removed**, which makes it worse than no test. The handler holds the `stderr` it was given at setup, so pytest's capture never sees it.

It now attaches its own handler with the real formatter, and additionally asserts the mechanism directly — that `httpx` is not enabled for INFO, so the record is never created. Verified both ways: fails with the fix reverted, passes with it in place.

Also verified end to end by sending through a local stand-in for Telegram with a token-shaped credential and grepping the entire output: one line, no token.

## Required separately, and more urgent than this PR

**The leaked token has to be rotated.** This stops new copies being written; it does nothing about what is already in the log store and its backups. Revoke via @BotFather, issue a new token, update the server's `.env`.

110 backend tests pass, ruff clean.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)