### PR TITLE
fix: bound the database wait by time instead of by attempt count (#78)

### DIFF
--- a/backend/app/db/bootstrap.py
+++ b/backend/app/db/bootstrap.py
@@ -13,6 +13,7 @@ role viable, since the common path needs no rights beyond the app's own.
 import logging
 import sys
 import time
+from collections.abc import Iterator
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import OperationalError, ProgrammingError
@@ -29,8 +30,39 @@ logger = logging.getLogger("app.db.bootstrap")
 # back to try again. That worked, but it turned a five-second wait into four
 # crashed starts, each logging an ERROR that no alert can distinguish from a
 # real failure.
-CONNECT_ATTEMPTS = 10
-RETRY_SECONDS = 2.0
+#
+# The budget is bounded by elapsed time rather than by a count of attempts,
+# because the question it answers is "how long may a cold start take", not "how
+# many times should we ask". Five minutes clears any plausible one: the nightly
+# backup stops Postgres after a full day of writes, so recovery replays WAL
+# while a dozen other containers compete for the same disk. It costs nothing
+# when the database is up — the budget is only spent while it is not — and it
+# still leaves ERROR meaning a database that really is gone, which is the whole
+# point of keeping the level.
+#
+# Delays grow 1, 2, 4, 8, 16 and then hold at 30. The cap earns its place as
+# much as the growth does: doubling uncapped to five minutes would put a single
+# 256-second wait in the middle, so a database that came back at second 40 would
+# go unnoticed until second 256.
+CONNECT_BUDGET_SECONDS = 300.0
+FIRST_RETRY_SECONDS = 1.0
+MAX_RETRY_SECONDS = 30.0
+
+
+class DatabaseUnreachableError(RuntimeError):
+    """The connect budget was spent without the server ever answering.
+
+    Carries the measured attempt count and elapsed time so the caller reports
+    what happened instead of deriving it from the constants. With delays that
+    vary, attempts × interval is not the elapsed time, and a log line that
+    computes one is simply wrong.
+    """
+
+    def __init__(self, attempts: int, elapsed: float, last_error: Exception) -> None:
+        super().__init__(f"Database unreachable after {attempts} attempts over {elapsed:.0f}s")
+        self.attempts = attempts
+        self.elapsed = elapsed
+        self.last_error = last_error
 
 
 def _database_exists() -> bool:
@@ -53,6 +85,14 @@ def _database_exists() -> bool:
         engine.dispose()
 
 
+def _retry_delays() -> Iterator[float]:
+    """The wait before each retry: 1, 2, 4, 8, 16, 30, 30, … seconds."""
+    delay = FIRST_RETRY_SECONDS
+    while True:
+        yield delay
+        delay = min(delay * 2, MAX_RETRY_SECONDS)
+
+
 def _database_exists_once_reachable() -> bool:
     """Wait for the database server, then report whether our database is there.
 
@@ -60,24 +100,31 @@ def _database_exists_once_reachable() -> bool:
     are not failures. Only exhausting the budget is an error, and the caller
     logs exactly one line for it.
     """
-    last_error: OperationalError | None = None
+    started = time.monotonic()
+    delays = _retry_delays()
+    attempt = 0
 
-    for attempt in range(1, CONNECT_ATTEMPTS + 1):
+    while True:
+        attempt += 1
         try:
             return _database_exists()
         except OperationalError as exc:
-            last_error = exc
-            if attempt < CONNECT_ATTEMPTS:
-                logger.warning(
-                    "Database server not reachable yet (attempt %d/%d), retrying in %.0fs",
-                    attempt,
-                    CONNECT_ATTEMPTS,
-                    RETRY_SECONDS,
-                )
-                time.sleep(RETRY_SECONDS)
+            elapsed = time.monotonic() - started
+            remaining = CONNECT_BUDGET_SECONDS - elapsed
+            if remaining <= 0:
+                raise DatabaseUnreachableError(attempt, elapsed, exc) from exc
 
-    assert last_error is not None
-    raise last_error
+            # Never sleep past the budget: trimming the last wait puts the final
+            # attempt on the deadline rather than beyond it.
+            delay = min(next(delays), remaining)
+            logger.warning(
+                "Database server not reachable yet (attempt %d, %.0fs of %.0fs), retrying in %.0fs",
+                attempt,
+                elapsed,
+                CONNECT_BUDGET_SECONDS,
+                delay,
+            )
+            time.sleep(delay)
 
 
 def _maintenance_url() -> str:
@@ -130,15 +177,21 @@ def main() -> None:
     )
     try:
         ensure_database_exists()
-    except OperationalError as exc:
+    except DatabaseUnreachableError as exc:
         # The one ERROR this module may emit: the wait was exhausted and the
-        # service genuinely cannot start.
+        # service genuinely cannot start. Both numbers are measured.
         logger.error(
             "Database server unreachable after %d attempts over %.0fs: %s",
-            CONNECT_ATTEMPTS,
-            CONNECT_ATTEMPTS * RETRY_SECONDS,
-            exc.__class__.__name__,
+            exc.attempts,
+            exc.elapsed,
+            exc.last_error.__class__.__name__,
         )
+        sys.exit(1)
+    except OperationalError as exc:
+        # Only reachable from the CREATE DATABASE path, which runs after the
+        # server has already answered once. Worded so it cannot be read as the
+        # server being down, because it is not.
+        logger.error("Database bootstrap could not connect: %s", exc.__class__.__name__)
         sys.exit(1)
 
 

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -7,9 +7,33 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.exc import OperationalError
 
 from app.config import settings
-from app.db.bootstrap import _maintenance_url, ensure_database_exists
+from app.db.bootstrap import DatabaseUnreachableError, _maintenance_url, ensure_database_exists
 
 THROWAWAY = "cadutrack_bootstrap_pytest"
+
+
+class FakeClock:
+    """A clock that advances only when the code under test sleeps.
+
+    The retry budget is measured in elapsed time, so stubbing sleep with a no-op
+    would leave the clock at zero and spin forever. Advancing a fake clock keeps
+    these tests instant while still exercising the real budget arithmetic.
+    """
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.slept: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+def _down() -> bool:
+    raise OperationalError("connection failed", None, Exception())
 
 
 def test_maintenance_url_keeps_the_credentials_and_swaps_the_database():
@@ -77,54 +101,115 @@ def test_a_transient_outage_produces_warnings_and_no_error(monkeypatch, caplog):
     def flaky() -> bool:
         attempts["n"] += 1
         if attempts["n"] < 3:
-            raise OperationalError("connection failed", None, Exception())
+            return _down()
         return True
 
     monkeypatch.setattr(bootstrap, "_database_exists", flaky)
-    monkeypatch.setattr(bootstrap, "RETRY_SECONDS", 0)
+    monkeypatch.setattr(bootstrap, "time", FakeClock())
 
     with caplog.at_level(logging.DEBUG, logger="app.db.bootstrap"):
         assert bootstrap._database_exists_once_reachable() is True
 
     levels = [record.levelname for record in caplog.records]
     assert levels == ["WARNING", "WARNING"]
-    assert "attempt 1/10" in caplog.records[0].getMessage()
+    assert "attempt 1" in caplog.records[0].getMessage()
+    assert "retrying in 1s" in caplog.records[0].getMessage()
+
+
+def test_the_delays_grow_and_then_hold_at_the_cap(monkeypatch):
+    """Growth alone is not enough; the cap is what bounds the overshoot.
+
+    Doubling uncapped would put a single 256-second wait inside a five-minute
+    budget, leaving a database that recovered at second 40 unnoticed until 256.
+    """
+    import app.db.bootstrap as bootstrap
+
+    delays = bootstrap._retry_delays()
+    assert [next(delays) for _ in range(8)] == [1, 2, 4, 8, 16, 30, 30, 30]
+
+
+def test_the_budget_is_spent_in_full_and_never_overrun(monkeypatch):
+    """The last wait is trimmed so the final attempt lands on the deadline."""
+    import app.db.bootstrap as bootstrap
+
+    clock = FakeClock()
+    monkeypatch.setattr(bootstrap, "_database_exists", _down)
+    monkeypatch.setattr(bootstrap, "time", clock)
+
+    with pytest.raises(DatabaseUnreachableError):
+        bootstrap._database_exists_once_reachable()
+
+    assert clock.slept == [1, 2, 4, 8, 16] + [30] * 8 + [29]
+    assert sum(clock.slept) == bootstrap.CONNECT_BUDGET_SECONDS
+
+
+def test_it_reaches_far_enough_for_the_cold_start_that_defeated_the_old_budget(monkeypatch):
+    """The regression under test: the old ~18s reach missed by 260 milliseconds.
+
+    Nothing here asserts 300 seconds specifically — the point is that the budget
+    outlasts a cold start by a wide margin rather than by a coin flip.
+    """
+    import app.db.bootstrap as bootstrap
+
+    clock = FakeClock()
+    ready_at = 60.0
+
+    def up_after_a_cold_start() -> bool:
+        if clock.now < ready_at:
+            return _down()
+        return True
+
+    monkeypatch.setattr(bootstrap, "_database_exists", up_after_a_cold_start)
+    monkeypatch.setattr(bootstrap, "time", clock)
+
+    assert bootstrap._database_exists_once_reachable() is True
+    assert clock.now < bootstrap.CONNECT_BUDGET_SECONDS
 
 
 def test_giving_up_raises_so_the_caller_can_log_one_error(monkeypatch):
     """Exhausting the budget is the only thing that deserves an ERROR."""
     import app.db.bootstrap as bootstrap
 
-    def always_down() -> bool:
-        raise OperationalError("connection failed", None, Exception())
+    monkeypatch.setattr(bootstrap, "_database_exists", _down)
+    monkeypatch.setattr(bootstrap, "time", FakeClock())
 
-    monkeypatch.setattr(bootstrap, "_database_exists", always_down)
-    monkeypatch.setattr(bootstrap, "RETRY_SECONDS", 0)
-
-    with pytest.raises(OperationalError):
+    with pytest.raises(DatabaseUnreachableError) as excinfo:
         bootstrap._database_exists_once_reachable()
 
+    assert excinfo.value.attempts == 15
+    assert excinfo.value.elapsed == 300.0
 
-def test_it_waits_rather_than_letting_the_container_crash_loop(monkeypatch):
-    """Sleeping between attempts is the point.
 
-    Without it the process exits, the entrypoint stops the container, and the
-    restart policy retries — which works, but logs a failure each time.
+def test_the_error_reports_measured_time_rather_than_a_computed_product(monkeypatch, caplog):
+    """`attempts × interval` stopped being the elapsed time when delays varied.
+
+    Fifteen attempts here span 300 seconds, not 15 × any constant, so a line
+    that multiplies would report a number that never happened.
     """
     import app.db.bootstrap as bootstrap
 
-    slept: list[float] = []
-    calls = {"n": 0}
+    monkeypatch.setattr(bootstrap, "_database_exists", _down)
+    monkeypatch.setattr(bootstrap, "time", FakeClock())
+    monkeypatch.setattr(bootstrap, "setup_logging", lambda **kwargs: None)
 
-    def twice_down() -> bool:
-        calls["n"] += 1
-        if calls["n"] < 3:
-            raise OperationalError("connection failed", None, Exception())
-        return True
+    with caplog.at_level(logging.ERROR, logger="app.db.bootstrap"):
+        with pytest.raises(SystemExit):
+            bootstrap.main()
 
-    monkeypatch.setattr(bootstrap, "_database_exists", twice_down)
-    monkeypatch.setattr(bootstrap.time, "sleep", lambda seconds: slept.append(seconds))
+    errors = [record for record in caplog.records if record.levelname == "ERROR"]
+    assert len(errors) == 1
+    assert "15 attempts over 300s" in errors[0].getMessage()
 
-    bootstrap._database_exists_once_reachable()
 
-    assert slept == [bootstrap.RETRY_SECONDS, bootstrap.RETRY_SECONDS]
+def test_main_exits_non_zero_when_the_budget_is_exhausted(monkeypatch):
+    """The restart policy is the outer loop, and it needs a failing exit code."""
+    import app.db.bootstrap as bootstrap
+
+    monkeypatch.setattr(bootstrap, "_database_exists", _down)
+    monkeypatch.setattr(bootstrap, "time", FakeClock())
+    monkeypatch.setattr(bootstrap, "setup_logging", lambda **kwargs: None)
+
+    with pytest.raises(SystemExit) as excinfo:
+        bootstrap.main()
+
+    assert excinfo.value.code == 1


### PR DESCRIPTION
Closes #78.

## The change

The retry budget was ten attempts at a fixed two seconds — nine waits, ~18 seconds of reach. It is now bounded by **elapsed time**: five minutes, with waits of 1, 2, 4, 8, 16 and then a 30 second cap.

| | reach | waits |
|---|---|---|
| before | ~18 s | 2, 2, 2, 2, 2, 2, 2, 2, 2 |
| after | 300 s | 1, 2, 4, 8, 16, 30, 30, … |

**Why time and not a bigger attempt count.** The question the budget answers is "how long may a cold start take", not "how many times should we ask". An idle Postgres needed ~17 s, so ~31 s would have been the same coin flip at better odds rather than actual margin. Five minutes costs nothing on the happy path — the budget is only spent while the database is genuinely not there.

**Why the cap.** Doubling uncapped to five minutes puts a single 256 second wait in the middle, so a database that came back at second 40 would go unnoticed until second 256. The cap bounds the overshoot to 30 seconds.

**Not copying `free-games-notifier`,** as the issue originally proposed: its `max_attempts=5, base_delay=1` is four waits totalling 15 seconds — *shorter* than the 18 this service already had. Adopting it would have been a regression presented as a fix.

## Also in here

- **The final `ERROR` reports measured elapsed time.** It computed `CONNECT_ATTEMPTS * RETRY_SECONDS`, which stops being the elapsed time the moment delays vary — the same defect class as the rest of this thread, in the line that reports it. A new `DatabaseUnreachableError` carries the measured attempt count and duration.
- **A second `except` in `main()`.** The old handler caught every `OperationalError` and reported "server unreachable after N attempts", including failures from the `CREATE DATABASE` path — which only runs *after* the server has already answered. Those now say something else, because the server is not down.

## Verification

**Against a real Postgres**, stopped and brought back 25 seconds into the wait (past the old reach), same command both ways:

| | levels | exit |
|---|---|---|
| old budget | `{'WARNING': 9, 'ERROR': 1}` | 1 |
| new budget | `{'WARNING': 5, 'INFO': 2}` | 0 |

The new run in full — note the WARNING lines carry the attempt number, the elapsed time and the next delay:

```
16:27:05.812  WARNING  Database server not reachable yet (attempt 1, 0s of 300s), retrying in 1s
16:27:06.821  WARNING  Database server not reachable yet (attempt 2, 1s of 300s), retrying in 2s
16:27:08.829  WARNING  Database server not reachable yet (attempt 3, 3s of 300s), retrying in 4s
16:27:12.846  WARNING  Database server not reachable yet (attempt 4, 7s of 300s), retrying in 8s
16:27:20.853  WARNING  Database server not reachable yet (attempt 5, 15s of 300s), retrying in 16s
16:27:36.899  INFO     Database 'cadutrack_probe' not found, creating it
16:27:36.977  INFO     Created database 'cadutrack_probe'
```

**Tests.** Six of the eight bootstrap tests fail when the constants are reverted to the old fixed schedule, so they test the fix rather than merely coexisting with it. The two that survive are the URL helper and the exit-code guard — the latter asserts behaviour that was already correct but untested, which is what #78 asked for.

The exhaustion path is covered by a fake clock rather than a live five-minute wait: it asserts 15 attempts spanning exactly 300 s, one `ERROR`, exit code 1. The mechanism itself (raise → single `ERROR` → non-zero exit) is what the old-budget run above exercised against a real database.

## Acceptance criteria

- [x] The reproduction completes with zero `ERROR` lines
- [x] Exhausting the longer budget still produces exactly one `ERROR`
- [x] Retry `WARNING` lines carry the attempt number and the next delay
- [x] The final `ERROR` reports measured elapsed time, not a computed product
- [x] A test asserts the process exits non-zero on exhaustion

One criterion needs correcting rather than ticking — see the issue comment: `RestartCount` cannot be compared *before and after* the reproduction, because the `docker restart` inside it resets the counter. Measured on a throwaway container under `restart: unless-stopped`: 7 before, 1 immediately after. It has to be read after that restart, not before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)