### PR TITLE
feat: show the app version, so a deploy no longer has to be taken on faith

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # The tag itself, e.g. "v0.11.0" — baked into the bundle so a
+          # deployed instance can say which release it actually is. This
+          # workflow only runs on a tag push, so ref_name is always that tag.
+          build-args: VERSION=${{ github.ref_name }}
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
 
@@ -106,6 +110,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # The tag itself, e.g. "v0.11.0" — read by app/config.py at startup
+          # and surfaced through /health and /settings.
+          build-args: VERSION=${{ github.ref_name }}
           # Separate scope from the frontend, or the two jobs evict each
           # other's layers from the shared Actions cache.
           cache-from: type=gha,scope=backend

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,13 @@
 FROM python:3.13-slim
 
+# The release tag this image is built from — only the release workflow passes
+# a real value here (via --build-arg VERSION=${{ github.ref_name }}); a local
+# build stays "dev". Read by app/config.py and surfaced through /health and
+# /settings, so a running container can be checked against what was actually
+# tagged and pushed instead of assumed.
+ARG VERSION=dev
+ENV APP_VERSION=${VERSION}
+
 WORKDIR /app
 
 # Run as a non-root user, matching apollo-server-dashboard's backend image.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -71,6 +71,15 @@ class Settings(BaseSettings):
     # what you want when running outside Docker.
     log_file: str = ""
 
+    # ── Meta ─────────────────────────────────────────────────────────────────
+    # The release tag this image was built from, e.g. "v0.11.0" — baked in by
+    # the Dockerfile's VERSION build arg, which only the release workflow sets.
+    # "dev" everywhere else: a local build, `docker compose up -d --build`,
+    # running the app directly. Exposed via /health and /settings so a running
+    # instance can be checked against what was actually deployed, rather than
+    # assumed — nothing in the UI said which version was running until this.
+    app_version: str = "dev"
+
     @property
     def database_url(self) -> str:
         """SQLAlchemy connection URL built from the DB_* settings."""

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Response, status
 
+from app.config import settings
 from app.db.session import check_connection
 
 router = APIRouter()
@@ -18,4 +19,5 @@ async def health(response: Response):
     return {
         "status": "ok" if database_ok else "degraded",
         "database": "ok" if database_ok else "unavailable",
+        "version": settings.app_version,
     }

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -35,6 +35,7 @@ def _response(db: Session) -> SettingsResponse:
         next_run_at=next_run_time(),
         timezone=env_settings.timezone,
         ollama_configured=bool(env_settings.ollama_url),
+        backend_version=env_settings.app_version,
     )
 
 

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -60,3 +60,7 @@ class SettingsResponse(BaseModel):
     # on with this false — e.g. Ollama not configured for this deployment —
     # the same distinction telegram_configured draws for alerts.
     ollama_configured: bool
+    # The release tag this backend was built from — "dev" outside the release
+    # pipeline. The frontend compares this to its own build-time version, so a
+    # deploy that only updated one image is visible instead of assumed.
+    backend_version: str

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,22 +1,35 @@
 """Health endpoint tests."""
 
 from app import routers
+from app.config import settings
 
 
 def test_health_reports_ok_when_database_answers(client, monkeypatch):
     monkeypatch.setattr(routers.health, "check_connection", lambda: True)
+    monkeypatch.setattr(settings, "app_version", "v0.11.0")
 
     response = client.get("/health")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "ok", "database": "ok"}
+    assert response.json() == {"status": "ok", "database": "ok", "version": "v0.11.0"}
 
 
 def test_health_reports_degraded_when_database_is_unreachable(client, monkeypatch):
     """A live API with a dead database must not look healthy to monitoring."""
     monkeypatch.setattr(routers.health, "check_connection", lambda: False)
+    monkeypatch.setattr(settings, "app_version", "v0.11.0")
 
     response = client.get("/health")
 
     assert response.status_code == 503
-    assert response.json() == {"status": "degraded", "database": "unavailable"}
+    assert response.json() == {"status": "degraded", "database": "unavailable", "version": "v0.11.0"}
+
+
+def test_health_reports_dev_outside_the_release_pipeline(client, monkeypatch):
+    """APP_VERSION is only ever set by the release workflow's build arg — a
+    local build or a plain `python -m app` must say so plainly rather than
+    silently claiming to be a numbered release it is not."""
+    monkeypatch.setattr(routers.health, "check_connection", lambda: True)
+    monkeypatch.setattr(settings, "app_version", "dev")
+
+    assert client.get("/health").json()["version"] == "dev"

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -187,3 +187,17 @@ def test_saving_alert_settings_never_touches_the_icon_toggle(api_client):
     api_client.put("/settings", json={"enabled": True, "alert_time": "09:00", "days_ahead": 3})
 
     assert api_client.get("/settings").json()["icons"]["ai_enabled"] is False
+
+
+@pytest.mark.integration
+def test_get_reports_the_backend_version(api_client, monkeypatch):
+    monkeypatch.setattr(env_settings, "app_version", "v0.11.0")
+
+    assert api_client.get("/settings").json()["backend_version"] == "v0.11.0"
+
+
+@pytest.mark.integration
+def test_get_reports_dev_outside_the_release_pipeline(api_client, monkeypatch):
+    monkeypatch.setattr(env_settings, "app_version", "dev")
+
+    assert api_client.get("/settings").json()["backend_version"] == "dev"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,6 +7,14 @@ COPY package*.json ./
 RUN npm ci
 
 COPY . .
+
+# The release tag this bundle is built from — only the release workflow passes
+# a real value (--build-arg VERSION=${{ github.ref_name }}); a local build
+# stays "dev". Vite inlines VITE_-prefixed env vars into the bundle at build
+# time, which is the only time a static site can pick this up at all.
+ARG VERSION=dev
+ENV VITE_APP_VERSION=${VERSION}
+
 RUN npm run build
 
 # Stage 2: serve the static build with nginx

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -453,6 +453,20 @@
   color: var(--text-muted);
 }
 
+.settings__version {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.settings__version--mismatch {
+  color: var(--danger);
+  font-weight: 600;
+}
+
 .settings__section-title {
   margin-top: 0.25rem;
   font-size: 0.8125rem;

--- a/frontend/src/components/SettingsDialog.test.tsx
+++ b/frontend/src/components/SettingsDialog.test.tsx
@@ -32,6 +32,9 @@ function response(overrides: Partial<SettingsResponse> = {}): SettingsResponse {
     // Pinned so the rendered time does not depend on the runner's zone.
     timezone: 'America/Mexico_City',
     ollama_configured: true,
+    // Matches the fallback APP_VERSION resolves to under vitest, where
+    // VITE_APP_VERSION is never set — see version.test.ts for that contract.
+    backend_version: 'dev',
     ...overrides,
   }
 }
@@ -240,5 +243,33 @@ describe('SettingsDialog icon reassignment', () => {
 
     resolveRequest(reassignment())
     await waitFor(() => expect(screen.getByRole('button', { name: 'Reasignar iconos' })).toBeEnabled())
+  })
+})
+
+describe('SettingsDialog version footer', () => {
+  it('shows a single version when frontend and backend agree', async () => {
+    // APP_VERSION resolves to 'dev' under vitest — see version.test.ts.
+    mockedGet.mockResolvedValue(response({ backend_version: 'dev' }))
+
+    renderDialog()
+
+    expect(await screen.findByText('CaduTrack dev')).toBeInTheDocument()
+  })
+
+  it('flags a mismatch instead of silently showing one of the two', async () => {
+    mockedGet.mockResolvedValue(response({ backend_version: 'v0.11.0' }))
+
+    renderDialog()
+
+    const footer = await screen.findByText(/no coinciden/)
+    expect(footer).toHaveTextContent('Frontend dev · API v0.11.0')
+  })
+
+  it('shows the frontend version alone before settings finish loading', () => {
+    mockedGet.mockReturnValue(new Promise(() => {})) // never resolves
+
+    renderDialog()
+
+    expect(screen.getByText('CaduTrack dev')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -6,6 +6,7 @@ import { toErrorMessage } from '@/services/api'
 import { reassignIcons } from '@/services/productsService'
 import { getSettings, saveIconSettings, saveSettings, triggerAlert } from '@/services/settingsService'
 import type { SettingsResponse } from '@/services/types'
+import { APP_VERSION } from '@/version'
 
 interface SettingsDialogProps {
   onClose: () => void
@@ -31,6 +32,22 @@ function formatNextRun(iso: string, timeZone: string): string {
     minute: '2-digit',
     timeZone,
   })
+}
+
+/**
+ * What the version footer should say, and whether it needs the reader's
+ * attention.
+ *
+ * Exists because "¿ya desplegaste v0.11.0?" / "según mí sí" was an actual
+ * exchange this app made possible — nothing anywhere said which version was
+ * running. Comparing the two independently-built images catches the other
+ * failure this same gap allows: a deploy that only pulled one of them.
+ */
+function versionSummary(backendVersion?: string): { text: string; mismatch: boolean } {
+  if (backendVersion === undefined || backendVersion === APP_VERSION) {
+    return { text: `CaduTrack ${APP_VERSION}`, mismatch: false }
+  }
+  return { text: `Frontend ${APP_VERSION} · API ${backendVersion} — no coinciden`, mismatch: true }
 }
 
 /** Alert preferences, the icon-assignment toggle, and a way to check delivery
@@ -136,6 +153,8 @@ export function SettingsDialog({ onClose, onIconsReassigned }: SettingsDialogPro
     })()
   }
 
+  const version = versionSummary(current?.backend_version)
+
   return (
     <Modal title="Ajustes" onClose={onClose}>
       {current === null && !error && <p className="state state--loading">Cargando…</p>}
@@ -225,6 +244,8 @@ export function SettingsDialog({ onClose, onIconsReassigned }: SettingsDialogPro
           {error}
         </p>
       )}
+
+      <p className={`settings__version${version.mismatch ? ' settings__version--mismatch' : ''}`}>{version.text}</p>
     </Modal>
   )
 }

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -75,6 +75,9 @@ export interface SettingsResponse {
    *  can be true with this false, the same distinction telegram_configured
    *  draws for alerts. */
   ollama_configured: boolean
+  /** The release tag the backend was built from — "dev" outside the release
+   *  pipeline. Compared against the frontend's own build-time version. */
+  backend_version: string
 }
 
 export type AlertSettingsPayload = Pick<AlertSettings, 'enabled' | 'alert_time' | 'days_ahead'>

--- a/frontend/src/version.test.ts
+++ b/frontend/src/version.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { APP_VERSION } from '@/version'
+
+describe('APP_VERSION', () => {
+  it('falls back to "dev" when VITE_APP_VERSION was not set at build time', () => {
+    // Vite inlines import.meta.env values at build time, so this cannot be
+    // toggled per test the way a runtime env var could — it only proves the
+    // fallback branch, which is also the only branch the test suite ever
+    // actually runs under (VITE_APP_VERSION is never set for `vitest`,
+    // matching a real `npm run dev`). The build-time-injection half of the
+    // contract is what frontend/Dockerfile and the release workflow cover.
+    expect(APP_VERSION).toBe('dev')
+  })
+})

--- a/frontend/src/version.ts
+++ b/frontend/src/version.ts
@@ -1,0 +1,10 @@
+/**
+ * This build's release tag, baked in at build time — see frontend/Dockerfile.
+ *
+ * A static bundle has no runtime environment to read this from later, so it
+ * has to be embedded when the JS is built, not when the container starts
+ * (unlike the backend, which can read APP_VERSION from its process
+ * environment on every request). "dev" is the value outside the release
+ * workflow: `npm run dev`, a local `docker compose up -d --build`.
+ */
+export const APP_VERSION = import.meta.env.VITE_APP_VERSION ?? 'dev'

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -3,6 +3,9 @@
 interface ImportMetaEnv {
   /** Base URL of the FastAPI backend. Unset means the relative "/api" path. */
   readonly VITE_API_URL?: string
+  /** The release tag this bundle was built from — see frontend/Dockerfile.
+   *  Unset outside the release workflow (npm run dev, a local docker build). */
+  readonly VITE_APP_VERSION?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Prompted directly: "¿ya desplegaste v0.11.0?" / "según mí sí" — nothing anywhere in the app said which version was actually running, so that question had no way to answer itself.

## What it does

Each image gets its release tag baked in at build time, from the same `github.ref_name` the release workflow already tags images with — no new source of truth, nothing to remember to bump by hand.

- **Backend**: `APP_VERSION` env var, set by the Dockerfile's `ARG VERSION` and read on every request — a running process can do that. Exposed via `GET /health` (for `curl`/infra checks) and in the `/settings` response (for the UI, no extra request).
- **Frontend**: a static bundle has no runtime environment to read this from later, so `VITE_APP_VERSION` gets inlined into the JS *at build time* — the only moment it's ever available.

Settings shows both, compared:

```
CaduTrack v0.11.0                                    ← agree
Frontend v0.11.0 · API v0.10.0 — no coinciden         ← flagged, in red
```

That second case is the one this is really for. Not just "which version is this" — "did a deploy that pulled one image and not the other just happen," which is exactly the kind of partial state that causes confusing bugs with no visible cause. It also renders before `/settings` ever loads (the frontend's own version needs no network call), so it's visible even when the backend is unreachable — one of the states this exists to diagnose.

## Verified past the unit tests

Built both images locally with `--build-arg VERSION=v-test-123`:

- Backend: `docker run --entrypoint env` shows `APP_VERSION=v-test-123` actually in the container's environment.
- Frontend: grepped the string directly out of the **compiled JS** in the built image (`grep -o 'v-test-123' /usr/share/nginx/html/assets/*.js`) — inlining is a build step that can silently no-op if the arg isn't wired the way the Dockerfile looks like it should, so I didn't want to trust that from reading the diff alone.
- Ran the built frontend image in a browser with no backend behind it at all, opened Settings, and saw **"CaduTrack v-test-123"** at the bottom — confirming the no-backend case renders correctly, not just the happy path.

## Tests

**Backend**: `/health` and `/settings` both covered for the real-version and `dev`-fallback cases. `ruff check` clean.

**Frontend**: a dedicated `version.test.ts` for the fallback (the only branch `vitest` can actually exercise — `VITE_APP_VERSION` is a build-time inlining, so the "real tag" branch is what the Docker verification above covers instead), plus three new `SettingsDialog` cases: versions agree, versions mismatch (exact text asserted), and the frontend-only footer before settings load. 186 backend / 195 frontend, `npm run lint && npm run build && npm test` in that order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)