### PR TITLE
feat: emit nginx access logs as JSON, and only for failures (#66)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -12,6 +12,11 @@ services:
     container_name: cadutrack
     ports:
       - "${FRONTEND_PORT:-9903}:80"
+    environment:
+      # nginx stamps its JSON log lines with the container's local time. Same
+      # value the API uses, so the two halves of one request do not appear
+      # hours apart when the streams are read together.
+      TZ: ${TIMEZONE:-UTC}
     restart: unless-stopped
     depends_on:
       - cadutrack-api

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,6 +12,24 @@ RUN npm run build
 # Stage 2: serve the static build with nginx
 FROM nginx:alpine
 
+# The container's whole log stream is meant to be JSON (see nginx.conf). Two
+# sources of plain text are not the access log and have to be silenced here.
+#
+# The entrypoint narrates its own startup in five lines of prose.
+ENV NGINX_ENTRYPOINT_QUIET_LOGS=1
+
+# nginx itself logs at notice, which is fourteen lines about worker processes
+# on every start — and this container restarts nightly with the backup. `warn`
+# keeps everything that reports a problem, including the upstream-resolution
+# errors from the 2026-08-31 outage, and drops the startup banner.
+#
+# Patched in place rather than by replacing nginx.conf wholesale, so the rest
+# of the base image's defaults keep tracking the upstream image. The grep is
+# the point: if a future base image words this line differently the build
+# fails here instead of silently going back to notice.
+RUN grep -q "^error_log  *[^ ]*error\.log  *notice;" /etc/nginx/nginx.conf \
+    && sed -i "s|^\(error_log  *[^ ]*error\.log  *\)notice;|\1warn;|" /etc/nginx/nginx.conf
+
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -7,11 +7,111 @@
 # own; nginx was the only component that stayed down, for an hour.
 resolver 127.0.0.11 valid=10s ipv6=off;
 
+# ─── Structured access logging ───────────────────────────────────────────────
+#
+# The rest of the fleet emits single-line JSON — timestamp, level, logger,
+# message, service — and the host's log pipeline promotes any JSON payload into
+# queryable fields with no per-service configuration. nginx wrote the default
+# combined format, so every line this container produced arrived unstructured
+# and without a level, invisible to the `level = 'ERROR'` search you actually
+# reach for during an incident. `escape=json` has been available since nginx
+# 1.11.8, so nothing here needs a sidecar or a parser.
+#
+# `service` stays "cadutrack", the same value the API uses: one filter covers
+# the whole app, and `logger` separates the components exactly as it already
+# does for uvicorn.access and app.routers.* on the backend.
+
+# Severity from the only signal nginx has. Mirrors the API's mapping in
+# app/logging_config.py so a single query spans both containers.
+map $status $log_level {
+    ~^5     ERROR;
+    ~^4     WARNING;
+    default INFO;
+}
+
+# Successful requests are deliberately not logged. This is a decision (#66),
+# not an oversight — do not "fix" it by removing the `if=` below without
+# reading this:
+#
+#   * Every /api/* request is already logged by the API itself, with the same
+#     status, method and path. Structuring these too would duplicate the only
+#     traffic anyone queries, and double every request count taken from it.
+#   * What is left is static assets — index.js and favicon.svg on every page
+#     load — which nobody has needed once, and which ADR 008 records as the
+#     exact shape of noise that made the previous log stack unusable.
+#
+# What nginx uniquely knows is when a request never reached the API at all.
+# The 502s of the 2026-08-31 outage existed in no other log. Those are kept,
+# along with every other 4xx and 5xx.
+#
+# To log successful requests as well, delete the `if=$loggable` on access_log.
+map $status $loggable {
+    ~^[23]  0;
+    default 1;
+}
+
+# $status is "000" when a client disconnects before a response line exists.
+# Unquoted in JSON that is a leading-zero number, which is a parse error — the
+# one input that would break the contract this file exists to satisfy.
+map $status $status_number {
+    ~^0+$   0;
+    default $status;
+}
+
+# $uri is post-rewrite: inside the /api/ location the prefix has already been
+# stripped, so it would log /products for a request to /api/products.
+# $request_uri is what the client actually asked for. The query string comes
+# off to match the API, where keeping it would fragment grouping by endpoint.
+#
+# A request nginx rejects before parsing its request line — 400, 414 — has
+# neither method nor URI. "-" is nginx's own convention for an absent value in
+# the combined format, and it keeps the message from rendering as bare spaces.
+map $request_uri $request_path {
+    ""                     "-";
+    ~^(?<path_only>[^?]*)  $path_only;
+    default                $request_uri;
+}
+
+map $request_method $request_method_or_dash {
+    ""      "-";
+    default $request_method;
+}
+
+log_format cadutrack_json escape=json
+    '{'
+    '"timestamp":"$time_iso8601",'
+    '"level":"$log_level",'
+    '"logger":"nginx.access",'
+    '"service":"cadutrack",'
+    '"message":"$request_method_or_dash $request_path $status",'
+    '"http_status":$status_number,'
+    '"http_method":"$request_method_or_dash",'
+    '"http_path":"$request_path",'
+    '"http_client":"$remote_addr",'
+    '"http_referer":"$http_referer",'
+    '"http_user_agent":"$http_user_agent",'
+    '"bytes_sent":$body_bytes_sent,'
+    '"request_time":$request_time'
+    '}';
+
 server {
     listen 80;
 
     root /usr/share/nginx/html;
     index index.html;
+
+    # Declared here rather than at http level on purpose: nginx inherits
+    # access_log only when the current level defines none, so this replaces the
+    # base image's combined-format line instead of adding a second one. At http
+    # level both would fire and every request would be logged twice, once as
+    # JSON and once as plain text.
+    access_log /dev/stdout cadutrack_json if=$loggable;
+
+    # error_log is the one format nginx will not let you template. The base
+    # image already symlinks it to stderr, so these lines are collected; they
+    # are simply not JSON. That is affordable because they are not what an
+    # alert fires on — a request that fails to reach the API also produces a
+    # 502 above, with a level attached.
 
     # Proxy API calls to the backend container.
     #


### PR DESCRIPTION
Closes #66.

## The decision the issue left open

#66 asked whether these logs are wanted at all, and listed two defensible outcomes. **Answered: structure them, and log only failures.**

Successful requests are dropped because every `/api/*` request is already logged by the API itself with the same status, method and path — structuring these too would duplicate the only traffic anybody queries, and double any request count taken from it. What is left is `index.js` and `favicon.svg` on every page load, which is the exact shape of noise ADR 008 records as having made the previous log stack unusable.

What nginx uniquely knows is when a request **never reached the API**. The 502s of the 2026-08-31 outage existed in no other log. Those are kept, along with every other 4xx and 5xx.

The reasoning is written into `nginx.conf` next to the `map`, per the issue's fourth criterion, with the one-line change to undo it if the trade-off ever looks wrong.

## What the container emits now

A whole session — page load, a successful API call, an SPA route, a 404 from the API, then the API disappearing:

```
{"timestamp":"2026-08-31T16:42:25+00:00","level":"WARNING","logger":"nginx.access","service":"cadutrack","message":"GET /api/nope 404","http_status":404,"http_method":"GET","http_path":"/api/nope","http_client":"192.168.65.1","http_referer":"","http_user_agent":"curl/8.7.1","bytes_sent":22,"request_time":0.001}
2026/08/31 16:42:25 [error] 33#33: *9 cadutrack-api could not be resolved (3: Host not found), client: ..., request: "GET /api/products HTTP/1.1"
{"timestamp":"2026-08-31T16:42:25+00:00","level":"ERROR","logger":"nginx.access","service":"cadutrack","message":"GET /api/products 502","http_status":502,"http_method":"GET","http_path":"/api/products","http_client":"192.168.65.1","http_referer":"","http_user_agent":"curl/8.7.1","bytes_sent":157,"request_time":0.038}
```

Three lines, where before there were nineteen and none of them queryable. The three successful requests logged nothing.

`service` stays `"cadutrack"` — the same value the API uses — and `logger` is `"nginx.access"`. One filter covers the whole app; the component lives in the field that already separates `uvicorn.access` from `app.routers.*` on the backend.

## Field details worth reviewing

- **`http_path` is `$request_uri` with the query stripped, not `$uri`.** Inside the `/api/` location the prefix has already been rewritten away, so `$uri` would have logged `/products` for a request to `/api/products`. The query string comes off to match the API, where keeping it would fragment grouping by endpoint.
- **`http_status` is a number, via a map.** `$status` is `"000"` when a client disconnects before a response line exists, and unquoted that is a leading-zero number — invalid JSON, and the one input capable of breaking the contract this change exists to satisfy. It maps to `0`.
- **`-` for method and path on unparsed requests.** A 400 or 414 is rejected before the request line is read, which rendered the message as bare spaces. `-` is nginx's own convention for an absent value.
- **`access_log` sits in `server`, not `http`.** nginx inherits it only when the current level defines none, so this *replaces* the base image's combined-format line. At `http` level both would fire and every request would be logged twice, once as JSON and once as plain text.

## Beyond what the issue asked

Two plain-text sources that are not the access log are silenced in the Dockerfile: the entrypoint's five lines of prose (`NGINX_ENTRYPOINT_QUIET_LOGS`), and nginx's notice-level startup banner — fourteen lines about worker processes, on a container that restarts nightly with the backup. `error_log` stays at `warn`, so the upstream-resolution errors from the outage still appear.

That patch is a `sed` against the base image guarded by a `grep`, so a future `nginx:alpine` that words the line differently **fails the build** instead of silently reverting to notice. That guard already earned itself during this work: the first attempt used one space where the image has two, and the build stopped rather than no-op'ing.

`compose.yaml` gives the frontend `TZ: ${TIMEZONE:-UTC}`, reusing the API's variable, so the two halves of one request do not appear hours apart when the streams are read together. Verified: `2026-08-31T10:42:51-06:00`.

## Verification

Built the real image and ran it against a stub upstream on a throwaway network.

| request | status | logged as |
|---|---|---|
| `GET /` | 200 | *nothing* |
| `GET /api/products` | 200 | *nothing* |
| `GET /settings` (SPA fallback) | 200 | *nothing* |
| `GET /api/nope` | 404 | `WARNING`, JSON |
| `GET /api/products`, API stopped | 502 | `ERROR`, JSON |

The status maps were checked in isolation across every class:

```
status 000  -> http_status=0    level=INFO     logged=yes
status 200  -> http_status=200  level=INFO     logged=no
status 301  -> http_status=301  level=INFO     logged=no
status 404  -> http_status=404  level=WARNING  logged=yes
status 414  -> http_status=414  level=WARNING  logged=yes
status 499  -> http_status=499  level=WARNING  logged=yes
status 502  -> http_status=502  level=ERROR    logged=yes
status 504  -> http_status=504  level=ERROR    logged=yes
```

## Acceptance criteria

- [x] A 404 or 500 through nginx is filterable by `level`
- [x] Field names match `free-games-notifier` and `cadutrack-api`
- [x] The chosen outcome is recorded in the config
- [x] Every line the frontend container emits parses as JSON — **with one documented exception**: nginx's `error_log` format cannot be templated, as the issue anticipated. Those lines are now the *only* non-JSON output, they are warn-level and above, and each one has a levelled JSON counterpart in the access log. Startup noise, which was the bulk of it, is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)