### PR TITLE
fix: the nightly restart outage — nginx DNS caching and bootstrap log levels (#75, #76)

### DIFF
--- a/backend/app/db/bootstrap.py
+++ b/backend/app/db/bootstrap.py
@@ -12,6 +12,7 @@ role viable, since the common path needs no rights beyond the app's own.
 
 import logging
 import sys
+import time
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import OperationalError, ProgrammingError
@@ -20,6 +21,16 @@ from app.config import settings
 from app.logging_config import setup_logging
 
 logger = logging.getLogger("app.db.bootstrap")
+
+# On a shared Docker network the database container is often still starting when
+# this runs — the nightly backup restarts everything at once. Waiting is the
+# correct response, and it has to happen here: without it the process exits, the
+# entrypoint's `set -e` stops the container, and the restart policy brings it
+# back to try again. That worked, but it turned a five-second wait into four
+# crashed starts, each logging an ERROR that no alert can distinguish from a
+# real failure.
+CONNECT_ATTEMPTS = 10
+RETRY_SECONDS = 2.0
 
 
 def _database_exists() -> bool:
@@ -42,6 +53,33 @@ def _database_exists() -> bool:
         engine.dispose()
 
 
+def _database_exists_once_reachable() -> bool:
+    """Wait for the database server, then report whether our database is there.
+
+    Intermediate attempts are WARNING, not ERROR: they are worth seeing and they
+    are not failures. Only exhausting the budget is an error, and the caller
+    logs exactly one line for it.
+    """
+    last_error: OperationalError | None = None
+
+    for attempt in range(1, CONNECT_ATTEMPTS + 1):
+        try:
+            return _database_exists()
+        except OperationalError as exc:
+            last_error = exc
+            if attempt < CONNECT_ATTEMPTS:
+                logger.warning(
+                    "Database server not reachable yet (attempt %d/%d), retrying in %.0fs",
+                    attempt,
+                    CONNECT_ATTEMPTS,
+                    RETRY_SECONDS,
+                )
+                time.sleep(RETRY_SECONDS)
+
+    assert last_error is not None
+    raise last_error
+
+
 def _maintenance_url() -> str:
     """The same connection, pointed at the default `postgres` database."""
     return settings.database_url.rsplit("/", 1)[0] + "/postgres"
@@ -49,7 +87,7 @@ def _maintenance_url() -> str:
 
 def ensure_database_exists() -> None:
     """Create the configured database if it is missing."""
-    if _database_exists():
+    if _database_exists_once_reachable():
         logger.info("Database %r is present", settings.db_name)
         return
 
@@ -93,7 +131,14 @@ def main() -> None:
     try:
         ensure_database_exists()
     except OperationalError as exc:
-        logger.error("Could not reach the database server: %s", exc.__class__.__name__)
+        # The one ERROR this module may emit: the wait was exhausted and the
+        # service genuinely cannot start.
+        logger.error(
+            "Database server unreachable after %d attempts over %.0fs: %s",
+            CONNECT_ATTEMPTS,
+            CONNECT_ATTEMPTS * RETRY_SECONDS,
+            exc.__class__.__name__,
+        )
         sys.exit(1)
 
 

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -1,7 +1,10 @@
 """Database bootstrap tests."""
 
+import logging
+
 import pytest
 from sqlalchemy import create_engine, text
+from sqlalchemy.exc import OperationalError
 
 from app.config import settings
 from app.db.bootstrap import _maintenance_url, ensure_database_exists
@@ -58,3 +61,70 @@ def test_is_a_no_op_when_the_database_already_exists(maintenance_engine, monkeyp
     ensure_database_exists()
 
     assert _exists(maintenance_engine, THROWAWAY)
+
+
+def test_a_transient_outage_produces_warnings_and_no_error(monkeypatch, caplog):
+    """A normal restart must not look like a failure.
+
+    An ERROR here is what an error-rate alert would fire on, every night, for a
+    condition that already recovered — and an alert that cries wolf nightly gets
+    muted within a fortnight.
+    """
+    import app.db.bootstrap as bootstrap
+
+    attempts = {"n": 0}
+
+    def flaky() -> bool:
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise OperationalError("connection failed", None, Exception())
+        return True
+
+    monkeypatch.setattr(bootstrap, "_database_exists", flaky)
+    monkeypatch.setattr(bootstrap, "RETRY_SECONDS", 0)
+
+    with caplog.at_level(logging.DEBUG, logger="app.db.bootstrap"):
+        assert bootstrap._database_exists_once_reachable() is True
+
+    levels = [record.levelname for record in caplog.records]
+    assert levels == ["WARNING", "WARNING"]
+    assert "attempt 1/10" in caplog.records[0].getMessage()
+
+
+def test_giving_up_raises_so_the_caller_can_log_one_error(monkeypatch):
+    """Exhausting the budget is the only thing that deserves an ERROR."""
+    import app.db.bootstrap as bootstrap
+
+    def always_down() -> bool:
+        raise OperationalError("connection failed", None, Exception())
+
+    monkeypatch.setattr(bootstrap, "_database_exists", always_down)
+    monkeypatch.setattr(bootstrap, "RETRY_SECONDS", 0)
+
+    with pytest.raises(OperationalError):
+        bootstrap._database_exists_once_reachable()
+
+
+def test_it_waits_rather_than_letting_the_container_crash_loop(monkeypatch):
+    """Sleeping between attempts is the point.
+
+    Without it the process exits, the entrypoint stops the container, and the
+    restart policy retries — which works, but logs a failure each time.
+    """
+    import app.db.bootstrap as bootstrap
+
+    slept: list[float] = []
+    calls = {"n": 0}
+
+    def twice_down() -> bool:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise OperationalError("connection failed", None, Exception())
+        return True
+
+    monkeypatch.setattr(bootstrap, "_database_exists", twice_down)
+    monkeypatch.setattr(bootstrap.time, "sleep", lambda seconds: slept.append(seconds))
+
+    bootstrap._database_exists_once_reachable()
+
+    assert slept == [bootstrap.RETRY_SECONDS, bootstrap.RETRY_SECONDS]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,3 +1,12 @@
+# Docker's embedded DNS. Without an explicit resolver nginx looks the upstream
+# name up once, at config load, and caches that address for the life of the
+# worker — for ever, in practice. The nightly backup stops and starts every
+# container at once, Docker reassigns addresses from a pool in start order, and
+# on 2026-08-31 nginx cached the address the API had held *before* the restart.
+# Everything else in the stack re-resolves per connection and recovered on its
+# own; nginx was the only component that stayed down, for an hour.
+resolver 127.0.0.11 valid=10s ipv6=off;
+
 server {
     listen 80;
 
@@ -6,11 +15,21 @@ server {
 
     # Proxy API calls to the backend container.
     #
-    # The trailing slash on proxy_pass is load-bearing: it strips the /api/
-    # prefix, because the API serves /products, not /api/products. Without it
-    # every request 404s. This mirrors the rewrite the Vite dev server does.
+    # The API serves /products, not /api/products, so the prefix has to come
+    # off. This mirrors the rewrite the Vite dev server does in development.
     location ^~ /api/ {
-        proxy_pass http://cadutrack-api:8001/;
+        # Held in a variable on purpose: a literal here is resolved once at
+        # startup, and the resolver above is only consulted when the upstream
+        # name comes from a variable.
+        set $api_upstream http://cadutrack-api:8001;
+
+        # This rewrite does the job the trailing slash used to do. nginx only
+        # strips a location prefix when proxy_pass takes a literal; with a
+        # variable it forwards the original URI untouched, so without this every
+        # request would arrive at the API still carrying /api/.
+        rewrite ^/api/(.*)$ /$1 break;
+
+        proxy_pass $api_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Both defects from the 03:00 outage. Separate causes, one incident, and they have to ship together — the next backup is tonight.

## #75 — nginx cached the API's address for ever

With a literal hostname and no `resolver`, nginx resolves the upstream once at config load and keeps that address for the life of the worker. The backup restarts every container at once, Docker reassigns addresses in start order, and that night nginx kept the address the API had held *before* the restart.

**Reproduced and proven, not reasoned about.** The stack was brought up, the API's address was taken by another container, the API restarted onto a new one, and nginx was left untouched:

| Frontend image | Before | IP change | After |
|---|---|---|---|
| `:latest` (v0.6.0, current config) | 200 | .4 → .6 | **502** |
| local build (with `resolver`) | 200 | .4 → .6 | **200** |

That is the incident, on demand.

**The trap the issue flagged is real and handled.** Moving the upstream into a variable is what makes nginx consult the resolver — and it also stops nginx stripping the location prefix, which it only does when `proxy_pass` takes a literal. An explicit `rewrite` takes over. Verified from the API's own access log:

```
http_path=/products        status=200  level=INFO
http_path=/products/9999   status=404  level=WARNING
```

Query strings survive too — the 200 above was `/api/products?location=pantry`.

The stale comment claiming the trailing slash was load-bearing is corrected rather than left to mislead the next reader.

## #76 — the description was wrong about the mechanism, which changes the fix

The issue says a retry loop logged at the wrong level. **There is no retry loop.** The bootstrap exits non-zero, the entrypoint's `set -e` stops the container, and `restart: unless-stopped` brings it back. Those four ERROR lines a second apart are four crashed container starts.

So relabelling was not possible: the waiting the description assumed had to be added. Which is the better outcome anyway — the container now waits instead of flapping.

Verified in a container pointed at a hostname that does not resolve:

```
primera: Database server not reachable yet (attempt 1/10), retrying in 2s
última:  Database server unreachable after 10 attempts over 20s: OperationalError
recuento por nivel: {'WARNING': 9, 'ERROR': 1}
```

Nine warnings, exactly one error, and only when it genuinely gives up. A transient outage produces zero errors — unit-tested, along with the sleeping actually happening, since without it the container is back to crash-looping.

113 backend tests pass, ruff clean.

## After merging

This needs a tag and a redeploy to reach the server. Without it, tonight's backup is another coin flip.

Closes #75
Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)