### PR TITLE
feat: increment and decrement a product's quantity from the list and the form (#82)

### DIFF
--- a/backend/app/routers/products.py
+++ b/backend/app/routers/products.py
@@ -4,12 +4,12 @@ import logging
 from datetime import date
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.orm import Session, selectinload
 
 from app.db.session import get_db
 from app.models import Category, Location, Product
-from app.schemas.product import ProductCreate, ProductRead, ProductUpdate
+from app.schemas.product import ProductCreate, ProductQuantityDelta, ProductRead, ProductUpdate
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +104,44 @@ def replace_product(
     # until we read it back.
     db.refresh(product)
     logger.info("Updated product %s (%s)", product.id, product.name)
+    return product
+
+
+@router.patch("/{product_id}/quantity", response_model=ProductRead)
+def adjust_quantity(
+    product_id: int, payload: ProductQuantityDelta, db: Session = Depends(get_db)
+) -> Product:
+    """Apply a relative change to a product's quantity.
+
+    Deliberately a delta, not PATCH-with-an-absolute-value: see
+    ProductQuantityDelta. The UPDATE below is what makes the delta contract
+    actually safe under concurrent requests, not just in principle. `quantity`
+    is read and written in the same statement, evaluated against the row's
+    live value at the moment of the update under Postgres's row lock — not a
+    value this function fetched earlier and might be replaying against a stale
+    read. Two overlapping requests serialize on that lock and each is applied
+    to what the other left behind, so composing correctly does not depend on
+    which one the database happens to run first.
+    """
+    product = _get_or_404(db, product_id)
+
+    result = db.execute(
+        update(Product)
+        .where(Product.id == product_id, Product.quantity + payload.delta > 0)
+        .values(quantity=Product.quantity + payload.delta)
+    )
+    if result.rowcount == 0:
+        # The existence check above already passed, so the only way to match
+        # zero rows here is the WHERE clause's positivity guard — the database
+        # constraint would catch this too, but as a 500 with no useful detail.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Adjusting by {payload.delta} would leave a non-positive quantity",
+        )
+
+    db.commit()
+    db.refresh(product)
+    logger.info("Adjusted product %s (%s) quantity by %s", product.id, product.name, payload.delta)
     return product
 
 

--- a/backend/app/schemas/product.py
+++ b/backend/app/schemas/product.py
@@ -35,6 +35,18 @@ class ProductUpdate(ProductBase):
     """
 
 
+class ProductQuantityDelta(BaseModel):
+    """A relative change to a product's quantity.
+
+    Sent as a delta rather than an absolute value: two quick taps racing on a
+    slow connection both send "-1" and compose correctly regardless of arrival
+    order, where two absolute values ("quantity = 4" twice) would silently
+    drop one of the taps. See #82.
+    """
+
+    delta: Decimal = Field(max_digits=10, decimal_places=2)
+
+
 class ProductRead(ProductBase):
     """A product as returned by the API."""
 

--- a/backend/tests/test_products_api.py
+++ b/backend/tests/test_products_api.py
@@ -1,6 +1,8 @@
 """Product endpoint tests."""
 
+import threading
 from datetime import date, timedelta
+from decimal import Decimal
 
 import pytest
 
@@ -133,10 +135,72 @@ def test_delete_removes_the_product(api_client):
     assert api_client.get("/products").json() == []
 
 
-@pytest.mark.parametrize("method,path", [("get", "/products/9999"), ("put", "/products/9999"), ("delete", "/products/9999")])
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("get", "/products/9999"),
+        ("put", "/products/9999"),
+        ("delete", "/products/9999"),
+        ("patch", "/products/9999/quantity"),
+    ],
+)
 def test_missing_product_is_404(api_client, method, path):
-    kwargs = {"json": _product()} if method == "put" else {}
+    kwargs: dict = {"json": _product()} if method == "put" else {}
+    if method == "patch":
+        kwargs = {"json": {"delta": "-1"}}
     assert getattr(api_client, method)(path, **kwargs).status_code == 404
+
+
+def test_quantity_increments(api_client):
+    product_id = api_client.post("/products", json=_product(quantity="2.00")).json()["id"]
+
+    response = api_client.patch(f"/products/{product_id}/quantity", json={"delta": "1"})
+
+    assert response.status_code == 200
+    assert response.json()["quantity"] == "3.00"
+
+
+def test_two_rapid_decrements_land_on_three_not_four(api_client):
+    """The composition guarantee #82 exists for: sent as two deltas, not two
+    absolute values, so neither tap is lost regardless of ordering."""
+    product_id = api_client.post("/products", json=_product(quantity="5.00")).json()["id"]
+
+    api_client.patch(f"/products/{product_id}/quantity", json={"delta": "-1"})
+    second = api_client.patch(f"/products/{product_id}/quantity", json={"delta": "-1"})
+
+    assert second.json()["quantity"] == "3.00"
+
+
+def test_a_fractional_quantity_steps_without_being_rounded(api_client):
+    """Numeric(10, 2) is the real precision boundary — not 0 decimal places —
+    so a purchase already carrying cents must keep them exactly after a step."""
+    product_id = api_client.post("/products", json=_product(quantity="0.59")).json()["id"]
+
+    response = api_client.patch(f"/products/{product_id}/quantity", json={"delta": "1"})
+
+    assert response.json()["quantity"] == "1.59"
+
+
+def test_decrementing_below_zero_is_rejected_without_a_500(api_client):
+    product_id = api_client.post("/products", json=_product(quantity="1.00")).json()["id"]
+
+    response = api_client.patch(f"/products/{product_id}/quantity", json={"delta": "-1"})
+
+    assert response.status_code == 422
+    assert "non-positive" in response.json()["detail"]
+    # Rejected, not partially applied.
+    assert api_client.get(f"/products/{product_id}").json()["quantity"] == "1.00"
+
+
+def test_decrementing_past_zero_is_rejected_the_same_way(api_client):
+    """The guard is quantity + delta > 0, not merely != 0 — a delta larger than
+    the current quantity must be caught too, not wrap or go negative."""
+    product_id = api_client.post("/products", json=_product(quantity="1.00")).json()["id"]
+
+    response = api_client.patch(f"/products/{product_id}/quantity", json={"delta": "-5"})
+
+    assert response.status_code == 422
+    assert api_client.get(f"/products/{product_id}").json()["quantity"] == "1.00"
 
 
 def test_response_carries_days_until_expiry_and_status(api_client):
@@ -168,3 +232,54 @@ def test_a_product_expiring_today_is_not_shown_as_expired(api_client):
     product = api_client.get("/products").json()[0]
     assert product["days_until_expiry"] == 0
     assert product["status"] == "expiring_soon"
+
+
+def test_concurrent_decrements_do_not_lose_an_update(api_client):
+    """Proves the atomic UPDATE, not just the sequential test above — by
+    calling the real endpoint function, not a hand-rolled copy of its SQL.
+
+    An earlier version of this test wrote its own raw UPDATE statement inside
+    the thread target instead of calling `adjust_quantity`. It passed even
+    with the endpoint reverted to a read-then-write implementation, because it
+    was proving a fact about Postgres in the abstract, not about this code —
+    the exact failure this project's testing conventions exist to catch. If
+    two concurrent calls read quantity=N before either commits and each
+    computes N-1 in Python, both write N-1 and one decrement vanishes; only a
+    SET clause evaluated against the row's live value at UPDATE time — not a
+    Python-computed constant — avoids it.
+
+    Racing two threads once is real but timing-dependent: on a fast local
+    database the two calls might not truly overlap on a given run, so a buggy
+    implementation could pass by luck. Racing 20 rounds turns "might overlap"
+    into "will overlap at least once", so a genuine lost-update bug reliably
+    shows up in the final total rather than depending on a single roll.
+    """
+    from app.db.session import SessionLocal
+    from app.routers.products import adjust_quantity
+    from app.schemas.product import ProductQuantityDelta
+
+    rounds = 20
+    product_id = api_client.post("/products", json=_product(quantity="100.00")).json()["id"]
+    errors: list[BaseException] = []
+
+    def decrement_via_own_session(start: threading.Barrier) -> None:
+        session = SessionLocal()
+        try:
+            start.wait(timeout=5)
+            adjust_quantity(product_id, ProductQuantityDelta(delta=Decimal("-1")), session)
+        except BaseException as exc:  # noqa: BLE001 - surfaced on the main thread below
+            errors.append(exc)
+        finally:
+            session.close()
+
+    for _ in range(rounds):
+        barrier = threading.Barrier(2)
+        threads = [threading.Thread(target=decrement_via_own_session, args=(barrier,)) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+
+    assert not errors, errors
+    expected = Decimal("100.00") - rounds * 2
+    assert api_client.get(f"/products/{product_id}").json()["quantity"] == f"{expected:.2f}"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -86,6 +86,41 @@
   color: var(--status-color, var(--text));
 }
 
+.product-card__quantity-error {
+  color: var(--danger);
+  font-size: 0.8125rem;
+}
+
+/* Used both on the card (value is plain text) and in the form (value is the
+   quantity input), so the button styling lives here once. */
+.quantity-stepper {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.quantity-stepper__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  font-size: 1rem;
+  line-height: 1;
+  border-radius: 0.375rem;
+}
+
+.quantity-stepper__value {
+  min-width: 1.5rem;
+  text-align: center;
+}
+
+.quantity-stepper__input {
+  width: 4.5rem;
+  text-align: center;
+}
+
 .state {
   padding: 2.5rem 1rem;
   text-align: center;
@@ -203,7 +238,8 @@
   gap: 0.3rem;
 }
 
-.form__field > span {
+.form__field > span,
+.form__field > label {
   font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text-muted);

--- a/frontend/src/components/ProductCard.test.tsx
+++ b/frontend/src/components/ProductCard.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ProductCard } from '@/components/ProductCard'
+import type { Product } from '@/services/types'
+
+vi.mock('@/services/productsService', () => ({
+  adjustProductQuantity: vi.fn(),
+}))
+
+const products = await import('@/services/productsService')
+const mockedAdjust = vi.mocked(products.adjustProductQuantity)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function product(overrides: Partial<Product> = {}): Product {
+  return {
+    id: 1,
+    name: 'Plátano',
+    category_id: null,
+    quantity: '3.00',
+    unit: 'piezas',
+    expires_at: '2026-09-03',
+    location: 'fridge',
+    notes: null,
+    category: null,
+    created_at: '2026-08-29T00:00:00Z',
+    updated_at: '2026-08-29T00:00:00Z',
+    days_until_expiry: 5,
+    status: 'expiring_soon',
+    ...overrides,
+  }
+}
+
+function renderCard(overrides: Partial<Product> = {}) {
+  const onQuantityChanged = vi.fn()
+  render(
+    <ul>
+      <ProductCard
+        product={product(overrides)}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onQuantityChanged={onQuantityChanged}
+      />
+    </ul>,
+  )
+  return { onQuantityChanged }
+}
+
+describe('ProductCard quantity stepper', () => {
+  it('sends +1 and reports the server response back to the list', async () => {
+    const updated = product({ quantity: '4.00' })
+    mockedAdjust.mockResolvedValue(updated)
+    const { onQuantityChanged } = renderCard({ quantity: '3.00' })
+
+    screen.getByRole('button', { name: 'Aumentar cantidad de Plátano' }).click()
+
+    await waitFor(() => expect(onQuantityChanged).toHaveBeenCalledWith(updated))
+    expect(mockedAdjust).toHaveBeenCalledWith(1, 1)
+  })
+
+  it('sends -1 from the "−" button', async () => {
+    mockedAdjust.mockResolvedValue(product({ quantity: '2.00' }))
+    renderCard({ quantity: '3.00' })
+
+    screen.getByRole('button', { name: 'Reducir cantidad de Plátano' }).click()
+
+    await waitFor(() => expect(mockedAdjust).toHaveBeenCalledWith(1, -1))
+  })
+
+  it('disables "−" at quantity 1, offering no path to zero', () => {
+    renderCard({ quantity: '1.00' })
+
+    expect(screen.getByRole('button', { name: 'Reducir cantidad de Plátano' })).toBeDisabled()
+    expect(mockedAdjust).not.toHaveBeenCalled()
+  })
+
+  it('keeps "+" enabled at quantity 1 — there is no upper bound', () => {
+    renderCard({ quantity: '1.00' })
+
+    expect(screen.getByRole('button', { name: 'Aumentar cantidad de Plátano' })).toBeEnabled()
+  })
+
+  it('disables both buttons while a request is in flight, to avoid a stacked duplicate tap', async () => {
+    let resolveRequest: (product: Product) => void = () => {}
+    mockedAdjust.mockReturnValue(
+      new Promise<Product>((resolve) => {
+        resolveRequest = resolve
+      }),
+    )
+    renderCard({ quantity: '3.00' })
+
+    screen.getByRole('button', { name: 'Aumentar cantidad de Plátano' }).click()
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /aumentar/i })).toBeDisabled())
+    expect(screen.getByRole('button', { name: /reducir/i })).toBeDisabled()
+
+    resolveRequest(product({ quantity: '4.00' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: /aumentar/i })).toBeEnabled())
+  })
+
+  it('shows the failure inline and leaves the displayed quantity untouched', async () => {
+    mockedAdjust.mockRejectedValue(new Error('nope'))
+    const { onQuantityChanged } = renderCard({ quantity: '3.00' })
+
+    screen.getByRole('button', { name: 'Aumentar cantidad de Plátano' }).click()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
+    expect(onQuantityChanged).not.toHaveBeenCalled()
+    expect(screen.getByText('3 piezas')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -1,14 +1,39 @@
+import { useState } from 'react'
+
 import { LOCATION_LABELS, expiryPhrase, quantityLabel } from '@/labels'
+import { canStepDown } from '@/quantity'
+import { toErrorMessage } from '@/services/api'
+import { adjustProductQuantity } from '@/services/productsService'
 import type { Product } from '@/services/types'
 
 interface ProductCardProps {
   product: Product
   onEdit: (product: Product) => void
   onDelete: (product: Product) => void
+  /** Called with the server's own response after a successful +/- tap, so the
+   *  list can update that one row without a full reload. */
+  onQuantityChanged: (updated: Product) => void
 }
 
 /** One product row: what it is, how much, where, and how urgent. */
-export function ProductCard({ product, onEdit, onDelete }: ProductCardProps) {
+export function ProductCard({ product, onEdit, onDelete, onQuantityChanged }: ProductCardProps) {
+  const [adjusting, setAdjusting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const adjust = (delta: 1 | -1) => {
+    setAdjusting(true)
+    setError(null)
+    void (async () => {
+      try {
+        onQuantityChanged(await adjustProductQuantity(product.id, delta))
+      } catch (caught) {
+        setError(toErrorMessage(caught))
+      } finally {
+        setAdjusting(false)
+      }
+    })()
+  }
+
   return (
     <li className={`product-card product-card--${product.status}`}>
       <div className="product-card__main">
@@ -16,10 +41,35 @@ export function ProductCard({ product, onEdit, onDelete }: ProductCardProps) {
         <p className="product-card__meta">
           {product.category ? <span>{product.category.name}</span> : <span className="product-card__uncategorised">Sin categoría</span>}
           <span aria-hidden="true">·</span>
-          <span>{quantityLabel(product.quantity, product.unit)}</span>
+          <span className="quantity-stepper">
+            <button
+              type="button"
+              className="quantity-stepper__button"
+              onClick={() => adjust(-1)}
+              disabled={adjusting || !canStepDown(product.quantity)}
+              aria-label={`Reducir cantidad de ${product.name}`}
+            >
+              −
+            </button>
+            <span className="quantity-stepper__value">{quantityLabel(product.quantity, product.unit)}</span>
+            <button
+              type="button"
+              className="quantity-stepper__button"
+              onClick={() => adjust(1)}
+              disabled={adjusting}
+              aria-label={`Aumentar cantidad de ${product.name}`}
+            >
+              +
+            </button>
+          </span>
           <span aria-hidden="true">·</span>
           <span>{LOCATION_LABELS[product.location]}</span>
         </p>
+        {error && (
+          <p className="product-card__quantity-error" role="alert">
+            {error}
+          </p>
+        )}
         {product.notes && <p className="product-card__notes">{product.notes}</p>}
       </div>
 

--- a/frontend/src/components/ProductForm.tsx
+++ b/frontend/src/components/ProductForm.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, type FormEvent } from 'react'
 
 import { Modal } from '@/components/Modal'
 import { LOCATION_LABELS } from '@/labels'
+import { canStepDown, stepQuantity } from '@/quantity'
 import { toErrorMessage } from '@/services/api'
 import { createProduct, replaceProduct } from '@/services/productsService'
 import type { Category, Location, Product, ProductPayload } from '@/services/types'
@@ -150,17 +151,42 @@ export function ProductForm({ product, categories, onSaved, onCancel }: ProductF
         </label>
 
         <div className="form__row">
-          <label className="form__field">
-            <span>Cantidad</span>
-            <input
-              type="number"
-              value={form.quantity}
-              onChange={(event) => update('quantity', event.target.value)}
-              min="0.01"
-              step="0.01"
-              required
-            />
-          </label>
+          {/* A plain wrapping <label> would implicitly associate its text with
+              every control inside it — both buttons as well as the input —
+              which makes getByLabelText('Cantidad') ambiguous. An explicit
+              htmlFor targets the input alone. */}
+          <div className="form__field">
+            <label htmlFor="product-quantity">Cantidad</label>
+            <span className="quantity-stepper">
+              <button
+                type="button"
+                className="quantity-stepper__button"
+                onClick={() => update('quantity', stepQuantity(form.quantity, -1))}
+                disabled={!canStepDown(form.quantity)}
+                aria-label="Reducir cantidad"
+              >
+                −
+              </button>
+              <input
+                id="product-quantity"
+                type="number"
+                className="quantity-stepper__input"
+                value={form.quantity}
+                onChange={(event) => update('quantity', event.target.value)}
+                min="0.01"
+                step="0.01"
+                required
+              />
+              <button
+                type="button"
+                className="quantity-stepper__button"
+                onClick={() => update('quantity', stepQuantity(form.quantity, 1))}
+                aria-label="Aumentar cantidad"
+              >
+                +
+              </button>
+            </span>
+          </div>
 
           <label className="form__field">
             <span>Unidad</span>

--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -11,6 +11,16 @@ interface UseProductsResult {
   /** Set when the list came from the offline cache rather than the network. */
   cachedAt: Date | null
   reload: () => void
+  /**
+   * Splice one already-saved product back into the list from its own server
+   * response, in place of a full reload.
+   *
+   * Built for the quantity stepper: a full `reload()` after every +/- tap
+   * would refetch the whole list — and briefly show a stale sort order, since
+   * a product's position depends on `expires_at`, not quantity — for a change
+   * that only ever touches one row and one field.
+   */
+  replaceProduct: (updated: Product) => void
 }
 
 /**
@@ -87,5 +97,10 @@ export function useProducts(filters: ProductFilters = {}): UseProductsResult {
     }
   }, [])
 
-  return { products, loading, error, cachedAt, reload }
+  // An event handler, not an effect — same reasoning as reload above.
+  const replaceProduct = useCallback((updated: Product) => {
+    setProducts((current) => current.map((product) => (product.id === updated.id ? updated : product)))
+  }, [])
+
+  return { products, loading, error, cachedAt, reload, replaceProduct }
 }

--- a/frontend/src/pages/ProductList.test.tsx
+++ b/frontend/src/pages/ProductList.test.tsx
@@ -9,6 +9,7 @@ vi.mock('@/services/productsService', () => ({
   createProduct: vi.fn(),
   replaceProduct: vi.fn(),
   deleteProduct: vi.fn(),
+  adjustProductQuantity: vi.fn(),
 }))
 
 vi.mock('@/services/categoriesService', () => ({

--- a/frontend/src/pages/ProductList.tsx
+++ b/frontend/src/pages/ProductList.tsx
@@ -30,7 +30,7 @@ type Dialog =
 
 /** Main screen: everything in the house, soonest to expire first. */
 export function ProductList() {
-  const { products, loading, error, cachedAt, reload } = useProducts()
+  const { products, loading, error, cachedAt, reload, replaceProduct } = useProducts()
   const categories = useCategories()
   const [dialog, setDialog] = useState<Dialog>({ kind: 'none' })
   const [deleting, setDeleting] = useState(false)
@@ -137,6 +137,7 @@ export function ProductList() {
                   product={product}
                   onEdit={(target) => setDialog({ kind: 'edit', product: target })}
                   onDelete={(target) => setDialog({ kind: 'delete', product: target })}
+                  onQuantityChanged={replaceProduct}
                 />
               ))}
             </ul>

--- a/frontend/src/quantity.test.ts
+++ b/frontend/src/quantity.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { canStepDown, stepQuantity } from '@/quantity'
+
+describe('stepQuantity', () => {
+  it('increments a whole number', () => {
+    expect(stepQuantity('2', 1)).toBe('3')
+  })
+
+  it('decrements a whole number', () => {
+    expect(stepQuantity('5', -1)).toBe('4')
+  })
+
+  it('keeps the fractional part exact rather than rounding it away', () => {
+    // NUMERIC(10, 2) is the API's real precision boundary — not "no decimals"
+    // — so a purchase already carrying cents must keep them after a step.
+    expect(stepQuantity('0.59', 1)).toBe('1.59')
+  })
+
+  it('does not accumulate floating-point noise across repeated steps', () => {
+    let value = '0.10'
+    for (let i = 0; i < 5; i += 1) value = stepQuantity(value, 1)
+    // Plain float addition (0.1 + 1 + 1 + 1 + 1 + 1) drifts to
+    // "5.099999999999999" in JS; cents arithmetic must not.
+    expect(value).toBe('5.1')
+  })
+
+  it('trims a trailing .00 the same way the rest of the app displays a quantity', () => {
+    expect(stepQuantity('2.00', 1)).toBe('3')
+  })
+
+  it('trims a trailing zero but keeps a meaningful decimal', () => {
+    expect(stepQuantity('1.50', 1)).toBe('2.5')
+  })
+
+  it('refuses to go to zero or below, returning the input unchanged', () => {
+    expect(stepQuantity('1', -1)).toBe('1')
+  })
+
+  it('refuses to cross zero for a fractional quantity smaller than one unit', () => {
+    expect(stepQuantity('0.50', -1)).toBe('0.50')
+  })
+
+  it('passes non-numeric input through unchanged rather than producing NaN', () => {
+    expect(stepQuantity('', 1)).toBe('')
+    expect(stepQuantity('abc', -1)).toBe('abc')
+  })
+})
+
+describe('canStepDown', () => {
+  it('is false at exactly 1, the floor the "−" button must stop at', () => {
+    expect(canStepDown('1')).toBe(false)
+    expect(canStepDown('1.00')).toBe(false)
+  })
+
+  it('is false below 1, where a step down would already cross zero', () => {
+    expect(canStepDown('0.59')).toBe(false)
+  })
+
+  it('is true above 1, including a value that is not itself a whole number', () => {
+    expect(canStepDown('1.50')).toBe(true)
+    expect(canStepDown('5')).toBe(true)
+  })
+})

--- a/frontend/src/quantity.ts
+++ b/frontend/src/quantity.ts
@@ -1,0 +1,51 @@
+/**
+ * Stepping a quantity by whole units, without floating-point drift and
+ * without rounding away precision the product already carries.
+ *
+ * `quantity` mirrors the API's `NUMERIC(10, 2)` column: at most two decimal
+ * places, never zero or negative (`CheckConstraint("quantity > 0")`). Cents
+ * arithmetic — scale to an integer, add, scale back — sidesteps the case
+ * where plain float math would turn "0.59 + 1" into "1.5900000000000001".
+ */
+
+const CENTS_PER_UNIT = 100
+
+function toCents(quantity: string): number | null {
+  // Number('') is 0, not NaN — without this an empty field would step to "1"
+  // instead of being left alone for the required-field validation to catch.
+  if (quantity.trim() === '') return null
+  const value = Number(quantity)
+  return Number.isFinite(value) ? Math.round(value * CENTS_PER_UNIT) : null
+}
+
+function fromCents(cents: number): string {
+  const fixed = (cents / CENTS_PER_UNIT).toFixed(2)
+  // Trim trailing zeros the same way the rest of the app displays a quantity
+  // (see quantityLabel in labels.ts): "3.00" -> "3", "1.50" -> "1.5".
+  return fixed.includes('.') ? fixed.replace(/0+$/, '').replace(/\.$/, '') : fixed
+}
+
+/**
+ * True when decrementing by one whole unit would still leave a positive
+ * quantity. Used to disable "−" rather than let it produce a value the API
+ * would reject — see #82: the button simply stops at 1, it does not offer a
+ * path to zero.
+ */
+export function canStepDown(quantity: string): boolean {
+  const cents = toCents(quantity)
+  return cents !== null && cents > CENTS_PER_UNIT
+}
+
+/**
+ * Add or subtract one whole unit. Returns `current` unchanged if the result
+ * would not be a positive number — callers that also disable the button
+ * (the card) get a no-op backstop; the form's stepper, which has no delta
+ * endpoint to reject an invalid value, relies on exactly this guard.
+ */
+export function stepQuantity(current: string, delta: 1 | -1): string {
+  const cents = toCents(current)
+  if (cents === null) return current
+
+  const next = cents + delta * CENTS_PER_UNIT
+  return next > 0 ? fromCents(next) : current
+}

--- a/frontend/src/services/productsService.ts
+++ b/frontend/src/services/productsService.ts
@@ -58,3 +58,17 @@ export async function replaceProduct(id: number, payload: ProductPayload): Promi
 export async function deleteProduct(id: number): Promise<void> {
   await api.delete(`/products/${id}`)
 }
+
+/**
+ * Adjust a product's quantity by a relative amount — never an absolute value,
+ * so two taps racing on a slow connection compose correctly regardless of
+ * arrival order. See the backend's ProductQuantityDelta and #82.
+ *
+ * Retried on the same terms as createProduct/replaceProduct: a stepper button
+ * is tapped from a phone near the fridge, exactly the situation #81 was
+ * written for, so a dropped-connection tap deserves the same second chance.
+ */
+export async function adjustProductQuantity(id: number, delta: number): Promise<Product> {
+  const { data } = await withRetry(() => api.patch<Product>(`/products/${id}/quantity`, { delta }))
+  return data
+}


### PR DESCRIPTION
Closes #82.

## What changed

`+`/`−` buttons on the product card and beside the quantity field in the form. From the card, a tap goes straight to the API; in the form it only touches local state until Guardar.

## The endpoint is a delta, and that's what makes the composition guarantee real

`PATCH /products/{id}/quantity`, body `{"delta": "-1"}`. Not an absolute value — two taps racing on a slow connection would otherwise both send "quantity = 3" and one would silently vanish.

Making that true under actual concurrent requests, not just as a design intention, is the SQL:

```python
update(Product)
    .where(Product.id == product_id, Product.quantity + payload.delta > 0)
    .values(quantity=Product.quantity + payload.delta)
```

`quantity = quantity + delta` is evaluated by Postgres against the row's live value at the moment of the UPDATE, under its row lock — not a value this function read earlier and is writing back. Two overlapping requests serialize on that lock, and each is applied to whatever the other left behind. The positivity check rides in the same statement, and a `rowcount == 0` becomes a 422 with a clear message — the acceptance criterion asked for this rather than letting the database's `CheckConstraint` produce a bare 500.

## The "−" button, per the decision already in the issue

Disables at quantity 1 rather than overloading the last decrement with "this product is gone" — marking something consumed is a separate, deliberate action reserved for #31.

It also disables **both** buttons for the duration of an in-flight request, so a fast double-tap on one card can't fire a second overlapping request from the same button. Verified live: two rapid clicks on "−" produced exactly one PATCH, because the second landed on an already-disabled element — not a bug, the designed guard working.

## Precision: two decimal places is the real boundary, not zero

`quantity` is `NUMERIC(10, 2)`. Both sides step in exact cents (scale to an integer, add, scale back) rather than floating point, so a value already carrying cents keeps them — `0.59 + 1 = 1.59`, not rounded to `2` and not `1.5900000000000001` either. Worth flagging: the issue's own example used `0.586 kg`, which the schema's `decimal_places=2` actually rejects with a 422 today — confirmed by testing it directly. Not something this PR changes; just noting the issue's illustrative number isn't reachable in the current app, so the real boundary this PR respects is 2 places, not 3.

## The concurrency test had to be rewritten once it was checked against a reverted implementation

Testing note, since it's the kind of thing worth being upfront about: the first version of `test_concurrent_decrements_do_not_lose_an_update` wrote its own raw `UPDATE products SET quantity = quantity + :delta ...` inside the thread target, instead of calling the actual endpoint function. It passed even when `adjust_quantity` was reverted to a read-then-write implementation — because it was proving a fact about Postgres in the abstract, not about this code.

Rewritten to call `adjust_quantity` directly with independent `SessionLocal()` instances, one per thread, racing 20 rounds of two concurrent `-1`s each (40 decrements total) so a genuine lost update reliably shows up in the final total instead of depending on whether a single race happened to overlap. Confirmed against the reintroduced bug across three separate runs — same result every time: `80.00` instead of the expected `60.00`, exactly half of every round's decrements lost.

## Verified

**Backend:** 124 tests pass, including the composition test (`5, -1, -1 → 3`), the real-concurrency test, a fractional-quantity step (`0.59 → 1.59`), rejection at the zero boundary without a 500, and the new 404 case. `ruff check` clean.

**Frontend:** 152 tests pass (`npm run lint && npm run build && npm test`, in that order — the sequence #86 got bitten by skipping). New coverage: `quantity.ts`'s cent-based stepping (including a repeated-step float-drift check), and `ProductCard`'s stepper — sends the right delta, disables `−` at 1, keeps `+` enabled there, disables both mid-request, and shows a failure inline without touching the displayed quantity.

**Browser, against a real running API:**
- The card's stepper updates that one row in place — no `GET /products` follows the `PATCH`, confirming `replaceProduct` avoids the full-list reload `useProducts` previously required for any change.
- Two rapid clicks on "−" → one `PATCH`, `3.00 → 2.00`.
- The form's stepper: five clicks on "−" from 4 stop exactly at **1**, no network call, matching the disabled-at-1 rule.

One incidental fix along the way: the form's quantity field was wrapped in a plain `<label>`, which implicitly associated its text with every control inside — both new buttons as well as the input — making `getByLabelText('Cantidad')` ambiguous and breaking two existing tests. Switched to an explicit `htmlFor`/`id` pair, which targets the input alone.

## Also flagged, not fixed here

While setting up a local test database I hit `backend/app/db/bootstrap.py` retrying for the full 5-minute budget against a wrong database role, logging a misleading "server unreachable" the whole time when the real problem was credentials. Out of scope for this PR, but directly relevant to #56 (least-privilege DB role) — flagged separately so it doesn't get lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)