### PR TITLE
fix: the timezone test asserted a gap that is only usually one day

### DIFF
--- a/backend/tests/test_expiry.py
+++ b/backend/tests/test_expiry.py
@@ -1,6 +1,6 @@
 """Expiry status calculation tests."""
 
-from datetime import date, timedelta
+from datetime import date
 
 import pytest
 
@@ -44,12 +44,16 @@ def test_days_until_expiry_counts_from_the_reference_date():
 def test_today_honours_the_configured_timezone(monkeypatch):
     """Guards against someone swapping in date.today().
 
-    Kiritimati (UTC+14) and Niue (UTC-11) are 25 hours apart, so their dates
-    always differ — whatever the host's own timezone happens to be.
+    Kiritimati (UTC+14) and Niue (UTC-11) are 25 hours apart, so one is always
+    on a later date than the other. Only the ordering is asserted, not the gap:
+    25 hours means the difference is one day for 23 hours out of every 24, and
+    two days for the remaining hour. Asserting one day passed locally and
+    failed on CI at 10:34 UTC.
     """
     monkeypatch.setattr(settings, "timezone", "Pacific/Kiritimati")
     ahead = today()
     monkeypatch.setattr(settings, "timezone", "Pacific/Niue")
     behind = today()
 
-    assert ahead - behind == timedelta(days=1)
+    # date.today() would make these equal, which is the regression this catches.
+    assert ahead > behind


### PR DESCRIPTION
`main` is red. The failure is a test I wrote, and described as deterministic when it was not.

## What it did

`test_today_honours_the_configured_timezone` compares `today()` under Pacific/Kiritimati (UTC+14) and Pacific/Niue (UTC−11) and asserted the dates differ by **exactly one day**. The reasoning at the time: 25 hours apart, so the dates always differ.

The dates do always differ. The **gap** does not stay at one day. For one hour out of every 24 — when Kiritimati has rolled into a new date and Niue has not yet reached the previous one — the gap is two days.

Checked across a full year, every hour:

```
horas comprobadas: 8760
aserción vieja (== 1 día) fallaría en 365 horas  (4.2%)
aserción nueva  (ahead > behind) falla en 0 horas
```

It passed on the pull request and failed on the merge, which ran at **10:34 UTC** — inside that window. A 4% flake will do that: it hides during review and surfaces on the commit nobody is watching.

## The fix

Assert the ordering, not the gap. Kiritimati is always on a later date than Niue, at every hour of the year.

That still catches what the test exists for: swapping in `date.today()` makes both calls return the same value, so `ahead > behind` fails.

## Note on v0.6.0

The tag was cut from this red commit. The images are unaffected — the release workflow builds and pushes, it does not run tests, and the failure is in a test rather than in shipped code. No re-tag is needed.

110 backend tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)