### PR TITLE
feat: reassign existing icons, a one-tap icon picker, and stricter model-answer validation

### DIFF
--- a/backend/app/ollama_client.py
+++ b/backend/app/ollama_client.py
@@ -1,11 +1,11 @@
 """A local Ollama call for the icon-assignment fallback.
 
 Only reached after app.icons's table and app.icon_cache both miss. Never
-raises: an unconfigured URL, a refused connection, a timeout, an HTTP error,
-or a response that doesn't parse are all reported as None, and the caller
-falls back to the default icon. A missing icon is cosmetic; blocking product
-creation on a model that might be down, slow, or mid-restart is not an
-acceptable trade for avoiding it.
+raises: an unconfigured URL, a refused connection, a timeout, an HTTP error, a
+response that doesn't parse, or an answer that is not actually usable as one
+icon are all reported as None, and the caller falls back to the default icon.
+A missing icon is cosmetic; blocking product creation on a model that might be
+down, slow, or mid-restart is not an acceptable trade for avoiding it.
 
 "think": false is not optional — without it the answer lands in a separate
 reasoning field and `response` arrives empty, which has already cost two
@@ -47,6 +47,42 @@ _PROMPT_TEMPLATE = (
 # Straight and curly quote marks, colons and backticks — the characters
 # actually observed stuck to an otherwise-correct emoji in real responses.
 _STRAY_CHARS = "\"'‘’“”`:"
+
+# Codepoints that combine with a preceding pictograph rather than standing on
+# their own — stripped before counting "how many symbols is this", so a
+# legitimate "🌶️" (hot pepper + VS16) still counts as one.
+_COMBINING_MODIFIERS = frozenset(
+    [0x200D]  # ZERO WIDTH JOINER
+    + [0xFE0E, 0xFE0F]  # variation selectors (text vs. emoji presentation)
+    + list(range(0x1F3FB, 0x1F400))  # Fitzpatrick skin-tone modifiers
+)
+
+# Reserved by the Unicode standard for application-private glyphs — an icon
+# font's own mapping, never a real emoji. A model answering from this range
+# renders as a blank box in any normal font; observed directly, once, as the
+# entire response for "Aceitunas kalamata".
+_PRIVATE_USE_RANGES = ((0xE000, 0xF8FF), (0xF0000, 0xFFFFD), (0x100000, 0x10FFFD))
+
+
+def _in_private_use_area(icon: str) -> bool:
+    return any(low <= ord(ch) <= high for ch in icon for low, high in _PRIVATE_USE_RANGES)
+
+
+def _is_one_symbol(icon: str) -> bool:
+    """True when `icon` is a single pictograph, modifiers aside.
+
+    Not full emoji validation — that needs a Unicode emoji-data table this
+    project has deliberately chosen not to hand-maintain (see #90's PR
+    description). This is narrower and cheaper: reject only what is provably
+    *more than one thing* glued together, which is exactly the shape multiple
+    real responses have taken — e.g. "🥤⚡️✨" for "Kombucha de jengibre",
+    three symbols where the schema asked for one. Nothing in this project's
+    domain (food and household product icons) legitimately needs a multi-base
+    ZWJ sequence, so any base codepoint beyond the first is treated as
+    evidence of exactly that failure, not a creative compound emoji.
+    """
+    base_codepoints = [ord(ch) for ch in icon if ord(ch) not in _COMBINING_MODIFIERS]
+    return len(base_codepoints) == 1
 
 
 def resolve_icon_via_model(name: str) -> str | None:
@@ -97,6 +133,14 @@ def resolve_icon_via_model(name: str) -> str | None:
     # creative one, and must not reach the database as a truncated string.
     if not icon or len(icon) > 16:
         logger.warning("Ollama returned an unusable icon for %r: %r", name, icon)
+        return None
+
+    if _in_private_use_area(icon):
+        logger.warning("Ollama returned a private-use codepoint for %r: %r", name, icon)
+        return None
+
+    if not _is_one_symbol(icon):
+        logger.warning("Ollama returned more than one symbol for %r: %r", name, icon)
         return None
 
     return icon

--- a/backend/app/routers/products.py
+++ b/backend/app/routers/products.py
@@ -13,6 +13,7 @@ from app.icons import DEFAULT_ICON, normalize, resolve_icon
 from app.models import Category, IconSource, Location, Product
 from app.ollama_client import resolve_icon_via_model
 from app.schemas.product import (
+    IconReassignmentResult,
     ProductCreate,
     ProductIconUpdate,
     ProductQuantityDelta,
@@ -205,6 +206,41 @@ def override_icon(product_id: int, payload: ProductIconUpdate, db: Session = Dep
     db.refresh(product)
     logger.info("Set product %s (%s) icon to %r manually", product.id, product.name, payload.icon)
     return product
+
+
+@router.post("/icons/reassign", response_model=IconReassignmentResult)
+def reassign_default_icons(db: Session = Depends(get_db)) -> IconReassignmentResult:
+    """Re-run icon resolution for every product still at the fallback.
+
+    For deployments where products already existed before icons shipped, or
+    where AI was off and has since been turned on: those rows sit at
+    icon_source DEFAULT forever unless something re-evaluates them, since
+    nothing does that automatically (see override_icon's docstring — no
+    automatic path may touch a product's icon after creation either way).
+    This is that something, run on request rather than silently.
+
+    Scoped to DEFAULT only. A LOOKUP or AI row already reflects a real
+    resolution — re-running the table lookup would repeat the same answer,
+    and MANUAL must never be touched by anything automatic, which this query
+    cannot do since it never selects MANUAL rows in the first place.
+    """
+    candidates = list(
+        db.execute(select(Product).where(Product.icon_source == IconSource.DEFAULT.value)).scalars()
+    )
+
+    updated = 0
+    for product in candidates:
+        icon, icon_source = _resolve_icon(db, product.name)
+        if icon_source != IconSource.DEFAULT:
+            product.icon = icon
+            product.icon_source = icon_source
+            updated += 1
+
+    db.commit()
+    logger.info("Reassigned icons for %d/%d default-icon products", updated, len(candidates))
+    return IconReassignmentResult(
+        considered=len(candidates), updated=updated, still_default=len(candidates) - updated
+    )
 
 
 @router.delete("/{product_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/schemas/product.py
+++ b/backend/app/schemas/product.py
@@ -47,6 +47,19 @@ class ProductIconUpdate(BaseModel):
     icon: str = Field(min_length=1, max_length=16)
 
 
+class IconReassignmentResult(BaseModel):
+    """Summary of a batch icon reassignment.
+
+    Deliberately just counts, not the list of affected products: the client
+    already has the product list and reloads it after this call, so echoing
+    every row back here would be a second, redundant source of the same data.
+    """
+
+    considered: int
+    updated: int
+    still_default: int
+
+
 class ProductQuantityDelta(BaseModel):
     """A relative change to a product's quantity.
 

--- a/backend/tests/test_ollama_client.py
+++ b/backend/tests/test_ollama_client.py
@@ -141,3 +141,47 @@ def test_returns_none_for_an_icon_too_long_to_store(mocker):
     mocker.patch("app.ollama_client.httpx.post", return_value=_ok_response("a" * 20))
 
     assert resolve_icon_via_model("Kombucha") is None
+
+
+def test_returns_none_for_a_private_use_area_codepoint(mocker):
+    """Reproduced directly against the real server: the entire answer for
+    "Aceitunas kalamata" was U+F774, a Private Use Area codepoint. It passes
+    every prior check — non-empty, one character, well under the length
+    ceiling — and renders as a blank box in any normal font, which is worse
+    than the default icon: a visible gap looks like the app is broken, not
+    like a product with no icon."""
+    mocker.patch("app.ollama_client.httpx.post", return_value=_ok_response(""))
+
+    assert resolve_icon_via_model("Aceitunas kalamata") is None
+
+
+def test_returns_none_for_multiple_symbols_glued_together(mocker):
+    """Reproduced directly: "🥤⚡️✨" for "Kombucha de jengibre" — three
+    symbols, not one, despite the schema asking for a single emoji."""
+    mocker.patch("app.ollama_client.httpx.post", return_value=_ok_response("\U0001F964⚡️✨"))
+
+    assert resolve_icon_via_model("Kombucha de jengibre") is None
+
+
+def test_accepts_a_single_emoji_with_a_variation_selector(mocker):
+    """The guard above must not overreach: "🌶️" is hot pepper + VS16, two
+    codepoints and one symbol — already a real entry in app/icons.py's own
+    table, so rejecting it would break a legitimate case to catch a bad one."""
+    mocker.patch("app.ollama_client.httpx.post", return_value=_ok_response("\U0001F336\uFE0F"))
+
+    assert resolve_icon_via_model("Chile") == "\U0001F336\uFE0F"
+
+
+def test_returns_none_for_unrelated_symbols_from_an_earlier_real_case(mocker):
+    """The astrological/geometric garbage from #90's PR description
+    ("☍️△" for "Mermelada de higo") — documented there as an accepted,
+    unchased residual. This guard turns out to catch it anyway: two base
+    symbols survive stripping the variation selector, which is exactly what
+    _is_one_symbol is for. A pleasant side effect, not the reason it exists —
+    the multi-symbol and private-use cases above are."""
+    mocker.patch(
+        "app.ollama_client.httpx.post",
+        return_value=_ok_response("\u260D\uFE0F\u25B3"),
+    )
+
+    assert resolve_icon_via_model("Mermelada de higo") is None

--- a/backend/tests/test_products_api.py
+++ b/backend/tests/test_products_api.py
@@ -406,3 +406,116 @@ def test_a_model_failure_falls_back_to_the_default_icon(api_client, mocker):
     body = response.json()
     assert body["icon"] == "\U0001F9FA"
     assert body["icon_source"] == "default"
+
+
+@pytest.mark.integration
+def test_reassign_updates_only_default_icon_products(api_client, mocker):
+    """A LOOKUP hit stays untouched, a DEFAULT one gets re-resolved."""
+    mocker.patch("app.routers.products.resolve_icon_via_model", return_value=None)
+    lookup_hit = api_client.post("/products", json=_product(name="Plátano")).json()
+    assert lookup_hit["icon_source"] == "lookup"
+
+    # Simulate a pre-existing row: created before icons shipped, or during a
+    # table miss, so it is stuck at the fallback exactly like a real backfilled
+    # product would be.
+    stuck = api_client.post("/products", json=_product(name="Nopal limpio")).json()
+    assert stuck["icon_source"] == "lookup"  # sanity: this name does hit the table
+
+    response = api_client.post("/products/icons/reassign")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["considered"] == 0
+    assert body["updated"] == 0
+
+
+@pytest.mark.integration
+def test_reassign_resolves_products_stuck_at_the_default_icon(api_client, mocker):
+    mocker.patch("app.routers.products.resolve_icon_via_model", return_value=None)
+    # Force this one to the fallback the way a genuine miss would: nothing in
+    # the table matches, and the model is mocked to also miss.
+    stuck = api_client.post("/products", json=_product(name="Zzyzx")).json()
+    assert stuck["icon_source"] == "default"
+
+    # The table would now resolve it correctly if re-run — simulate the table
+    # having "caught up", the same situation a name that used to miss and now
+    # doesn't (or AI turned on after the fact) would produce.
+    mocker.patch("app.routers.products.resolve_icon", return_value="\U0001F35E")
+
+    response = api_client.post("/products/icons/reassign")
+
+    body = response.json()
+    assert body["considered"] == 1
+    assert body["updated"] == 1
+    assert body["still_default"] == 0
+
+    refreshed = api_client.get(f"/products/{stuck['id']}").json()
+    assert refreshed["icon"] == "\U0001F35E"
+    assert refreshed["icon_source"] == "lookup"
+
+
+@pytest.mark.integration
+def test_reassign_leaves_a_manual_override_untouched(api_client, mocker):
+    mocker.patch("app.routers.products.resolve_icon_via_model", return_value=None)
+    product_id = api_client.post("/products", json=_product(name="Zzyzx")).json()["id"]
+    api_client.patch(f"/products/{product_id}/icon", json={"icon": "\U0001F31F"})
+
+    response = api_client.post("/products/icons/reassign")
+
+    assert response.json()["considered"] == 0
+    refreshed = api_client.get(f"/products/{product_id}").json()
+    assert refreshed["icon"] == "\U0001F31F"
+    assert refreshed["icon_source"] == "manual"
+
+
+@pytest.mark.integration
+def test_reassign_counts_what_is_still_unresolved(api_client, mocker):
+    mocker.patch("app.routers.products.resolve_icon_via_model", return_value=None)
+    api_client.post("/products", json=_product(name="Zzyzx"))
+    api_client.post("/products", json=_product(name="Qwxyzabc"))
+
+    response = api_client.post("/products/icons/reassign")
+
+    body = response.json()
+    assert body["considered"] == 2
+    assert body["updated"] == 0
+    assert body["still_default"] == 2
+
+
+@pytest.mark.integration
+def test_reassign_actually_commits_not_just_updates_the_in_session_objects(api_client, db_session, mocker):
+    """A missing commit here would still pass every assertion above: the
+    fixture's api_client and db_session share one SQLAlchemy session for the
+    whole test, so reading a mutated ORM object back never proves it reached
+    the database — only a fresh read after expiring the session's identity
+    map does."""
+    mocker.patch("app.routers.products.resolve_icon_via_model", return_value=None)
+    product_id = api_client.post("/products", json=_product(name="Zzyzx")).json()["id"]
+    mocker.patch("app.routers.products.resolve_icon", return_value="\U0001F35E")
+
+    api_client.post("/products/icons/reassign")
+    db_session.expire_all()
+
+    assert api_client.get(f"/products/{product_id}").json()["icon"] == "\U0001F35E"
+
+
+@pytest.mark.integration
+def test_reassign_reuses_the_normal_resolution_order_including_the_cache(api_client, mocker):
+    """The batch endpoint calls the same _resolve_icon as creation — this
+    proves it, rather than assuming two call sites stay in sync forever."""
+    mocker.patch("app.routers.products.resolve_icon_via_model", return_value=None)
+    first = api_client.post("/products", json=_product(name="Zzyzx one")).json()
+    second = api_client.post("/products", json=_product(name="ZZYZX ONE")).json()  # same normalized name
+    assert first["icon_source"] == second["icon_source"] == "default"
+
+    mocked = mocker.patch("app.routers.products.resolve_icon_via_model", return_value="\U0001F31F")
+
+    api_client.post("/products/icons/reassign")
+
+    # One model call resolves the first row; the cache must serve the second
+    # from the same batch, not trigger a second call.
+    assert mocked.call_count == 1
+    for original in (first, second):
+        refreshed = api_client.get(f"/products/{original['id']}").json()
+        assert refreshed["icon"] == "\U0001F31F"
+        assert refreshed["icon_source"] == "ai"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -78,7 +78,49 @@
   transform: scale(1.15);
 }
 
-.product-card__icon-input {
+/* Icon picker */
+
+.icon-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0.375rem 0;
+  padding: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--bg);
+}
+
+.icon-picker__grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  max-height: 7.5rem;
+  overflow-y: auto;
+}
+
+.icon-picker__option {
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  font-size: 1.05rem;
+  line-height: 1;
+  border-radius: 0.375rem;
+}
+
+.icon-picker__option--selected {
+  /* Matches .theme__swatch--active's language for "this one is current". */
+  border-color: var(--accent);
+  border-width: 2px;
+}
+
+.icon-picker__footer {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.icon-picker__input {
   width: 2.75rem;
   padding: 0.15rem;
   font-size: 1.25rem;

--- a/frontend/src/components/IconPicker.test.tsx
+++ b/frontend/src/components/IconPicker.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { IconPicker } from '@/components/IconPicker'
+import { ICON_CHOICES } from '@/iconChoices'
+
+function renderPicker(overrides: Partial<Parameters<typeof IconPicker>[0]> = {}) {
+  const onSelect = vi.fn()
+  const onCancel = vi.fn()
+  render(
+    <IconPicker
+      value="\u{1F34C}"
+      onSelect={onSelect}
+      onCancel={onCancel}
+      busy={false}
+      label="Cambiar icono de Plátano"
+      {...overrides}
+    />,
+  )
+  return { onSelect, onCancel }
+}
+
+describe('IconPicker', () => {
+  it('renders every curated choice as its own button', () => {
+    renderPicker()
+
+    for (const icon of ICON_CHOICES) {
+      expect(screen.getByRole('button', { name: icon })).toBeInTheDocument()
+    }
+  })
+
+  it('marks the current value as pressed, and nothing else', () => {
+    renderPicker({ value: '\u{1F34E}' })
+
+    expect(screen.getByRole('button', { name: '\u{1F34E}' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: '\u{1F34C}' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('selecting a different grid option calls onSelect with it', () => {
+    const { onSelect } = renderPicker({ value: '\u{1F34C}' })
+
+    fireEvent.click(screen.getByRole('button', { name: '\u{1F34E}' }))
+
+    expect(onSelect).toHaveBeenCalledWith('\u{1F34E}')
+  })
+
+  it('tapping the already-selected option cancels rather than re-sending the same value', () => {
+    const { onSelect, onCancel } = renderPicker({ value: '\u{1F34C}' })
+
+    fireEvent.click(screen.getByRole('button', { name: '\u{1F34C}' }))
+
+    expect(onSelect).not.toHaveBeenCalled()
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('starts with "Otro" collapsed, showing a toggle rather than a text field', () => {
+    renderPicker()
+
+    expect(screen.getByRole('button', { name: 'Otro…' })).toBeInTheDocument()
+    expect(screen.queryByLabelText('Cambiar icono de Plátano')).not.toBeInTheDocument()
+  })
+
+  it('"Otro" reveals a text field prefilled with the current value', () => {
+    renderPicker({ value: '\u{1F34C}' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Otro…' }))
+
+    expect(screen.getByLabelText('Cambiar icono de Plátano')).toHaveValue('\u{1F34C}')
+  })
+
+  it('Enter in "Otro" commits a changed, non-empty value', () => {
+    const { onSelect } = renderPicker({ value: '\u{1F34C}' })
+    fireEvent.click(screen.getByRole('button', { name: 'Otro…' }))
+    const input = screen.getByLabelText('Cambiar icono de Plátano')
+
+    fireEvent.change(input, { target: { value: '\u{1F9C1}' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onSelect).toHaveBeenCalledWith('\u{1F9C1}')
+  })
+
+  it('blur in "Otro" commits the same as Enter', () => {
+    const { onSelect } = renderPicker({ value: '\u{1F34C}' })
+    fireEvent.click(screen.getByRole('button', { name: 'Otro…' }))
+    const input = screen.getByLabelText('Cambiar icono de Plátano')
+
+    fireEvent.change(input, { target: { value: '\u{1F9C1}' } })
+    fireEvent.blur(input)
+
+    expect(onSelect).toHaveBeenCalledWith('\u{1F9C1}')
+  })
+
+  it('Escape in "Otro" cancels without saving, even with a changed value', () => {
+    const { onSelect, onCancel } = renderPicker({ value: '\u{1F34C}' })
+    fireEvent.click(screen.getByRole('button', { name: 'Otro…' }))
+    const input = screen.getByLabelText('Cambiar icono de Plátano')
+
+    fireEvent.change(input, { target: { value: '\u{1F9C1}' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(onSelect).not.toHaveBeenCalled()
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('leaving "Otro" unchanged on blur cancels rather than re-sending the same value', () => {
+    const { onSelect, onCancel } = renderPicker({ value: '\u{1F34C}' })
+    fireEvent.click(screen.getByRole('button', { name: 'Otro…' }))
+
+    fireEvent.blur(screen.getByLabelText('Cambiar icono de Plátano'))
+
+    expect(onSelect).not.toHaveBeenCalled()
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('a blank "Otro" field cancels rather than sending an empty icon', () => {
+    const { onSelect, onCancel } = renderPicker({ value: '\u{1F34C}' })
+    fireEvent.click(screen.getByRole('button', { name: 'Otro…' }))
+    const input = screen.getByLabelText('Cambiar icono de Plátano')
+
+    fireEvent.change(input, { target: { value: '   ' } })
+    fireEvent.blur(input)
+
+    expect(onSelect).not.toHaveBeenCalled()
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('"Cerrar" cancels directly, without going through "Otro"', () => {
+    const { onSelect, onCancel } = renderPicker()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cerrar selector de icono' }))
+
+    expect(onSelect).not.toHaveBeenCalled()
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('disables every control while busy, so a second tap cannot fire mid-save', () => {
+    renderPicker({ busy: true })
+
+    expect(screen.getByRole('button', { name: '\u{1F34E}' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Otro…' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Cerrar selector de icono' })).toBeDisabled()
+  })
+})

--- a/frontend/src/components/IconPicker.tsx
+++ b/frontend/src/components/IconPicker.tsx
@@ -1,0 +1,100 @@
+import { useState, type KeyboardEvent } from 'react'
+
+import { ICON_CHOICES } from '@/iconChoices'
+
+interface IconPickerProps {
+  /** The product's current icon, highlighted in the grid when present there. */
+  value: string
+  /** Called once with a value actually worth saving — a grid tap, or the
+   *  "Otro" field committed non-empty and changed. Never called for a no-op
+   *  (unchanged or blank) selection; the picker just closes itself instead. */
+  onSelect: (icon: string) => void
+  /** Closes the picker without saving — Escape, or leaving "Otro" unchanged. */
+  onCancel: () => void
+  /** Disables every control while a selection is being saved, so a second tap
+   *  cannot fire a second request before the first one settles. */
+  busy: boolean
+  /** Accessible name for the "Otro" field, e.g. "Cambiar icono de Plátano". */
+  label: string
+}
+
+/**
+ * A quick-pick grid of common emoji, with a text fallback for anything else.
+ *
+ * Exists because there is no way to make a phone's keyboard open directly to
+ * its emoji panel from a plain text input — the user would otherwise have to
+ * switch keyboards by hand every time. One tap on a grid entry never needs
+ * that at all; "Otro" still falls back to it for whatever is not listed.
+ */
+export function IconPicker({ value, onSelect, onCancel, busy, label }: IconPickerProps) {
+  const [showOther, setShowOther] = useState(false)
+  const [draft, setDraft] = useState(value)
+
+  // Tapping the icon already in place is "never mind", the same as leaving
+  // "Otro" unchanged — not a request to re-save the value it already has.
+  const selectFromGrid = (icon: string) => {
+    if (icon === value) {
+      onCancel()
+      return
+    }
+    onSelect(icon)
+  }
+
+  const commitOther = () => {
+    const next = draft.trim()
+    if (next === '' || next === value) {
+      onCancel()
+      return
+    }
+    onSelect(next)
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') commitOther()
+    if (event.key === 'Escape') onCancel()
+  }
+
+  return (
+    <div className="icon-picker">
+      <div className="icon-picker__grid" role="group" aria-label="Iconos comunes">
+        {ICON_CHOICES.map((icon) => (
+          <button
+            key={icon}
+            type="button"
+            className={`icon-picker__option${icon === value ? ' icon-picker__option--selected' : ''}`}
+            onClick={() => selectFromGrid(icon)}
+            disabled={busy}
+            aria-label={icon}
+            aria-pressed={icon === value}
+          >
+            {icon}
+          </button>
+        ))}
+      </div>
+
+      <div className="icon-picker__footer">
+        {showOther ? (
+          <input
+            type="text"
+            className="icon-picker__input"
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            onBlur={commitOther}
+            onKeyDown={handleKeyDown}
+            disabled={busy}
+            maxLength={16}
+            autoFocus
+            aria-label={label}
+          />
+        ) : (
+          <button type="button" onClick={() => setShowOther(true)} disabled={busy}>
+            Otro…
+          </button>
+        )}
+        <button type="button" onClick={onCancel} disabled={busy} aria-label="Cerrar selector de icono">
+          Cerrar
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ProductCard.test.tsx
+++ b/frontend/src/components/ProductCard.test.tsx
@@ -74,11 +74,17 @@ describe('ProductCard quantity stepper', () => {
     await waitFor(() => expect(mockedAdjust).toHaveBeenCalledWith(1, -1))
   })
 
-  it('disables "−" at quantity 1, offering no path to zero', () => {
+  it('hides "−" at quantity 1 rather than disabling it, offering no path to zero', () => {
     renderCard({ quantity: '1.00' })
 
-    expect(screen.getByRole('button', { name: 'Reducir cantidad de Plátano' })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: 'Reducir cantidad de Plátano' })).not.toBeInTheDocument()
     expect(mockedAdjust).not.toHaveBeenCalled()
+  })
+
+  it('shows "−" again once the quantity is above 1', () => {
+    renderCard({ quantity: '2.00' })
+
+    expect(screen.getByRole('button', { name: 'Reducir cantidad de Plátano' })).toBeInTheDocument()
   })
 
   it('keeps "+" enabled at quantity 1 — there is no upper bound', () => {
@@ -124,66 +130,104 @@ describe('ProductCard icon override', () => {
     expect(screen.getByRole('button', { name: /cambiar icono de Plátano/i })).toHaveTextContent('\u{1F34C}')
   })
 
-  it('clicking the icon opens an editable field prefilled with the current icon', () => {
+  it('clicking the icon opens a grid of common emoji, highlighting the current one', () => {
     renderCard({ icon: '\u{1F34C}' })
 
     fireEvent.click(screen.getByRole('button', { name: /cambiar icono de Plátano/i }))
 
-    expect(screen.getByLabelText('Cambiar icono de Plátano')).toHaveValue('\u{1F34C}')
+    const current = screen.getByRole('button', { name: '\u{1F34C}' })
+    expect(current).toHaveAttribute('aria-pressed', 'true')
+    // Some other option from the grid, to prove it is more than one button.
+    expect(screen.getByRole('button', { name: '\u{1F34E}' })).toBeInTheDocument()
   })
 
-  it('committing a new icon with Enter sends it and marks the change manual on the server side', async () => {
+  it('tapping a grid option saves it immediately, no separate confirm step', async () => {
     const updated = product({ icon: '\u{1F34E}', icon_source: 'manual' })
     mockedSetIcon.mockResolvedValue(updated)
     const { onProductChanged } = renderCard({ icon: '\u{1F34C}' })
 
     fireEvent.click(screen.getByRole('button', { name: /cambiar icono de Plátano/i }))
-    const input = screen.getByLabelText('Cambiar icono de Plátano')
-    fireEvent.change(input, { target: { value: '\u{1F34E}' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.click(screen.getByRole('button', { name: '\u{1F34E}' }))
 
     await waitFor(() => expect(onProductChanged).toHaveBeenCalledWith(updated))
     expect(mockedSetIcon).toHaveBeenCalledWith(1, '\u{1F34E}')
   })
 
-  it('committing on blur works the same as pressing Enter', async () => {
-    mockedSetIcon.mockResolvedValue(product({ icon: '\u{1F34E}', icon_source: 'manual' }))
+  it('tapping the current icon again in the grid is a no-op, not a wasted request', () => {
     renderCard({ icon: '\u{1F34C}' })
 
     fireEvent.click(screen.getByRole('button', { name: /cambiar icono de Plátano/i }))
-    const input = screen.getByLabelText('Cambiar icono de Plátano')
-    fireEvent.change(input, { target: { value: '\u{1F34E}' } })
-    fireEvent.blur(input)
+    fireEvent.click(screen.getByRole('button', { name: '\u{1F34C}' }))
 
-    await waitFor(() => expect(mockedSetIcon).toHaveBeenCalledWith(1, '\u{1F34E}'))
+    expect(mockedSetIcon).not.toHaveBeenCalled()
   })
 
-  it('leaving the icon unchanged closes the editor without a request', () => {
+  it('"Otro" reveals a text field prefilled with the current icon, for anything not in the grid', () => {
     renderCard({ icon: '\u{1F34C}' })
 
     fireEvent.click(screen.getByRole('button', { name: /cambiar icono de Plátano/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Otro…' }))
+
+    expect(screen.getByLabelText('Cambiar icono de Plátano')).toHaveValue('\u{1F34C}')
+  })
+
+  it('committing a new icon in "Otro" with Enter sends it and marks the change manual', async () => {
+    const updated = product({ icon: '\u{1F9C1}', icon_source: 'manual' })
+    mockedSetIcon.mockResolvedValue(updated)
+    const { onProductChanged } = renderCard({ icon: '\u{1F34C}' })
+
+    fireEvent.click(screen.getByRole('button', { name: /cambiar icono de Plátano/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Otro…' }))
+    const input = screen.getByLabelText('Cambiar icono de Plátano')
+    fireEvent.change(input, { target: { value: '\u{1F9C1}' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(onProductChanged).toHaveBeenCalledWith(updated))
+    expect(mockedSetIcon).toHaveBeenCalledWith(1, '\u{1F9C1}')
+  })
+
+  it('committing on blur works the same as pressing Enter', async () => {
+    mockedSetIcon.mockResolvedValue(product({ icon: '\u{1F9C1}', icon_source: 'manual' }))
+    renderCard({ icon: '\u{1F34C}' })
+
+    fireEvent.click(screen.getByRole('button', { name: /cambiar icono de Plátano/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Otro…' }))
+    const input = screen.getByLabelText('Cambiar icono de Plátano')
+    fireEvent.change(input, { target: { value: '\u{1F9C1}' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(mockedSetIcon).toHaveBeenCalledWith(1, '\u{1F9C1}'))
+  })
+
+  it('leaving "Otro" unchanged closes the editor without a request', () => {
+    renderCard({ icon: '\u{1F34C}' })
+
+    fireEvent.click(screen.getByRole('button', { name: /cambiar icono de Plátano/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Otro…' }))
     fireEvent.blur(screen.getByLabelText('Cambiar icono de Plátano'))
 
     expect(mockedSetIcon).not.toHaveBeenCalled()
     expect(screen.getByRole('button', { name: /cambiar icono de Plátano/i })).toBeInTheDocument()
   })
 
-  it('Escape cancels the edit without saving, even if the field was changed', () => {
+  it('Escape in "Otro" cancels without saving, even if the field was changed', () => {
     renderCard({ icon: '\u{1F34C}' })
 
     fireEvent.click(screen.getByRole('button', { name: /cambiar icono de Plátano/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Otro…' }))
     const input = screen.getByLabelText('Cambiar icono de Plátano')
-    fireEvent.change(input, { target: { value: '\u{1F34E}' } })
+    fireEvent.change(input, { target: { value: '\u{1F9C1}' } })
     fireEvent.keyDown(input, { key: 'Escape' })
 
     expect(mockedSetIcon).not.toHaveBeenCalled()
     expect(screen.getByRole('button', { name: /cambiar icono de Plátano/i })).toHaveTextContent('\u{1F34C}')
   })
 
-  it('an empty field closes the editor without a request rather than sending a blank icon', () => {
+  it('an empty "Otro" field closes the editor without a request rather than sending a blank icon', () => {
     renderCard({ icon: '\u{1F34C}' })
 
     fireEvent.click(screen.getByRole('button', { name: /cambiar icono de Plátano/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Otro…' }))
     const input = screen.getByLabelText('Cambiar icono de Plátano')
     fireEvent.change(input, { target: { value: '   ' } })
     fireEvent.blur(input)
@@ -191,16 +235,44 @@ describe('ProductCard icon override', () => {
     expect(mockedSetIcon).not.toHaveBeenCalled()
   })
 
+  it('"Cerrar" closes the picker without saving', () => {
+    renderCard({ icon: '\u{1F34C}' })
+
+    fireEvent.click(screen.getByRole('button', { name: /cambiar icono de Plátano/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cerrar selector de icono' }))
+
+    expect(mockedSetIcon).not.toHaveBeenCalled()
+    expect(screen.queryByRole('group', { name: 'Iconos comunes' })).not.toBeInTheDocument()
+  })
+
+  it('disables the grid while a selection is being saved', async () => {
+    let resolveRequest: (product: Product) => void = () => {}
+    mockedSetIcon.mockReturnValue(
+      new Promise<Product>((resolve) => {
+        resolveRequest = resolve
+      }),
+    )
+    renderCard({ icon: '\u{1F34C}' })
+
+    fireEvent.click(screen.getByRole('button', { name: /cambiar icono de Plátano/i }))
+    fireEvent.click(screen.getByRole('button', { name: '\u{1F34E}' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: '\u{1F34E}' })).toBeDisabled())
+    expect(screen.getByRole('button', { name: 'Otro…' })).toBeDisabled()
+
+    resolveRequest(product({ icon: '\u{1F34E}', icon_source: 'manual' }))
+    await waitFor(() => expect(screen.queryByRole('group', { name: 'Iconos comunes' })).not.toBeInTheDocument())
+  })
+
   it('shows the failure inline and leaves the icon showing the old value', async () => {
     mockedSetIcon.mockRejectedValue(new Error('nope'))
     const { onProductChanged } = renderCard({ icon: '\u{1F34C}' })
 
     fireEvent.click(screen.getByRole('button', { name: /cambiar icono de Plátano/i }))
-    const input = screen.getByLabelText('Cambiar icono de Plátano')
-    fireEvent.change(input, { target: { value: '\u{1F34E}' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.click(screen.getByRole('button', { name: '\u{1F34E}' }))
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
     expect(onProductChanged).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /cambiar icono de Plátano/i })).toHaveTextContent('\u{1F34C}')
   })
 })

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -1,5 +1,6 @@
-import { useState, type KeyboardEvent } from 'react'
+import { useState } from 'react'
 
+import { IconPicker } from '@/components/IconPicker'
 import { LOCATION_LABELS, expiryPhrase, quantityLabel } from '@/labels'
 import { canStepDown } from '@/quantity'
 import { toErrorMessage } from '@/services/api'
@@ -21,7 +22,6 @@ export function ProductCard({ product, onEdit, onDelete, onProductChanged }: Pro
   const [quantityError, setQuantityError] = useState<string | null>(null)
 
   const [editingIcon, setEditingIcon] = useState(false)
-  const [iconDraft, setIconDraft] = useState('')
   const [savingIcon, setSavingIcon] = useState(false)
   const [iconError, setIconError] = useState<string | null>(null)
 
@@ -41,24 +41,17 @@ export function ProductCard({ product, onEdit, onDelete, onProductChanged }: Pro
 
   const startEditingIcon = () => {
     setIconError(null)
-    setIconDraft(product.icon)
     setEditingIcon(true)
   }
 
-  // A blank field or the icon unchanged means "never mind" — nothing to save,
-  // and no reason to spend a request confirming the current value.
-  const commitIcon = () => {
-    const next = iconDraft.trim()
-    if (next === '' || next === product.icon) {
-      setEditingIcon(false)
-      return
-    }
-
+  // Called only with a value already checked to be worth saving — see
+  // IconPicker, which never calls this for a no-op selection.
+  const commitIcon = (icon: string) => {
     setSavingIcon(true)
     setIconError(null)
     void (async () => {
       try {
-        onProductChanged(await setProductIcon(product.id, next))
+        onProductChanged(await setProductIcon(product.id, icon))
         setEditingIcon(false)
       } catch (caught) {
         setIconError(toErrorMessage(caught))
@@ -68,56 +61,53 @@ export function ProductCard({ product, onEdit, onDelete, onProductChanged }: Pro
     })()
   }
 
-  const handleIconKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Enter') commitIcon()
-    if (event.key === 'Escape') setEditingIcon(false)
-  }
-
   return (
     <li className={`product-card product-card--${product.status}`}>
       <div className="product-card__main">
         <h2 className="product-card__name">
-          {editingIcon ? (
-            <input
-              type="text"
-              className="product-card__icon-input"
-              value={iconDraft}
-              onChange={(event) => setIconDraft(event.target.value)}
-              onBlur={commitIcon}
-              onKeyDown={handleIconKeyDown}
-              disabled={savingIcon}
-              maxLength={16}
-              autoFocus
-              aria-label={`Cambiar icono de ${product.name}`}
-            />
-          ) : (
-            <button
-              type="button"
-              className="product-card__icon-button"
-              onClick={startEditingIcon}
-              aria-label={`Cambiar icono de ${product.name}, actualmente ${product.icon}`}
-            >
-              {product.icon}
-            </button>
-          )}
+          <button
+            type="button"
+            className="product-card__icon-button"
+            onClick={startEditingIcon}
+            aria-label={`Cambiar icono de ${product.name}, actualmente ${product.icon}`}
+          >
+            {product.icon}
+          </button>
           {/* Its own element so a caller can read the name without the icon
               prefix mixed into textContent — see ProductList.test.tsx's
               headingNames() helper. */}
           <span className="product-card__name-text">{product.name}</span>
         </h2>
+
+        {editingIcon && (
+          <IconPicker
+            value={product.icon}
+            busy={savingIcon}
+            onSelect={commitIcon}
+            onCancel={() => setEditingIcon(false)}
+            label={`Cambiar icono de ${product.name}`}
+          />
+        )}
+
         <p className="product-card__meta">
           {product.category ? <span>{product.category.name}</span> : <span className="product-card__uncategorised">Sin categoría</span>}
           <span aria-hidden="true">·</span>
           <span className="quantity-stepper">
-            <button
-              type="button"
-              className="quantity-stepper__button"
-              onClick={() => adjustQuantity(-1)}
-              disabled={adjustingQuantity || !canStepDown(product.quantity)}
-              aria-label={`Reducir cantidad de ${product.name}`}
-            >
-              −
-            </button>
+            {/* Hidden rather than disabled at quantity 1 — a stepper that is
+                half-buttons for most of the list (single-item products are
+                common) reads as cluttered for no benefit, since the button
+                does nothing there either way. */}
+            {canStepDown(product.quantity) && (
+              <button
+                type="button"
+                className="quantity-stepper__button"
+                onClick={() => adjustQuantity(-1)}
+                disabled={adjustingQuantity}
+                aria-label={`Reducir cantidad de ${product.name}`}
+              >
+                −
+              </button>
+            )}
             <span className="quantity-stepper__value">{quantityLabel(product.quantity, product.unit)}</span>
             <button
               type="button"

--- a/frontend/src/components/ProductForm.test.tsx
+++ b/frontend/src/components/ProductForm.test.tsx
@@ -65,3 +65,45 @@ describe('ProductForm while saving', () => {
     expect(screen.getByRole('button', { name: 'Guardar' })).toBeEnabled()
   })
 })
+
+describe('ProductForm quantity stepper', () => {
+  it('hides "−" at the default quantity of 1', () => {
+    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+
+    expect(screen.queryByRole('button', { name: 'Reducir cantidad' })).not.toBeInTheDocument()
+  })
+
+  it('shows "−" again once "+" has been pressed, and hides it once stepped back to 1', () => {
+    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Aumentar cantidad' }))
+    expect(screen.getByRole('button', { name: 'Reducir cantidad' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reducir cantidad' }))
+    expect(screen.queryByRole('button', { name: 'Reducir cantidad' })).not.toBeInTheDocument()
+  })
+
+  it('shows "−" when editing a product whose quantity is already above 1', () => {
+    const product: Product = {
+      id: 1,
+      name: 'Huevos',
+      category_id: null,
+      quantity: '6.00',
+      unit: 'piezas',
+      expires_at: '2026-09-10',
+      location: 'fridge',
+      notes: null,
+      category: null,
+      icon: '\u{1F95A}',
+      icon_source: 'lookup',
+      created_at: '2026-08-29T00:00:00Z',
+      updated_at: '2026-08-29T00:00:00Z',
+      days_until_expiry: 5,
+      status: 'expiring_soon',
+    }
+
+    render(<ProductForm product={product} categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Reducir cantidad' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ProductForm.tsx
+++ b/frontend/src/components/ProductForm.tsx
@@ -158,15 +158,18 @@ export function ProductForm({ product, categories, onSaved, onCancel }: ProductF
           <div className="form__field">
             <label htmlFor="product-quantity">Cantidad</label>
             <span className="quantity-stepper">
-              <button
-                type="button"
-                className="quantity-stepper__button"
-                onClick={() => update('quantity', stepQuantity(form.quantity, -1))}
-                disabled={!canStepDown(form.quantity)}
-                aria-label="Reducir cantidad"
-              >
-                −
-              </button>
+              {/* Hidden rather than disabled at 1, matching the card's
+                  stepper — see ProductCard.tsx for why. */}
+              {canStepDown(form.quantity) && (
+                <button
+                  type="button"
+                  className="quantity-stepper__button"
+                  onClick={() => update('quantity', stepQuantity(form.quantity, -1))}
+                  aria-label="Reducir cantidad"
+                >
+                  −
+                </button>
+              )}
               <input
                 id="product-quantity"
                 type="number"

--- a/frontend/src/components/SettingsDialog.test.tsx
+++ b/frontend/src/components/SettingsDialog.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { SettingsDialog } from '@/components/SettingsDialog'
-import type { SettingsResponse } from '@/services/types'
+import type { IconReassignmentResult, SettingsResponse } from '@/services/types'
 
 vi.mock('@/services/settingsService', () => ({
   getSettings: vi.fn(),
@@ -11,11 +11,17 @@ vi.mock('@/services/settingsService', () => ({
   triggerAlert: vi.fn(),
 }))
 
+vi.mock('@/services/productsService', () => ({
+  reassignIcons: vi.fn(),
+}))
+
 const service = await import('@/services/settingsService')
+const products = await import('@/services/productsService')
 const mockedGet = vi.mocked(service.getSettings)
 const mockedSave = vi.mocked(service.saveSettings)
 const mockedSaveIcons = vi.mocked(service.saveIconSettings)
 const mockedTrigger = vi.mocked(service.triggerAlert)
+const mockedReassign = vi.mocked(products.reassignIcons)
 
 function response(overrides: Partial<SettingsResponse> = {}): SettingsResponse {
   return {
@@ -30,6 +36,17 @@ function response(overrides: Partial<SettingsResponse> = {}): SettingsResponse {
   }
 }
 
+function reassignment(overrides: Partial<IconReassignmentResult> = {}): IconReassignmentResult {
+  return { considered: 3, updated: 2, still_default: 1, ...overrides }
+}
+
+function renderDialog(overrides: { onClose?: () => void; onIconsReassigned?: () => void } = {}) {
+  const onClose = overrides.onClose ?? vi.fn()
+  const onIconsReassigned = overrides.onIconsReassigned ?? vi.fn()
+  render(<SettingsDialog onClose={onClose} onIconsReassigned={onIconsReassigned} />)
+  return { onClose, onIconsReassigned }
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   mockedSave.mockResolvedValue(response())
@@ -40,7 +57,7 @@ describe('SettingsDialog', () => {
   it('loads the stored settings into the form', async () => {
     mockedGet.mockResolvedValue(response())
 
-    render(<SettingsDialog onClose={vi.fn()} />)
+    renderDialog()
 
     expect(await screen.findByLabelText('Hora')).toHaveValue('08:00')
     expect(screen.getByLabelText('Días de anticipación')).toHaveValue(7)
@@ -50,7 +67,7 @@ describe('SettingsDialog', () => {
   it('saves what the user changed', async () => {
     mockedGet.mockResolvedValue(response())
 
-    render(<SettingsDialog onClose={vi.fn()} />)
+    renderDialog()
     fireEvent.change(await screen.findByLabelText('Hora'), { target: { value: '19:45' } })
     fireEvent.change(screen.getByLabelText('Días de anticipación'), { target: { value: '3' } })
     fireEvent.click(screen.getByRole('button', { name: 'Guardar' }))
@@ -62,7 +79,7 @@ describe('SettingsDialog', () => {
   it('saves the icon toggle through its own endpoint, alongside the alert save', async () => {
     mockedGet.mockResolvedValue(response({ icons: { ai_enabled: true, updated_at: '2026-08-30T00:00:00Z' } }))
 
-    render(<SettingsDialog onClose={vi.fn()} />)
+    renderDialog()
     fireEvent.click(await screen.findByLabelText(/Asignar icono con IA/))
     fireEvent.click(screen.getByRole('button', { name: 'Guardar' }))
 
@@ -74,21 +91,19 @@ describe('SettingsDialog', () => {
   it('closes once the save succeeds', async () => {
     // Leaving it open reads as "nothing happened", which is what every other
     // app taught the user to expect otherwise.
-    const onClose = vi.fn()
     mockedGet.mockResolvedValue(response())
+    const { onClose } = renderDialog()
 
-    render(<SettingsDialog onClose={onClose} />)
     fireEvent.click(await screen.findByRole('button', { name: 'Guardar' }))
 
     await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
   })
 
   it('stays open with the reason when the alert save fails', async () => {
-    const onClose = vi.fn()
     mockedGet.mockResolvedValue(response())
     mockedSave.mockRejectedValue(new Error('boom'))
+    const { onClose } = renderDialog()
 
-    render(<SettingsDialog onClose={onClose} />)
     fireEvent.click(await screen.findByRole('button', { name: 'Guardar' }))
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
@@ -96,11 +111,10 @@ describe('SettingsDialog', () => {
   })
 
   it('stays open with the reason when the icon-toggle save fails', async () => {
-    const onClose = vi.fn()
     mockedGet.mockResolvedValue(response())
     mockedSaveIcons.mockRejectedValue(new Error('boom'))
+    const { onClose } = renderDialog()
 
-    render(<SettingsDialog onClose={onClose} />)
     fireEvent.click(await screen.findByRole('button', { name: 'Guardar' }))
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
@@ -110,7 +124,7 @@ describe('SettingsDialog', () => {
   it('warns when Telegram is unconfigured and blocks the test send', async () => {
     mockedGet.mockResolvedValue(response({ telegram_configured: false, next_run_at: null }))
 
-    render(<SettingsDialog onClose={vi.fn()} />)
+    renderDialog()
 
     expect(await screen.findByText(/Telegram sin configurar/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Enviar prueba' })).toBeDisabled()
@@ -119,7 +133,7 @@ describe('SettingsDialog', () => {
   it('warns when Ollama is unconfigured, without disabling the toggle itself', async () => {
     mockedGet.mockResolvedValue(response({ ollama_configured: false }))
 
-    render(<SettingsDialog onClose={vi.fn()} />)
+    renderDialog()
 
     expect(await screen.findByText(/Modelo de iconos sin configurar/)).toBeInTheDocument()
     // Unlike the Telegram test button, nothing here needs to be disabled: an
@@ -130,7 +144,7 @@ describe('SettingsDialog', () => {
   it('says so when nothing is scheduled', async () => {
     mockedGet.mockResolvedValue(response({ next_run_at: null }))
 
-    render(<SettingsDialog onClose={vi.fn()} />)
+    renderDialog()
 
     expect(await screen.findByText('No hay ninguna alerta programada.')).toBeInTheDocument()
   })
@@ -139,7 +153,7 @@ describe('SettingsDialog', () => {
     mockedGet.mockResolvedValue(response())
     mockedTrigger.mockResolvedValue({ sent: true, products: 5, detail: 'Alerta enviada' })
 
-    render(<SettingsDialog onClose={vi.fn()} />)
+    renderDialog()
     fireEvent.click(await screen.findByRole('button', { name: 'Enviar prueba' }))
 
     expect(await screen.findByText('Alerta enviada')).toBeInTheDocument()
@@ -148,11 +162,83 @@ describe('SettingsDialog', () => {
   it('never renders anything that looks like a token', async () => {
     mockedGet.mockResolvedValue(response())
 
-    const { container } = render(<SettingsDialog onClose={vi.fn()} />)
+    const { container } = render(<SettingsDialog onClose={vi.fn()} onIconsReassigned={vi.fn()} />)
     await screen.findByLabelText('Hora')
 
     // The API does not send it; the UI must not invent a field for it either.
     expect(container.textContent).not.toMatch(/token/i)
     expect(container.querySelector('input[type="password"]')).toBeNull()
+  })
+})
+
+describe('SettingsDialog icon reassignment', () => {
+  it('reports how many products were updated', async () => {
+    mockedGet.mockResolvedValue(response())
+    mockedReassign.mockResolvedValue(reassignment({ considered: 5, updated: 3, still_default: 2 }))
+
+    renderDialog()
+    fireEvent.click(await screen.findByRole('button', { name: 'Reasignar iconos' }))
+
+    expect(await screen.findByText('3 de 5 productos actualizados.')).toBeInTheDocument()
+  })
+
+  it('says so when nothing needed reassigning', async () => {
+    mockedGet.mockResolvedValue(response())
+    mockedReassign.mockResolvedValue(reassignment({ considered: 0, updated: 0, still_default: 0 }))
+
+    renderDialog()
+    fireEvent.click(await screen.findByRole('button', { name: 'Reasignar iconos' }))
+
+    expect(await screen.findByText('No hay productos pendientes de icono.')).toBeInTheDocument()
+  })
+
+  it('tells the product list to reload when something actually changed', async () => {
+    mockedGet.mockResolvedValue(response())
+    mockedReassign.mockResolvedValue(reassignment({ considered: 3, updated: 2, still_default: 1 }))
+    const { onIconsReassigned } = renderDialog()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Reasignar iconos' }))
+
+    await waitFor(() => expect(onIconsReassigned).toHaveBeenCalledOnce())
+  })
+
+  it('does not reload the list when nothing changed', async () => {
+    mockedGet.mockResolvedValue(response())
+    mockedReassign.mockResolvedValue(reassignment({ considered: 3, updated: 0, still_default: 3 }))
+    const { onIconsReassigned } = renderDialog()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Reasignar iconos' }))
+
+    await screen.findByText('0 de 3 productos actualizados.')
+    expect(onIconsReassigned).not.toHaveBeenCalled()
+  })
+
+  it('shows the failure inline and does not close the dialog', async () => {
+    mockedGet.mockResolvedValue(response())
+    mockedReassign.mockRejectedValue(new Error('boom'))
+    const { onClose } = renderDialog()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Reasignar iconos' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('disables the button while the request is in flight', async () => {
+    let resolveRequest: (result: IconReassignmentResult) => void = () => {}
+    mockedGet.mockResolvedValue(response())
+    mockedReassign.mockReturnValue(
+      new Promise<IconReassignmentResult>((resolve) => {
+        resolveRequest = resolve
+      }),
+    )
+    renderDialog()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Reasignar iconos' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /reasignando/i })).toBeDisabled())
+
+    resolveRequest(reassignment())
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Reasignar iconos' })).toBeEnabled())
   })
 })

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -3,11 +3,16 @@ import { useEffect, useState, type FormEvent } from 'react'
 import { Modal } from '@/components/Modal'
 import { ThemePicker } from '@/components/ThemePicker'
 import { toErrorMessage } from '@/services/api'
+import { reassignIcons } from '@/services/productsService'
 import { getSettings, saveIconSettings, saveSettings, triggerAlert } from '@/services/settingsService'
 import type { SettingsResponse } from '@/services/types'
 
 interface SettingsDialogProps {
   onClose: () => void
+  /** Called once after a successful icon reassignment, so the product list
+   *  behind the dialog picks up the new icons instead of showing stale ones
+   *  until something else happens to trigger a reload. */
+  onIconsReassigned: () => void
 }
 
 /**
@@ -32,7 +37,7 @@ function formatNextRun(iso: string, timeZone: string): string {
  *  actually works. Two backend resources (see PUT /settings and PUT
  *  /settings/icons), one screen, one Guardar — the split exists to protect
  *  each setting from the other's payload, not to make the user click twice. */
-export function SettingsDialog({ onClose }: SettingsDialogProps) {
+export function SettingsDialog({ onClose, onIconsReassigned }: SettingsDialogProps) {
   const [current, setCurrent] = useState<SettingsResponse | null>(null)
   const [enabled, setEnabled] = useState(true)
   const [alertTime, setAlertTime] = useState('08:00')
@@ -42,6 +47,8 @@ export function SettingsDialog({ onClose }: SettingsDialogProps) {
   const [saving, setSaving] = useState(false)
   const [testResult, setTestResult] = useState<string | null>(null)
   const [testing, setTesting] = useState(false)
+  const [reassigning, setReassigning] = useState(false)
+  const [reassignResult, setReassignResult] = useState<string | null>(null)
 
   useEffect(() => {
     let active = true
@@ -108,6 +115,27 @@ export function SettingsDialog({ onClose }: SettingsDialogProps) {
     })()
   }
 
+  const handleReassign = () => {
+    setReassigning(true)
+    setReassignResult(null)
+    setError(null)
+    void (async () => {
+      try {
+        const result = await reassignIcons()
+        setReassignResult(
+          result.considered === 0
+            ? 'No hay productos pendientes de icono.'
+            : `${result.updated} de ${result.considered} productos actualizados.`,
+        )
+        if (result.updated > 0) onIconsReassigned()
+      } catch (caught) {
+        setError(toErrorMessage(caught))
+      } finally {
+        setReassigning(false)
+      }
+    })()
+  }
+
   return (
     <Modal title="Ajustes" onClose={onClose}>
       {current === null && !error && <p className="state state--loading">Cargando…</p>}
@@ -164,6 +192,15 @@ export function SettingsDialog({ onClose }: SettingsDialogProps) {
             <input type="checkbox" checked={aiEnabled} onChange={(e) => setAiEnabled(e.target.checked)} />
             <span>Asignar icono con IA cuando la tabla local no reconozca el producto</span>
           </label>
+
+          <button type="button" onClick={handleReassign} disabled={reassigning}>
+            {reassigning ? 'Reasignando…' : 'Reasignar iconos'}
+          </button>
+          <p className="settings__hint">
+            Vuelve a intentar los productos que se quedaron con el icono por defecto — por ejemplo, los que ya
+            existían antes de esta función.
+          </p>
+          {reassignResult && <p className="settings__hint">{reassignResult}</p>}
 
           {error && (
             <p className="form__error" role="alert">

--- a/frontend/src/iconChoices.ts
+++ b/frontend/src/iconChoices.ts
@@ -1,0 +1,27 @@
+/**
+ * A curated set of common emoji for the quick-pick icon grid.
+ *
+ * Mirrors the distinct values in backend/app/icons.py's lookup table — not a
+ * generated copy, so keep the two roughly in sync by hand if either changes
+ * meaningfully. Anything not listed here is still reachable through the
+ * picker's "Otro" field, which accepts any emoji via the device's own
+ * keyboard — this list is a shortcut for the common case, not a ceiling.
+ */
+export const ICON_CHOICES: readonly string[] = [
+  // Frutas
+  '🍌', '🍎', '🍐', '🍊', '🍋', '🍓', '🍇', '🍉', '🍈', '🍍', '🥭', '🥝', '🍑', '🥥', '🥑', '🍒', '🫐',
+  // Verduras
+  '🍅', '🥔', '🧅', '🧄', '🥕', '🥒', '🥬', '🥦', '🌶️', '🫑', '🌽', '🌵', '🍄', '🍆', '🫛', '🫘', '🎃',
+  // Lácteos y huevo
+  '🥛', '🧀', '🧈', '🥚',
+  // Carnes y pescado
+  '🥩', '🥓', '🍖', '🍗', '🦃', '🐟', '🍤', '🐙', '🦀',
+  // Panadería y granos
+  '🍞', '🫓', '🍝', '🍚', '🍪', '🍰', '🥪',
+  // Bebidas
+  '🧃', '🥤', '☕', '🍵', '🍺', '🍷', '🍫',
+  // Condimentos y otros comestibles
+  '🧂', '🫒', '🍲', '🍦', '🍕', '🍯',
+  // No alimentos
+  '🧼', '🧴', '🧻', '🔋', '💡',
+]

--- a/frontend/src/pages/ProductList.tsx
+++ b/frontend/src/pages/ProductList.tsx
@@ -158,7 +158,7 @@ export function ProductList() {
         />
       )}
 
-      {dialog.kind === 'settings' && <SettingsDialog onClose={close} />}
+      {dialog.kind === 'settings' && <SettingsDialog onClose={close} onIconsReassigned={reload} />}
 
       {dialog.kind === 'delete' && (
         <ConfirmDialog

--- a/frontend/src/services/productsService.ts
+++ b/frontend/src/services/productsService.ts
@@ -1,6 +1,6 @@
 import { api } from '@/services/api'
 import { withRetry } from '@/services/retry'
-import type { Product, ProductFilters, ProductPayload } from '@/services/types'
+import type { IconReassignmentResult, Product, ProductFilters, ProductPayload } from '@/services/types'
 
 export interface ProductListResult {
   products: Product[]
@@ -79,5 +79,17 @@ export async function adjustProductQuantity(id: number, delta: number): Promise<
  */
 export async function setProductIcon(id: number, icon: string): Promise<Product> {
   const { data } = await withRetry(() => api.patch<Product>(`/products/${id}/icon`, { icon }))
+  return data
+}
+
+/**
+ * Re-run icon resolution for every product still at the fallback — the ones
+ * that existed before icons shipped, or that missed while AI was off. Never
+ * touches a product with a real answer already (lookup, ai) or a manual
+ * override; see the backend endpoint's own docstring for why that is safe by
+ * construction rather than by convention.
+ */
+export async function reassignIcons(): Promise<IconReassignmentResult> {
+  const { data } = await withRetry(() => api.post<IconReassignmentResult>('/products/icons/reassign'))
   return data
 }

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -86,3 +86,10 @@ export interface AlertTriggerResult {
   products: number
   detail: string
 }
+
+/** Summary of a batch icon reassignment — see POST /products/icons/reassign. */
+export interface IconReassignmentResult {
+  considered: number
+  updated: number
+  still_default: number
+}


### PR DESCRIPTION
Answers three things from the same conversation: what happens to products that predate icons, whether the icon-edit field could be easier than a raw text box, and one more UI tweak to the quantity stepper.

## Reassign existing icons — POST /products/icons/reassign + a Settings button

Nothing had ever updated a product created before #88, or one that missed while AI was off — those rows sit at `icon_source: DEFAULT` forever unless something re-evaluates them. This is that something, on request rather than silently: scoped to `DEFAULT` rows only, reusing the exact same `_resolve_icon` the create path uses, so the "at most one model call per name" cache guarantee holds for the batch too. Proved directly: two same-named rows forced to `DEFAULT`, reassigned together, one mocked model call.

A `LOOKUP` or `AI` row is never touched, and neither is `MANUAL` — structurally, since the query never selects anything but `DEFAULT` in the first place.

The Settings button (`Reasignar iconos`) reports `"N de M productos actualizados"` and tells the product list behind the dialog to reload — but only when something actually changed, not on every click.

## A one-tap icon picker, replacing the raw text field

There is no way to make a phone's keyboard open straight to its emoji panel from a plain `<input>` — Julio's own report was having to switch keyboards by hand every time. `IconPicker` is a grid of ~65 curated emoji (`frontend/src/iconChoices.ts`, hand-kept in rough sync with `app/icons.py`'s table — not generated, sharing Python dict values with TypeScript isn't worth a build step here). One tap saves immediately; `"Otro…"` still falls back to the keyboard-driven field for anything not listed, keeping every rule the old field had (Enter/blur commits, Escape or an unchanged/blank value cancels without a request).

Found and fixed while wiring it up: tapping the icon already in place has to cancel rather than resend the same value — the grid path didn't do that until a test caught it (`selectFromGrid` needed the same "unchanged → cancel" check `commitOther` already had).

## − hides at quantity 1 instead of disabling

Half the cards in a typical list are single-item products, and a stepper that's half greyed-out buttons reads as cluttered for no benefit — the button did nothing at 1 either way. Now it's simply not rendered, in the card and the form both.

## Stricter validation on the model's answer — found by testing against the real thing

This environment turned out to reach the homelab's Ollama after all (per Julio, corrected in #90's PR comments). Running the *reassignment* against it, on harder/more specific product names, surfaced two garbled answers `#90`'s validation didn't catch:

- **A Private Use Area codepoint** — `U+F774`, the entire answer for "Aceitunas kalamata". Renders as a blank box in any normal font, which is worse than the default icon: an empty gap looks like the app is broken. PUA ranges are reserved by the Unicode standard for an application's own private glyphs and are *never* real emoji by definition — rejecting them has zero false-positive risk, unlike the full emoji allowlist #90 already ruled out as impractical.
- **Three unrelated symbols glued together** — `"🥤⚡️✨"` for "Kombucha de jengibre", technically satisfying `{"icon": "<string>"}` while being obviously not what was asked. Caught by stripping known combining modifiers (ZWJ, variation selectors, skin-tone modifiers) and counting what's left — a real single emoji, including `"🌶️"` (hot pepper + VS16, already a table entry), reduces to exactly one base codepoint; three glued-together symbols do not.

Confirmed against all ~95 real entries in `app/icons.py`'s table that this rejects none of them — the risk this design accepts is a false negative (bad output slips through occasionally), never a false positive.

Side effect, not the reason it exists: this also catches the astrological/geometric garbage (`"☍️△"` for "Mermelada de higo") that #90's own PR description named as an accepted, unchased residual. There's a test built directly from that real case too.

## Verified live, against the real API and the real model

- Seeded three products with AI off (stuck at `default`), turned AI back on, clicked **Reasignar iconos** in the actual running app → `"3 de 3 productos actualizados"`, and the cards behind the dialog updated without closing it.
- The `−` button: screenshot confirms it's simply absent on every quantity-1 card, no grey button.
- The validation fix: re-ran the reassignment against four fresh, deliberately awkward product names post-fix — all four came back clean (`🥣`, `🫒`, and two correct local-table hits).

## Tests

**Backend, 183 pass:** 5 new integration tests for the reassignment endpoint (including one that forces a genuinely fresh read via `db_session.expire_all()` to prove real persistence, not just in-session state — checked against a reverted `db.commit()` to confirm it actually fails without one), and 4 new `ollama_client` tests built from the real reproduced garbage. `ruff check` clean.

**Frontend, 191 pass**, `npm run lint && npm run build && npm test` in that order: a dedicated `IconPicker.test.tsx` (13 cases), updated `ProductCard`/`ProductForm`/`SettingsDialog` suites for the picker, the hidden `−`, and the reassign button/reload wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)