### PR TITLE
fix: only cache JSON in the products cache (#69)

### DIFF
--- a/frontend/src/sw.test.ts
+++ b/frontend/src/sw.test.ts
@@ -1,0 +1,43 @@
+/**
+ * The service worker itself cannot run under vitest, so the caching decision is
+ * extracted and tested directly. It is the piece whose failure is silent: a bad
+ * entry only surfaces offline, long after it was written.
+ */
+import { describe, expect, it } from 'vitest'
+
+/** Mirrors the condition in sw.ts. */
+function shouldCache(response: Response): boolean {
+  if (response.status !== 200) return false
+  return !!response.headers.get('content-type')?.includes('application/json')
+}
+
+function reply(status: number, contentType: string | null): Response {
+  // Null body: a 204 may not carry one, and the body is irrelevant here anyway.
+  return new Response(null, {
+    status,
+    headers: contentType ? { 'content-type': contentType } : {},
+  })
+}
+
+describe('what may enter the products cache', () => {
+  it('accepts a real JSON response', () => {
+    expect(shouldCache(reply(200, 'application/json'))).toBe(true)
+    expect(shouldCache(reply(200, 'application/json; charset=utf-8'))).toBe(true)
+  })
+
+  it('rejects an Access login page', () => {
+    // A 200 text/html — indistinguishable from success by status alone, and the
+    // reason this guard exists.
+    expect(shouldCache(reply(200, 'text/html; charset=utf-8'))).toBe(false)
+  })
+
+  it('rejects a response with no content type at all', () => {
+    expect(shouldCache(reply(200, null))).toBe(false)
+  })
+
+  it('rejects anything that is not a 200', () => {
+    for (const status of [204, 301, 302, 401, 403, 404, 500, 502]) {
+      expect(shouldCache(reply(status, 'application/json'))).toBe(false)
+    }
+  })
+})

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -39,6 +39,15 @@ const stampCacheDate = {
   cacheWillUpdate: async ({ response }: { response: Response }) => {
     if (response.status !== 200) return null
 
+    // A 200 is not enough once anything sits between the app and the API.
+    // Cloudflare Access answers an expired session with its login page — a
+    // perfectly ordinary 200 text/html — which would replace the product list
+    // in the cache and then be served, as the product list, on every later
+    // offline open. Requiring JSON keeps anything a proxy invents out.
+    if (!response.headers.get('content-type')?.includes('application/json')) {
+      return null
+    }
+
     const headers = new Headers(response.headers)
     headers.set(CACHED_AT, new Date().toISOString())
     return new Response(await response.clone().blob(), {


### PR DESCRIPTION
Found while planning #37, before it could happen.

## The interaction

Cloudflare Access answers an expired session with its login page — **an ordinary `200 text/html`**. The service worker caches any `200` for `GET /products`, so:

1. The Access session expires while the app is open
2. The app fetches the product list
3. Cloudflare answers `200` with login HTML
4. **The service worker caches that as the product list**
5. Every later offline open serves the login page where JSON is expected

The app breaks, and stays broken offline even after logging back in, because the poisoned entry is what the cache holds.

Not reachable today — CaduTrack is LAN only, so nothing can answer but the API. #37 introduces exactly that possibility, which is why this lands before it rather than after.

## The fix

`content-type` must contain `application/json` before a response is stored, alongside the existing `200` check. Anything a proxy invents passes through to the app without displacing good data.

## Tested

The service worker cannot run under vitest, so the caching decision is asserted directly. That is the piece worth testing: its failure is silent and only surfaces offline, long after the bad entry was written.

Covers real JSON with and without a charset, an Access login page, a response with no content type at all, and eight non-200 statuses.

73 frontend tests, lint and build clean.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)