### PR TITLE
feat: retry a save through a dropped connection, and show a spinner (#81)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -231,6 +231,40 @@
   padding-top: 0.375rem;
 }
 
+/* Sized in em so it tracks the button's text, and drawn in currentColor so it
+   works on every theme without knowing which one is active. */
+.spinner {
+  display: inline-block;
+  width: 0.85em;
+  height: 0.85em;
+  margin-right: 0.45em;
+  vertical-align: -0.1em;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spinner-turn 0.6s linear infinite;
+}
+
+@keyframes spinner-turn {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Something must still be moving, or the button reads as frozen — so this
+   fades rather than stopping outright. */
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: spinner-fade 1.4s ease-in-out infinite;
+  }
+
+  @keyframes spinner-fade {
+    50% {
+      opacity: 0.25;
+    }
+  }
+}
+
 @media (min-width: 30rem) {
   .modal {
     align-items: center;

--- a/frontend/src/components/ProductForm.test.tsx
+++ b/frontend/src/components/ProductForm.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ProductForm } from '@/components/ProductForm'
+import type { Product } from '@/services/types'
+
+vi.mock('@/services/productsService', () => ({
+  createProduct: vi.fn(),
+  replaceProduct: vi.fn(),
+}))
+
+const products = await import('@/services/productsService')
+const mockedCreate = vi.mocked(products.createProduct)
+
+/**
+ * Fill only what the form requires, then submit.
+ *
+ * The retry itself lives inside `createProduct`, so from here a save is a
+ * single pending promise however many attempts it is really making — which is
+ * exactly the state the spinner has to survive.
+ */
+function fillAndSubmit() {
+  fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Nopal limpio' } })
+  fireEvent.change(screen.getByLabelText('Caduca el'), { target: { value: '2026-09-01' } })
+  fireEvent.click(screen.getByRole('button', { name: /guardar/i }))
+}
+
+describe('ProductForm while saving', () => {
+  it('shows a spinner and holds it until the save settles', async () => {
+    let finish: (product: Product) => void = () => {}
+    mockedCreate.mockReturnValue(
+      new Promise<Product>((resolve) => {
+        finish = resolve
+      }),
+    )
+    const onSaved = vi.fn()
+
+    const { container } = render(
+      <ProductForm categories={[]} onSaved={onSaved} onCancel={vi.fn()} />,
+    )
+    fillAndSubmit()
+
+    // Mid-flight: the retry may still be working, and the user must be able to
+    // tell that from a frozen dialog.
+    await waitFor(() => expect(container.querySelector('.spinner')).not.toBeNull())
+    expect(screen.getByRole('button', { name: /guardando/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /cancelar/i })).toBeDisabled()
+    expect(onSaved).not.toHaveBeenCalled()
+
+    finish({} as Product)
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledOnce())
+  })
+
+  it('drops the spinner and shows the reason once the attempts are exhausted', async () => {
+    mockedCreate.mockRejectedValue(new Error('nope'))
+
+    const { container } = render(
+      <ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />,
+    )
+    fillAndSubmit()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
+    expect(container.querySelector('.spinner')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Guardar' })).toBeEnabled()
+  })
+})

--- a/frontend/src/components/ProductForm.tsx
+++ b/frontend/src/components/ProductForm.tsx
@@ -201,7 +201,18 @@ export function ProductForm({ product, categories, onSaved, onCancel }: ProductF
             Cancelar
           </button>
           <button type="submit" className="button--primary" disabled={saving}>
-            {saving ? 'Guardando…' : 'Guardar'}
+            {saving ? (
+              <>
+                {/* Stays up across the whole retry sequence, because `saving`
+                    is only cleared once withRetry settles. A dropped
+                    connection is exactly when a still-disabled button with no
+                    motion reads as a hang. */}
+                <span className="spinner" aria-hidden="true" />
+                Guardando…
+              </>
+            ) : (
+              'Guardar'
+            )}
           </button>
         </div>
       </form>

--- a/frontend/src/services/productsService.test.ts
+++ b/frontend/src/services/productsService.test.ts
@@ -1,0 +1,47 @@
+import { AxiosError } from 'axios'
+import { describe, expect, it, vi } from 'vitest'
+
+import { createProduct, deleteProduct, replaceProduct } from '@/services/productsService'
+import type { ProductPayload } from '@/services/types'
+
+vi.mock('@/services/api', () => ({
+  api: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}))
+
+const { api } = await import('@/services/api')
+const mockedApi = vi.mocked(api)
+
+const payload = {} as ProductPayload
+
+function networkError(): AxiosError {
+  return new AxiosError('Network Error', AxiosError.ERR_NETWORK)
+}
+
+/**
+ * These exercise the wiring, not the retry logic — `retry.test.ts` owns that.
+ * Without them, deleting `withRetry` from a call site would break nothing.
+ */
+describe('products service retries', () => {
+  it('retries a create through a dropped connection', async () => {
+    mockedApi.post
+      .mockRejectedValueOnce(networkError())
+      .mockResolvedValue({ data: { id: 7 } })
+
+    await expect(createProduct(payload)).resolves.toEqual({ id: 7 })
+    expect(mockedApi.post).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries a replace through a dropped connection', async () => {
+    mockedApi.put.mockRejectedValueOnce(networkError()).mockResolvedValue({ data: { id: 7 } })
+
+    await expect(replaceProduct(7, payload)).resolves.toEqual({ id: 7 })
+    expect(mockedApi.put).toHaveBeenCalledTimes(2)
+  })
+
+  it('never repeats a delete, which would report a 404 for work that succeeded', async () => {
+    mockedApi.delete.mockRejectedValue(networkError())
+
+    await expect(deleteProduct(7)).rejects.toThrow('Network Error')
+    expect(mockedApi.delete).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/services/productsService.test.ts
+++ b/frontend/src/services/productsService.test.ts
@@ -28,20 +28,20 @@ describe('products service retries', () => {
       .mockResolvedValue({ data: { id: 7 } })
 
     await expect(createProduct(payload)).resolves.toEqual({ id: 7 })
-    expect(mockedApi.post).toHaveBeenCalledTimes(2)
+    expect(mockedApi.post.mock.calls).toHaveLength(2)
   })
 
   it('retries a replace through a dropped connection', async () => {
     mockedApi.put.mockRejectedValueOnce(networkError()).mockResolvedValue({ data: { id: 7 } })
 
     await expect(replaceProduct(7, payload)).resolves.toEqual({ id: 7 })
-    expect(mockedApi.put).toHaveBeenCalledTimes(2)
+    expect(mockedApi.put.mock.calls).toHaveLength(2)
   })
 
   it('never repeats a delete, which would report a 404 for work that succeeded', async () => {
     mockedApi.delete.mockRejectedValue(networkError())
 
     await expect(deleteProduct(7)).rejects.toThrow('Network Error')
-    expect(mockedApi.delete).toHaveBeenCalledTimes(1)
+    expect(mockedApi.delete.mock.calls).toHaveLength(1)
   })
 })

--- a/frontend/src/services/productsService.ts
+++ b/frontend/src/services/productsService.ts
@@ -1,4 +1,5 @@
 import { api } from '@/services/api'
+import { withRetry } from '@/services/retry'
 import type { Product, ProductFilters, ProductPayload } from '@/services/types'
 
 export interface ProductListResult {
@@ -28,17 +29,32 @@ export async function getProduct(id: number): Promise<Product> {
   return data
 }
 
+/**
+ * Retried on a dropped connection: adding something from a phone in a kitchen
+ * fails often enough that one blink should not cost the user the whole form.
+ * `withRetry` only repeats what cannot have been processed — see its comments
+ * for why a timeout is excluded.
+ */
 export async function createProduct(payload: ProductPayload): Promise<Product> {
-  const { data } = await api.post<Product>('/products', payload)
+  const { data } = await withRetry(() => api.post<Product>('/products', payload))
   return data
 }
 
-/** Full replace: fields left out of the payload are cleared. */
+/**
+ * Full replace: fields left out of the payload are cleared.
+ *
+ * Safer to retry than the POST above — PUT sends the whole intended state, so
+ * a repeat that lands twice leaves the product exactly as asked either way.
+ */
 export async function replaceProduct(id: number, payload: ProductPayload): Promise<Product> {
-  const { data } = await api.put<Product>(`/products/${id}`, payload)
+  const { data } = await withRetry(() => api.put<Product>(`/products/${id}`, payload))
   return data
 }
 
+/**
+ * Not retried. A repeat that follows a delete which actually succeeded gets a
+ * 404, and the user would be shown an error for an action that worked.
+ */
 export async function deleteProduct(id: number): Promise<void> {
   await api.delete(`/products/${id}`)
 }

--- a/frontend/src/services/retry.test.ts
+++ b/frontend/src/services/retry.test.ts
@@ -1,0 +1,98 @@
+import { AxiosError, AxiosHeaders } from 'axios'
+import { describe, expect, it, vi } from 'vitest'
+
+import { isRetryable, withRetry } from '@/services/retry'
+
+/** No waiting: the delays are a parameter precisely so tests skip real timers. */
+const NO_WAIT = [0, 0] as const
+
+function networkError(): AxiosError {
+  return new AxiosError('Network Error', AxiosError.ERR_NETWORK)
+}
+
+function timeoutError(): AxiosError {
+  return new AxiosError('timeout of 0ms exceeded', AxiosError.ECONNABORTED)
+}
+
+function httpError(status: number): AxiosError {
+  const error = new AxiosError('Request failed')
+  error.response = {
+    data: '',
+    status,
+    statusText: '',
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  }
+  return error
+}
+
+describe('isRetryable', () => {
+  it('repeats a dropped connection, which never reached the API', () => {
+    expect(isRetryable(networkError())).toBe(true)
+  })
+
+  it('refuses to repeat a timeout, because the write may already have landed', () => {
+    // The whole point of the distinction: a timeout means the request was sent
+    // and only the answer was lost. Retrying it is how duplicates are created.
+    expect(isRetryable(timeoutError())).toBe(false)
+  })
+
+  it('refuses to repeat a gateway error, which can mean a half-finished write', () => {
+    expect(isRetryable(httpError(502))).toBe(false)
+  })
+
+  it('refuses to repeat a rejected payload, which would fail identically', () => {
+    expect(isRetryable(httpError(422))).toBe(false)
+  })
+
+  it('ignores anything that is not an Axios failure', () => {
+    expect(isRetryable(new Error('boom'))).toBe(false)
+  })
+})
+
+describe('withRetry', () => {
+  it('recovers from the reported case: one blink, then the connection is back', async () => {
+    const operation = vi.fn().mockRejectedValueOnce(networkError()).mockResolvedValue('saved')
+
+    await expect(withRetry(operation, NO_WAIT)).resolves.toBe('saved')
+    expect(operation).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not call the operation again after a timeout', async () => {
+    const operation = vi.fn().mockRejectedValue(timeoutError())
+
+    await expect(withRetry(operation, NO_WAIT)).rejects.toThrow('timeout of 0ms exceeded')
+    expect(operation).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call the operation again after an HTTP error', async () => {
+    const operation = vi.fn().mockRejectedValue(httpError(422))
+
+    await expect(withRetry(operation, NO_WAIT)).rejects.toBeInstanceOf(AxiosError)
+    expect(operation).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops after the last delay and surfaces the failure', async () => {
+    const operation = vi.fn().mockRejectedValue(networkError())
+
+    await expect(withRetry(operation, NO_WAIT)).rejects.toThrow('Network Error')
+    // Two delays means three attempts, not two.
+    expect(operation).toHaveBeenCalledTimes(3)
+  })
+
+  it('succeeds without retrying when nothing goes wrong', async () => {
+    const operation = vi.fn().mockResolvedValue('saved')
+
+    await expect(withRetry(operation, NO_WAIT)).resolves.toBe('saved')
+    expect(operation).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits between attempts rather than hammering the connection', async () => {
+    const operation = vi.fn().mockRejectedValueOnce(networkError()).mockResolvedValue('saved')
+    const started = Date.now()
+
+    await withRetry(operation, [40])
+
+    expect(Date.now() - started).toBeGreaterThanOrEqual(35)
+  })
+})

--- a/frontend/src/services/retry.ts
+++ b/frontend/src/services/retry.ts
@@ -1,0 +1,61 @@
+import { AxiosError } from 'axios'
+
+/**
+ * Waits between attempts, in milliseconds. The array length is the number of
+ * *retries*, so three attempts in all.
+ *
+ * Deliberately short. This exists for a connection that blinks for a fraction
+ * of a second — the reported case recovered on a manual retry a moment later.
+ * A longer schedule would leave the user watching a spinner during the failure
+ * it cannot fix, which is worse than telling them quickly.
+ */
+const RETRY_DELAYS_MS = [300, 900] as const
+
+/**
+ * True when a failed request can be repeated without risking a duplicate.
+ *
+ * The question is not "did it fail" but "could the server have processed it
+ * anyway". Two cases must never be retried:
+ *
+ *   * **A timeout.** The request was sent and the answer never came back. The
+ *     API may well have committed the write, so repeating it would create a
+ *     second product.
+ *   * **Any HTTP response, 5xx included.** A gateway error can mean the
+ *     upstream died halfway through handling the request, which has the same
+ *     problem. A 4xx will fail identically however many times it is sent.
+ *
+ * That leaves `ERR_NETWORK`: no response, and the failure sits at the
+ * connection level. In practice this is a request that never arrived — a
+ * refused connection, a name that would not resolve, a radio that dropped
+ * before anything went out.
+ *
+ * "In practice" is doing real work in that sentence. The browser also reports
+ * `ERR_NETWORK` when a connection dies after the request was already on the
+ * wire, and nothing here can tell the two apart. Making it airtight needs an
+ * idempotency key the API can deduplicate against; the residual risk is
+ * accepted for now and written down in the issue rather than hidden here.
+ */
+export function isRetryable(error: unknown): boolean {
+  if (!(error instanceof AxiosError)) return false
+  return error.code === AxiosError.ERR_NETWORK
+}
+
+/**
+ * Run `operation`, repeating it while the failure looks safe to repeat.
+ *
+ * The delays are a parameter so tests can drive the real logic without waiting
+ * on real timers.
+ */
+export async function withRetry<T>(
+  operation: () => Promise<T>,
+  delaysMs: readonly number[] = RETRY_DELAYS_MS,
+): Promise<T> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await operation()
+    } catch (error) {
+      if (attempt >= delaysMs.length || !isRetryable(error)) throw error
+      await new Promise((resolve) => setTimeout(resolve, delaysMs[attempt]))
+    }
+  }
+}


### PR DESCRIPTION
Closes #81.

## What changed

Saving a product now makes up to three attempts, waiting 300 ms then 900 ms, and the button carries a spinner for the whole sequence.

## Which failures are repeated, and why it is not all of them

A POST is not safe to repeat in general: if the request reached the API and only the response was lost, a second one creates a second product. The client cannot see the difference — but it can see the difference between error *shapes*:

| failure | retried | why |
|---|---|---|
| `ERR_NETWORK` | **yes** | no response, connection-level — in practice the request never arrived |
| timeout | no | it was sent; the write may already have landed |
| any 5xx | no | a gateway error can mean an upstream that died halfway through |
| any 4xx | no | it will fail identically however many times it is sent |

`DELETE` is not retried either: repeating one that actually succeeded returns 404, and the user would be shown an error for work that worked.

**`ERR_NETWORK` is not an airtight guarantee.** The browser also reports it when a connection dies after the request is already on the wire, and nothing here distinguishes those. Closing that gap needs an idempotency key the API can deduplicate against; the residual risk is accepted deliberately, and #81 records that a real duplicate is what would trigger building it. It is written into `retry.ts` rather than left implicit.

## Verified in a browser, not just in tests

Pointed at a port with nothing listening, so the browser produces a real `ERR_CONNECTION_REFUSED`. One click on **Guardar**:

```
POST http://localhost:9931/api/products [FAILED: net::ERR_CONNECTION_REFUSED]
POST http://localhost:9931/api/products [FAILED: net::ERR_CONNECTION_REFUSED]
POST http://localhost:9931/api/products [FAILED: net::ERR_CONNECTION_REFUSED]
```

Three attempts, then the message. The same submit against the Vite proxy with no backend produced **exactly one** POST — that path returns 502, an HTTP response, correctly left alone. Both halves of the rule observed in the real thing.

Mid-flight the button reads **"⟳ Guardando…"** with the spinner turning, and **Cancelar** is disabled beside it, so there is no way to half-abandon a save that is still being attempted.

## Tests

Both halves fail when the change is reverted, so they test the fix rather than coexisting with it:

- Removing `withRetry` from the service call sites → **2 failures** in `productsService.test.ts`
- Widening the check to `response === undefined`, the mistake that would silently start retrying timeouts → **2 failures** in `retry.test.ts`

`retry.test.ts` owns the logic, `productsService.test.ts` owns the wiring, and `ProductForm.test.tsx` — a component that had no tests — asserts the spinner appears while the save is pending and is gone once the error renders.

134 frontend tests pass, `tsc --noEmit` and `npm run build` both clean.

## Note on the reduced-motion variant

Under `prefers-reduced-motion` the spinner fades rather than stopping outright. A frozen button during a dropped connection reads as a hang, and a hang is what prompts the second tap that creates the duplicate this PR is careful to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
