### PR TITLE
docs: use the app's own icon in the readme title, drop [WIP]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# CaduTrack 🥦 [WIP]
+# <img src="frontend/public/icons/icon-192.png" alt="" width="30" align="top"> CaduTrack [WIP]
 
 A food expiry tracker app to register purchased food items, their expiration dates, and receive alerts before they expire — so nothing goes to waste.
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# <img src="frontend/public/icons/icon-192.png" alt="" width="30" align="top"> CaduTrack [WIP]
+# <img src="frontend/public/icons/icon-192.png" alt="" width="30" align="top"> CaduTrack
 
 A food expiry tracker app to register purchased food items, their expiration dates, and receive alerts before they expire — so nothing goes to waste.
 


### PR DESCRIPTION
The readme opened with `# CaduTrack 🥦 [WIP]`. Both halves were stale.

**The broccoli** predated the app having an icon and now contradicts it — the icon chosen in #24 is a milk carton with a clock badge. Replaced with the actual icon file rather than a different emoji, so the two cannot drift apart again: changing the logo changes the readme with it.

**`[WIP]`** described the repository the day the plan was written. CaduTrack is now deployed on the home server, in daily use, and sending expiry alerts on a schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)