### PR TITLE
fix: don't retry a database auth failure as if the server were down

### DIFF
--- a/backend/app/db/bootstrap.py
+++ b/backend/app/db/bootstrap.py
@@ -11,6 +11,7 @@ role viable, since the common path needs no rights beyond the app's own.
 """
 
 import logging
+import re
 import sys
 import time
 from collections.abc import Iterator
@@ -65,6 +66,41 @@ class DatabaseUnreachableError(RuntimeError):
         self.last_error = last_error
 
 
+class DatabaseAuthenticationError(RuntimeError):
+    """The server answered but rejected our credentials.
+
+    Raised immediately instead of joining the retry loop: waiting cannot turn a
+    wrong DB_USER or DB_PASSWORD into a right one, and retrying it for the full
+    connect budget would misreport a credentials problem as the server being
+    down.
+    """
+
+    def __init__(self, cause: OperationalError) -> None:
+        super().__init__(f"Database rejected our credentials, check DB_USER/DB_PASSWORD: {cause}")
+
+
+# psycopg does not attach a SQLSTATE to failures raised during connection setup
+# (auth happens before the wire protocol can hand back a typed exception) — the
+# server's message text is the only signal available. Verified against a live
+# Postgres 16: an unknown role or wrong password produces "password
+# authentication failed for user ..." under the default scram/md5 auth, or
+# "role ... does not exist" under trust/peer auth; a missing database produces
+# "database ... does not exist". The two must not be confused: the first is
+# never worth retrying, the second always is.
+_DATABASE_MISSING_RE = re.compile(r'database "[^"]*" does not exist')
+_AUTH_FAILURE_RE = re.compile(r'password authentication failed|role "[^"]*" does not exist')
+
+
+def _is_missing_database(exc: OperationalError) -> bool:
+    """True when the server answered but the configured database isn't there."""
+    return bool(_DATABASE_MISSING_RE.search(str(exc)))
+
+
+def _is_authentication_failure(exc: OperationalError) -> bool:
+    """True when the server rejected our credentials rather than being down."""
+    return bool(_AUTH_FAILURE_RE.search(str(exc)))
+
+
 def _database_exists() -> bool:
     """True when the configured database can be connected to."""
     engine = create_engine(
@@ -76,10 +112,10 @@ def _database_exists() -> bool:
             connection.execute(text("SELECT 1"))
         return True
     except OperationalError as exc:
-        # psycopg maps SQLSTATE 3D000 (invalid_catalog_name) to this; anything
-        # else is a genuine connection problem the caller should see.
-        if "3D000" in str(exc) or "does not exist" in str(exc):
+        if _is_missing_database(exc):
             return False
+        if _is_authentication_failure(exc):
+            raise DatabaseAuthenticationError(exc) from exc
         raise
     finally:
         engine.dispose()
@@ -186,6 +222,11 @@ def main() -> None:
             exc.elapsed,
             exc.last_error.__class__.__name__,
         )
+        sys.exit(1)
+    except DatabaseAuthenticationError as exc:
+        # Fails on the first attempt, not after the budget: the server was
+        # reachable the whole time, so this must not be read as it being down.
+        logger.error("%s", exc)
         sys.exit(1)
     except OperationalError as exc:
         # Only reachable from the CREATE DATABASE path, which runs after the

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -7,7 +7,12 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.exc import OperationalError
 
 from app.config import settings
-from app.db.bootstrap import DatabaseUnreachableError, _maintenance_url, ensure_database_exists
+from app.db.bootstrap import (
+    DatabaseAuthenticationError,
+    DatabaseUnreachableError,
+    _maintenance_url,
+    ensure_database_exists,
+)
 
 THROWAWAY = "cadutrack_bootstrap_pytest"
 
@@ -34,6 +39,62 @@ class FakeClock:
 
 def _down() -> bool:
     raise OperationalError("connection failed", None, Exception())
+
+
+def _operational_error(message: str) -> OperationalError:
+    """Build an OperationalError carrying the given server-reported message.
+
+    Message text is the only signal available to classify these: psycopg
+    does not attach a SQLSTATE to failures raised during connection setup,
+    where auth happens before the wire protocol can hand back a typed
+    exception. These strings were captured against a live Postgres 16.
+    """
+    return OperationalError("connection failed", None, Exception(message))
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        'FATAL:  database "cadutrack" does not exist',
+        'FATAL:  database "cadutrack_bootstrap_pytest" does not exist',
+    ],
+)
+def test_a_missing_database_is_classified_as_missing_not_an_auth_failure(message):
+    import app.db.bootstrap as bootstrap
+
+    exc = _operational_error(message)
+    assert bootstrap._is_missing_database(exc) is True
+    assert bootstrap._is_authentication_failure(exc) is False
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        # The default scram/md5 auth path: Postgres deliberately gives this
+        # same message for a wrong password and for a role that doesn't
+        # exist, to avoid revealing which one it was.
+        'FATAL:  password authentication failed for user "cadutrack"',
+        # The trust/peer auth path: a role check happens up front, so the
+        # message names the role directly — and it contains "does not
+        # exist", which is exactly what the old substring check confused
+        # with a missing database.
+        'FATAL:  role "cadutrack" does not exist',
+    ],
+)
+def test_a_credentials_failure_is_classified_as_auth_not_a_missing_database(message):
+    import app.db.bootstrap as bootstrap
+
+    exc = _operational_error(message)
+    assert bootstrap._is_authentication_failure(exc) is True
+    assert bootstrap._is_missing_database(exc) is False
+
+
+def test_a_generic_connection_failure_is_classified_as_neither(monkeypatch):
+    import app.db.bootstrap as bootstrap
+
+    exc = _operational_error("connection refused")
+    assert bootstrap._is_missing_database(exc) is False
+    assert bootstrap._is_authentication_failure(exc) is False
 
 
 def test_maintenance_url_keeps_the_credentials_and_swaps_the_database():
@@ -114,6 +175,28 @@ def test_a_transient_outage_produces_warnings_and_no_error(monkeypatch, caplog):
     assert levels == ["WARNING", "WARNING"]
     assert "attempt 1" in caplog.records[0].getMessage()
     assert "retrying in 1s" in caplog.records[0].getMessage()
+
+
+def test_an_authentication_failure_is_not_retried(monkeypatch):
+    """Bad credentials will never fix themselves, so don't spend the budget.
+
+    Mirrors test_the_budget_is_spent_in_full_and_never_overrun, which proves a
+    transient failure DOES retry for the full 300s — this proves a credentials
+    failure does NOT: it must fail on the very first attempt, with no sleep.
+    """
+    import app.db.bootstrap as bootstrap
+
+    def bad_credentials() -> bool:
+        raise bootstrap.DatabaseAuthenticationError(_operational_error("irrelevant"))
+
+    clock = FakeClock()
+    monkeypatch.setattr(bootstrap, "_database_exists", bad_credentials)
+    monkeypatch.setattr(bootstrap, "time", clock)
+
+    with pytest.raises(DatabaseAuthenticationError):
+        bootstrap._database_exists_once_reachable()
+
+    assert clock.slept == []
 
 
 def test_the_delays_grow_and_then_hold_at_the_cap(monkeypatch):
@@ -213,3 +296,31 @@ def test_main_exits_non_zero_when_the_budget_is_exhausted(monkeypatch):
         bootstrap.main()
 
     assert excinfo.value.code == 1
+
+
+def test_main_reports_bad_credentials_instead_of_a_server_that_never_came_up(monkeypatch, caplog):
+    """The wrong error message here sends troubleshooting at the wrong system.
+
+    A misclassified auth failure used to burn the full 300s and then log
+    "server unreachable" — pointing at Postgres/network when the fix was
+    always in the .env. This must fail on the first attempt, with no WARNING
+    retries, and say to check the credentials.
+    """
+    import app.db.bootstrap as bootstrap
+
+    def bad_credentials() -> bool:
+        raise bootstrap.DatabaseAuthenticationError(
+            _operational_error('FATAL:  password authentication failed for user "cadutrack"')
+        )
+
+    monkeypatch.setattr(bootstrap, "_database_exists", bad_credentials)
+    monkeypatch.setattr(bootstrap, "time", FakeClock())
+    monkeypatch.setattr(bootstrap, "setup_logging", lambda **kwargs: None)
+
+    with caplog.at_level(logging.DEBUG, logger="app.db.bootstrap"):
+        with pytest.raises(SystemExit) as excinfo:
+            bootstrap.main()
+
+    assert excinfo.value.code == 1
+    assert [record.levelname for record in caplog.records] == ["ERROR"]
+    assert "DB_USER/DB_PASSWORD" in caplog.records[0].getMessage()


### PR DESCRIPTION
## Summary
- `_database_exists()` classified the "database missing" case with a bare `"does not exist" in str(exc)` check, which also matches Postgres's `role "x" does not exist` message for an unknown role under trust/peer auth — bad credentials got silently treated as a missing database.
- A wrong password (or unknown role under the default scram/md5 auth) produces `password authentication failed for user "x"`, matching neither existing branch, so it fell through and was retried identically to a transient outage for the full 300s connect budget — then logged a misleading "server unreachable" ERROR even though the server was up the whole time.
- Verified against a live Postgres 16 (psycopg3 attaches no SQLSTATE to connection-phase failures, so message text is the only reliable signal) that both failure shapes now get classified as `DatabaseAuthenticationError` and fail immediately, with a log message pointing at `DB_USER`/`DB_PASSWORD` instead of the server.
- No behavior change for the two paths that already worked: a transient outage still retries with WARNINGs for up to 300s, and a genuinely missing database still gets created.

This matters now because #56 (deferred) proposes moving to a least-privilege DB role — the moment that role or its password is misconfigured, this bug would burn 5 minutes on every container restart while pointing troubleshooting at Postgres/network instead of the `.env`.

## Test plan
- [x] `pytest tests/test_bootstrap.py -m "not integration"` — 15/15 pass, including new tests for message classification, no-retry-on-auth-failure, and the `main()` exit path
- [x] `pytest tests/test_bootstrap.py -m integration` against a real Postgres — existing create/no-op tests still pass
- [x] End-to-end against a real Postgres with a wrong role: fails in ~0.4s (was ~300s) with `Database rejected our credentials, check DB_USER/DB_PASSWORD: ... role "wrong_role_name" does not exist`
- [x] `ruff check` clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)