### PR TITLE
feat: mark products as consumed and keep a history

### DIFF
--- a/backend/alembic/versions/2e871a12d0b8_add_product_consumed_at.py
+++ b/backend/alembic/versions/2e871a12d0b8_add_product_consumed_at.py
@@ -1,0 +1,31 @@
+"""add product consumed_at
+
+Revision ID: 2e871a12d0b8
+Revises: ebde07d3dd73
+Create Date: 2026-08-31 23:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2e871a12d0b8'
+down_revision: str | None = 'ebde07d3dd73'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('products', sa.Column('consumed_at', sa.DateTime(timezone=True), nullable=True), schema='cadutrack')
+    op.create_index(op.f('ix_cadutrack_products_consumed_at'), 'products', ['consumed_at'], unique=False, schema='cadutrack')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_cadutrack_products_consumed_at'), table_name='products', schema='cadutrack')
+    op.drop_column('products', 'consumed_at', schema='cadutrack')

--- a/backend/app/alerts.py
+++ b/backend/app/alerts.py
@@ -27,7 +27,8 @@ def products_needing_attention(
 
     Expired items are included deliberately. They are the ones most worth acting
     on, and the action — eat it or bin it and delete the row — is the same one
-    that stops them reappearing tomorrow.
+    that stops them reappearing tomorrow. A consumed item needs no such nudge:
+    it already left the fridge, by the tidier path.
     """
     if days_ahead is None:
         _enabled, _alert_time, days_ahead = read_only(session)
@@ -36,7 +37,7 @@ def products_needing_attention(
     statement = (
         select(Product)
         .options(selectinload(Product.category))
-        .where(Product.expires_at <= horizon)
+        .where(Product.expires_at <= horizon, Product.consumed_at.is_(None))
         .order_by(Product.expires_at, Product.name)
     )
     return list(session.execute(statement).scalars())

--- a/backend/app/models/product.py
+++ b/backend/app/models/product.py
@@ -95,6 +95,12 @@ class Product(Base):
         server_default=func.now(),
         server_onupdate=FetchedValue(),
     )
+    # NULL means active (in the fridge); set means consumed, moved to history.
+    # Indexed because every list view now filters on it, the same reason
+    # expires_at is indexed above.
+    consumed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
 
     category: Mapped[Category | None] = relationship(back_populates="products")
 

--- a/backend/app/routers/products.py
+++ b/backend/app/routers/products.py
@@ -4,7 +4,7 @@ import logging
 from datetime import date
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session, selectinload
 
 from app import icon_cache, icon_settings_store
@@ -66,6 +66,10 @@ def list_products(
         select(Product)
         # Without this the category of every row is a separate query.
         .options(selectinload(Product.category))
+        # Consumed products live in GET /products/history instead — a product
+        # marked consumed has left the fridge, so it has no business back in
+        # the list that represents what's currently in it.
+        .where(Product.consumed_at.is_(None))
         .order_by(Product.expires_at, Product.name)
     )
 
@@ -76,6 +80,25 @@ def list_products(
     if expires_before is not None:
         statement = statement.where(Product.expires_at < expires_before)
 
+    return list(db.execute(statement).scalars())
+
+
+@router.get("/history", response_model=list[ProductRead])
+def list_consumed_products(db: Session = Depends(get_db)) -> list[Product]:
+    """Consumed products, most recently consumed first.
+
+    Declared ahead of GET /{product_id} deliberately: Starlette matches routes
+    in registration order, and product_id's type annotation is only enforced
+    after a path already matched, so a later declaration here would have
+    "history" swallowed by {product_id} and rejected as a bad int instead of
+    ever reaching this function.
+    """
+    statement = (
+        select(Product)
+        .options(selectinload(Product.category))
+        .where(Product.consumed_at.is_not(None))
+        .order_by(Product.consumed_at.desc())
+    )
     return list(db.execute(statement).scalars())
 
 
@@ -205,6 +228,45 @@ def override_icon(product_id: int, payload: ProductIconUpdate, db: Session = Dep
     db.commit()
     db.refresh(product)
     logger.info("Set product %s (%s) icon to %r manually", product.id, product.name, payload.icon)
+    return product
+
+
+@router.post("/{product_id}/consume", response_model=ProductRead)
+def consume_product(product_id: int, db: Session = Depends(get_db)) -> Product:
+    """Mark a product as consumed, moving it from the active list to history.
+
+    Not a PATCH with a body: there is nothing to send, and the action is not
+    idempotent the way a value-setting PATCH is — see the 409 below, and
+    productsService.ts's consumeProduct, which is deliberately not retried for
+    the same reason as delete: a repeat that follows a success would 409, and
+    the user would be shown an error for an action that already worked.
+    """
+    product = _get_or_404(db, product_id)
+    if product.consumed_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Product is already marked as consumed"
+        )
+
+    product.consumed_at = func.now()
+    db.commit()
+    db.refresh(product)
+    logger.info("Marked product %s (%s) as consumed", product.id, product.name)
+    return product
+
+
+@router.post("/{product_id}/restore", response_model=ProductRead)
+def restore_product(product_id: int, db: Session = Depends(get_db)) -> Product:
+    """Undo a consumed mark, returning a product to the active list."""
+    product = _get_or_404(db, product_id)
+    if product.consumed_at is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Product is not marked as consumed"
+        )
+
+    product.consumed_at = None
+    db.commit()
+    db.refresh(product)
+    logger.info("Restored product %s (%s) from history", product.id, product.name)
     return product
 
 

--- a/backend/app/schemas/product.py
+++ b/backend/app/schemas/product.py
@@ -89,6 +89,10 @@ class ProductRead(ProductBase):
     icon_source: IconSource
     created_at: datetime
     updated_at: datetime
+    # Null while active. Set only by POST /products/{id}/consume, cleared only
+    # by POST /products/{id}/restore — never accepted on ProductCreate/Update
+    # for the same reason icon is kept off them (see ProductIconUpdate above).
+    consumed_at: datetime | None = None
 
     @computed_field
     @property

--- a/backend/tests/test_alerts.py
+++ b/backend/tests/test_alerts.py
@@ -99,6 +99,23 @@ def test_query_covers_expired_and_upcoming_but_not_the_distant_future(db_session
 
 
 @pytest.mark.integration
+def test_a_consumed_product_is_excluded_even_though_it_is_expired(db_session):
+    """A consumed item already left the fridge — it must not keep nagging
+    the daily alert after being checked off. See #31."""
+    from datetime import datetime, timezone
+
+    consumed = _product("Ya comido", -1)
+    consumed.consumed_at = datetime.now(timezone.utc)
+    db_session.add(consumed)
+    db_session.add(_product("Sin comer", -1))
+    db_session.commit()
+
+    found = products_needing_attention(db_session, days_ahead=7, reference=date(2026, 9, 1))
+
+    assert [p.name for p in found] == ["Sin comer"]
+
+
+@pytest.mark.integration
 def test_nothing_to_report_sends_nothing(db_session):
     """A daily "all good" message trains you to ignore the channel."""
     db_session.add(_product("Lejano", 90))

--- a/backend/tests/test_products_api.py
+++ b/backend/tests/test_products_api.py
@@ -143,6 +143,8 @@ def test_delete_removes_the_product(api_client):
         ("delete", "/products/9999"),
         ("patch", "/products/9999/quantity"),
         ("patch", "/products/9999/icon"),
+        ("post", "/products/9999/consume"),
+        ("post", "/products/9999/restore"),
     ],
 )
 def test_missing_product_is_404(api_client, method, path):
@@ -519,3 +521,101 @@ def test_reassign_reuses_the_normal_resolution_order_including_the_cache(api_cli
         refreshed = api_client.get(f"/products/{original['id']}").json()
         assert refreshed["icon"] == "\U0001F31F"
         assert refreshed["icon_source"] == "ai"
+
+
+# ── Consume / restore / history (#31) ────────────────────────────────────────
+
+
+def test_consuming_a_product_removes_it_from_the_active_list(api_client):
+    product_id = api_client.post("/products", json=_product()).json()["id"]
+
+    response = api_client.post(f"/products/{product_id}/consume")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["consumed_at"] is not None
+    assert api_client.get("/products").json() == []
+
+
+def test_a_newly_created_product_reports_consumed_at_as_null(api_client):
+    product = api_client.post("/products", json=_product()).json()
+    assert product["consumed_at"] is None
+
+
+def test_consuming_twice_is_rejected_rather_than_silently_reapplied(api_client):
+    """Mirrors delete's own non-retry stance (see productsService.ts): a
+    second consume is a real conflict, not a no-op, so a client that retries
+    blindly gets a clear signal instead of a quietly stale timestamp."""
+    product_id = api_client.post("/products", json=_product()).json()["id"]
+    api_client.post(f"/products/{product_id}/consume")
+
+    response = api_client.post(f"/products/{product_id}/consume")
+
+    assert response.status_code == 409
+
+
+def test_restoring_a_consumed_product_returns_it_to_the_active_list(api_client):
+    product_id = api_client.post("/products", json=_product()).json()["id"]
+    api_client.post(f"/products/{product_id}/consume")
+
+    response = api_client.post(f"/products/{product_id}/restore")
+
+    assert response.status_code == 200
+    assert response.json()["consumed_at"] is None
+    assert [p["id"] for p in api_client.get("/products").json()] == [product_id]
+
+
+def test_restoring_a_product_that_was_never_consumed_is_rejected(api_client):
+    product_id = api_client.post("/products", json=_product()).json()["id"]
+
+    response = api_client.post(f"/products/{product_id}/restore")
+
+    assert response.status_code == 409
+
+
+def test_history_lists_only_consumed_products_most_recent_first(api_client):
+    first = api_client.post("/products", json=_product(name="Yogur")).json()["id"]
+    second = api_client.post("/products", json=_product(name="Queso")).json()["id"]
+    api_client.post("/products", json=_product(name="Arroz"))  # left active
+
+    api_client.post(f"/products/{first}/consume")
+    api_client.post(f"/products/{second}/consume")
+
+    history = api_client.get("/products/history").json()
+
+    assert [p["id"] for p in history] == [second, first]
+    assert all(p["consumed_at"] is not None for p in history)
+
+
+def test_history_is_empty_until_something_is_consumed(api_client):
+    api_client.post("/products", json=_product())
+    assert api_client.get("/products/history").json() == []
+
+
+@pytest.mark.integration
+def test_consuming_actually_commits_not_just_the_in_session_object(api_client, db_session):
+    """Same reasoning as test_reassign_actually_commits above: api_client and
+    db_session share one SQLAlchemy session in this fixture, so only a fresh
+    read after expiring the identity map proves the UPDATE reached the
+    database rather than just this test's in-memory object."""
+    product_id = api_client.post("/products", json=_product()).json()["id"]
+
+    api_client.post(f"/products/{product_id}/consume")
+    db_session.expire_all()
+
+    assert api_client.get("/products/history").json()[0]["id"] == product_id
+
+
+def test_filters_still_apply_within_the_active_list_once_something_is_consumed(api_client):
+    """Guards against a filter clause accidentally undoing the consumed_at
+    exclusion by replacing rather than composing with it."""
+    today = date.today()
+    fridge_id = api_client.post(
+        "/products", json=_product(name="Yogur", location="fridge", expires_at=str(today + timedelta(days=3)))
+    ).json()["id"]
+    api_client.post(
+        "/products", json=_product(name="Arroz", location="pantry", expires_at=str(today + timedelta(days=200)))
+    )
+    api_client.post(f"/products/{fridge_id}/consume")
+
+    assert api_client.get("/products", params={"location": "fridge"}).json() == []

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -500,6 +500,48 @@
   font-weight: 600;
 }
 
+/* History */
+
+.product-history {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.product-history__row {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.625rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.product-history__row:last-child {
+  border-bottom: none;
+}
+
+.product-history__icon {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.product-history__details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.product-history__name {
+  font-weight: 600;
+}
+
+.product-history__meta {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
 /* Theme picker */
 
 .theme {

--- a/frontend/src/components/ProductCard.test.tsx
+++ b/frontend/src/components/ProductCard.test.tsx
@@ -7,11 +7,13 @@ import type { Product } from '@/services/types'
 vi.mock('@/services/productsService', () => ({
   adjustProductQuantity: vi.fn(),
   setProductIcon: vi.fn(),
+  consumeProduct: vi.fn(),
 }))
 
 const products = await import('@/services/productsService')
 const mockedAdjust = vi.mocked(products.adjustProductQuantity)
 const mockedSetIcon = vi.mocked(products.setProductIcon)
+const mockedConsume = vi.mocked(products.consumeProduct)
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -32,6 +34,7 @@ function product(overrides: Partial<Product> = {}): Product {
     icon_source: 'lookup',
     created_at: '2026-08-29T00:00:00Z',
     updated_at: '2026-08-29T00:00:00Z',
+    consumed_at: null,
     days_until_expiry: 5,
     status: 'expiring_soon',
     ...overrides,
@@ -40,6 +43,7 @@ function product(overrides: Partial<Product> = {}): Product {
 
 function renderCard(overrides: Partial<Product> = {}) {
   const onProductChanged = vi.fn()
+  const onConsumed = vi.fn()
   render(
     <ul>
       <ProductCard
@@ -47,10 +51,11 @@ function renderCard(overrides: Partial<Product> = {}) {
         onEdit={vi.fn()}
         onDelete={vi.fn()}
         onProductChanged={onProductChanged}
+        onConsumed={onConsumed}
       />
     </ul>,
   )
-  return { onProductChanged }
+  return { onProductChanged, onConsumed }
 }
 
 describe('ProductCard quantity stepper', () => {
@@ -274,5 +279,45 @@ describe('ProductCard icon override', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
     expect(onProductChanged).not.toHaveBeenCalled()
     expect(screen.getByRole('button', { name: /cambiar icono de Plátano/i })).toHaveTextContent('\u{1F34C}')
+  })
+})
+
+describe('ProductCard consume action', () => {
+  it('calls the API and notifies the parent with the product id', async () => {
+    mockedConsume.mockResolvedValue(product({ consumed_at: '2026-08-31T12:00:00Z' }))
+    const { onConsumed } = renderCard()
+
+    fireEvent.click(screen.getByRole('button', { name: /marcar plátano como consumido/i }))
+
+    await waitFor(() => expect(onConsumed).toHaveBeenCalledWith(1))
+    expect(mockedConsume).toHaveBeenCalledWith(1)
+  })
+
+  it('disables the button while the request is in flight', async () => {
+    let resolveRequest: (product: Product) => void = () => {}
+    mockedConsume.mockReturnValue(
+      new Promise<Product>((resolve) => {
+        resolveRequest = resolve
+      }),
+    )
+    renderCard()
+
+    fireEvent.click(screen.getByRole('button', { name: /marcar plátano como consumido/i }))
+
+    expect(screen.getByRole('button', { name: /marcar plátano como consumido/i })).toBeDisabled()
+    resolveRequest(product({ consumed_at: '2026-08-31T12:00:00Z' }))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /marcar plátano como consumido/i })).not.toBeDisabled(),
+    )
+  })
+
+  it('shows the failure inline and does not notify the parent', async () => {
+    mockedConsume.mockRejectedValue(new Error('nope'))
+    const { onConsumed } = renderCard()
+
+    fireEvent.click(screen.getByRole('button', { name: /marcar plátano como consumido/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
+    expect(onConsumed).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -4,7 +4,7 @@ import { IconPicker } from '@/components/IconPicker'
 import { LOCATION_LABELS, expiryPhrase, quantityLabel } from '@/labels'
 import { canStepDown } from '@/quantity'
 import { toErrorMessage } from '@/services/api'
-import { adjustProductQuantity, setProductIcon } from '@/services/productsService'
+import { adjustProductQuantity, consumeProduct, setProductIcon } from '@/services/productsService'
 import type { Product } from '@/services/types'
 
 interface ProductCardProps {
@@ -14,16 +14,22 @@ interface ProductCardProps {
   /** Called with the server's own response after a successful quantity tap or
    *  icon change, so the list can update that one row without a full reload. */
   onProductChanged: (updated: Product) => void
+  /** Called with the id after a successful consume — the row leaves the
+   *  active list entirely rather than being updated in place. */
+  onConsumed: (id: number) => void
 }
 
 /** One product row: what it is, how much, where, and how urgent. */
-export function ProductCard({ product, onEdit, onDelete, onProductChanged }: ProductCardProps) {
+export function ProductCard({ product, onEdit, onDelete, onProductChanged, onConsumed }: ProductCardProps) {
   const [adjustingQuantity, setAdjustingQuantity] = useState(false)
   const [quantityError, setQuantityError] = useState<string | null>(null)
 
   const [editingIcon, setEditingIcon] = useState(false)
   const [savingIcon, setSavingIcon] = useState(false)
   const [iconError, setIconError] = useState<string | null>(null)
+
+  const [consuming, setConsuming] = useState(false)
+  const [consumeError, setConsumeError] = useState<string | null>(null)
 
   const adjustQuantity = (delta: 1 | -1) => {
     setAdjustingQuantity(true)
@@ -57,6 +63,21 @@ export function ProductCard({ product, onEdit, onDelete, onProductChanged }: Pro
         setIconError(toErrorMessage(caught))
       } finally {
         setSavingIcon(false)
+      }
+    })()
+  }
+
+  const handleConsume = () => {
+    setConsuming(true)
+    setConsumeError(null)
+    void (async () => {
+      try {
+        await consumeProduct(product.id)
+        onConsumed(product.id)
+      } catch (caught) {
+        setConsumeError(toErrorMessage(caught))
+      } finally {
+        setConsuming(false)
       }
     })()
   }
@@ -132,6 +153,11 @@ export function ProductCard({ product, onEdit, onDelete, onProductChanged }: Pro
             {iconError}
           </p>
         )}
+        {consumeError && (
+          <p className="product-card__quantity-error" role="alert">
+            {consumeError}
+          </p>
+        )}
         {product.notes && <p className="product-card__notes">{product.notes}</p>}
       </div>
 
@@ -140,6 +166,15 @@ export function ProductCard({ product, onEdit, onDelete, onProductChanged }: Pro
           <time dateTime={product.expires_at}>{expiryPhrase(product.days_until_expiry)}</time>
         </p>
         <div className="product-card__actions">
+          <button
+            type="button"
+            className="button--icon"
+            onClick={handleConsume}
+            disabled={consuming}
+            aria-label={`Marcar ${product.name} como consumido`}
+          >
+            {consuming ? 'Marcando…' : 'Consumido'}
+          </button>
           <button
             type="button"
             className="button--icon"

--- a/frontend/src/components/ProductForm.test.tsx
+++ b/frontend/src/components/ProductForm.test.tsx
@@ -98,6 +98,7 @@ describe('ProductForm quantity stepper', () => {
       icon_source: 'lookup',
       created_at: '2026-08-29T00:00:00Z',
       updated_at: '2026-08-29T00:00:00Z',
+      consumed_at: null,
       days_until_expiry: 5,
       status: 'expiring_soon',
     }

--- a/frontend/src/components/ProductHistory.test.tsx
+++ b/frontend/src/components/ProductHistory.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ProductHistory } from '@/components/ProductHistory'
+import type { Product } from '@/services/types'
+
+vi.mock('@/services/productsService', () => ({
+  listConsumedProducts: vi.fn(),
+  restoreProduct: vi.fn(),
+}))
+
+const products = await import('@/services/productsService')
+const mockedHistory = vi.mocked(products.listConsumedProducts)
+const mockedRestore = vi.mocked(products.restoreProduct)
+
+function product(overrides: Partial<Product> = {}): Product {
+  return {
+    id: 1,
+    name: 'Yogur',
+    category_id: null,
+    quantity: '1.00',
+    unit: null,
+    expires_at: '2026-08-25',
+    location: 'fridge',
+    notes: null,
+    category: null,
+    icon: '\u{1F95B}',
+    icon_source: 'lookup',
+    created_at: '2026-08-20T00:00:00Z',
+    updated_at: '2026-08-20T00:00:00Z',
+    consumed_at: '2026-08-24T15:30:00Z',
+    days_until_expiry: -6,
+    status: 'expired',
+    ...overrides,
+  }
+}
+
+function renderHistory() {
+  const onClose = vi.fn()
+  const onRestored = vi.fn()
+  render(<ProductHistory onClose={onClose} onRestored={onRestored} />)
+  return { onClose, onRestored }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ProductHistory', () => {
+  it('lists every consumed product with its quantity', async () => {
+    mockedHistory.mockResolvedValue([product({ name: 'Yogur', quantity: '2.00' })])
+
+    renderHistory()
+
+    expect(await screen.findByText('Yogur')).toBeInTheDocument()
+    expect(screen.getByText(/^2 ·/)).toBeInTheDocument()
+  })
+
+  it('shows an empty message when nothing has been consumed', async () => {
+    mockedHistory.mockResolvedValue([])
+
+    renderHistory()
+
+    expect(await screen.findByText('Todavía no has marcado nada como consumido.')).toBeInTheDocument()
+  })
+
+  it('shows a readable error when the request fails', async () => {
+    mockedHistory.mockRejectedValue(new Error('boom'))
+
+    renderHistory()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
+  })
+
+  it('restores a product and removes it from this list', async () => {
+    mockedHistory.mockResolvedValue([product({ id: 5, name: 'Queso' })])
+    mockedRestore.mockResolvedValue(product({ id: 5, name: 'Queso', consumed_at: null }))
+    const { onRestored } = renderHistory()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Restaurar Queso' }))
+
+    await waitFor(() => expect(mockedRestore).toHaveBeenCalledWith(5))
+    await waitFor(() => expect(screen.queryByText('Queso')).not.toBeInTheDocument())
+    expect(onRestored).toHaveBeenCalled()
+  })
+
+  it('shows the failure inline and leaves the row in place', async () => {
+    mockedHistory.mockResolvedValue([product({ id: 5, name: 'Queso' })])
+    mockedRestore.mockRejectedValue(new Error('nope'))
+    const { onRestored } = renderHistory()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Restaurar Queso' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
+    expect(screen.getByText('Queso')).toBeInTheDocument()
+    expect(onRestored).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/ProductHistory.tsx
+++ b/frontend/src/components/ProductHistory.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from 'react'
+
+import { Modal } from '@/components/Modal'
+import { quantityLabel } from '@/labels'
+import { toErrorMessage } from '@/services/api'
+import { listConsumedProducts, restoreProduct } from '@/services/productsService'
+import type { Product } from '@/services/types'
+
+interface ProductHistoryProps {
+  onClose: () => void
+  /** Called after a successful restore, so the active list behind this dialog
+   *  picks up the returning product instead of showing a stale list until
+   *  something else triggers a reload — same pattern as SettingsDialog's
+   *  onIconsReassigned. */
+  onRestored: () => void
+}
+
+/**
+ * When a product was consumed, in the viewer's own local time.
+ *
+ * Unlike SettingsDialog's next-alert time, which means server time and must
+ * stay in the server's zone to match the hour picker next to it, this
+ * timestamp records the moment the viewer tapped a button on their own
+ * device — their own zone is the correct one to show it in.
+ */
+function formatConsumedAt(iso: string): string {
+  return new Date(iso).toLocaleString('es-MX', {
+    day: 'numeric',
+    month: 'long',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+/** History of consumed products, with a way to undo a mistaken tap. See #31. */
+export function ProductHistory({ onClose, onRestored }: ProductHistoryProps) {
+  const [products, setProducts] = useState<Product[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [restoringId, setRestoringId] = useState<number | null>(null)
+  const [restoreError, setRestoreError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    void (async () => {
+      try {
+        const data = await listConsumedProducts()
+        if (active) setProducts(data)
+      } catch (caught) {
+        if (active) setError(toErrorMessage(caught))
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const handleRestore = (product: Product) => {
+    setRestoringId(product.id)
+    setRestoreError(null)
+    void (async () => {
+      try {
+        await restoreProduct(product.id)
+        setProducts((current) => current?.filter((candidate) => candidate.id !== product.id) ?? null)
+        onRestored()
+      } catch (caught) {
+        setRestoreError(toErrorMessage(caught))
+      } finally {
+        setRestoringId(null)
+      }
+    })()
+  }
+
+  return (
+    <Modal title="Historial de consumidos" onClose={onClose}>
+      {products === null && !error && <p className="state state--loading">Cargando…</p>}
+
+      {error && (
+        <p className="form__error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {products !== null && products.length === 0 && (
+        <p className="state state--empty">Todavía no has marcado nada como consumido.</p>
+      )}
+
+      {products !== null && products.length > 0 && (
+        <ul className="product-history">
+          {products.map((product) => (
+            <li key={product.id} className="product-history__row">
+              <span className="product-history__icon" aria-hidden="true">
+                {product.icon}
+              </span>
+              <span className="product-history__details">
+                <span className="product-history__name">{product.name}</span>
+                <span className="product-history__meta">
+                  {quantityLabel(product.quantity, product.unit)}
+                  {/* consumed_at is never null for a row returned by
+                      /products/history — see the backend endpoint. */}
+                  {product.consumed_at && ` · ${formatConsumedAt(product.consumed_at)}`}
+                </span>
+              </span>
+              <button
+                type="button"
+                className="button--icon"
+                onClick={() => handleRestore(product)}
+                disabled={restoringId === product.id}
+                aria-label={`Restaurar ${product.name}`}
+              >
+                {restoringId === product.id ? 'Restaurando…' : 'Restaurar'}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {restoreError && (
+        <p className="form__error" role="alert">
+          {restoreError}
+        </p>
+      )}
+    </Modal>
+  )
+}

--- a/frontend/src/filters.test.ts
+++ b/frontend/src/filters.test.ts
@@ -18,6 +18,7 @@ function product(overrides: Partial<Product> = {}): Product {
     icon_source: 'lookup',
     created_at: '2026-08-29T00:00:00Z',
     updated_at: '2026-08-29T00:00:00Z',
+    consumed_at: null,
     days_until_expiry: 5,
     status: 'expiring_soon',
     ...overrides,

--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -21,6 +21,14 @@ interface UseProductsResult {
    * that only ever touches one row and one field.
    */
   replaceProduct: (updated: Product) => void
+  /**
+   * Drop one product from the list without a full reload.
+   *
+   * Built for marking a product consumed: unlike a quantity or icon change,
+   * the row does not get updated in place, it leaves the active list
+   * entirely — replaceProduct would have nowhere to put it back.
+   */
+  removeProduct: (id: number) => void
 }
 
 /**
@@ -102,5 +110,9 @@ export function useProducts(filters: ProductFilters = {}): UseProductsResult {
     setProducts((current) => current.map((product) => (product.id === updated.id ? updated : product)))
   }, [])
 
-  return { products, loading, error, cachedAt, reload, replaceProduct }
+  const removeProduct = useCallback((id: number) => {
+    setProducts((current) => current.filter((product) => product.id !== id))
+  }, [])
+
+  return { products, loading, error, cachedAt, reload, replaceProduct, removeProduct }
 }

--- a/frontend/src/pages/ProductList.test.tsx
+++ b/frontend/src/pages/ProductList.test.tsx
@@ -11,6 +11,9 @@ vi.mock('@/services/productsService', () => ({
   deleteProduct: vi.fn(),
   adjustProductQuantity: vi.fn(),
   setProductIcon: vi.fn(),
+  consumeProduct: vi.fn(),
+  listConsumedProducts: vi.fn(),
+  restoreProduct: vi.fn(),
 }))
 
 vi.mock('@/services/categoriesService', () => ({
@@ -24,6 +27,9 @@ const mockedList = vi.mocked(products.listProducts)
 const mockedCreate = vi.mocked(products.createProduct)
 const mockedReplace = vi.mocked(products.replaceProduct)
 const mockedDelete = vi.mocked(products.deleteProduct)
+const mockedConsume = vi.mocked(products.consumeProduct)
+const mockedHistory = vi.mocked(products.listConsumedProducts)
+const mockedRestore = vi.mocked(products.restoreProduct)
 const mockedCategories = vi.mocked(categories.listCategories)
 
 function product(overrides: Partial<Product> = {}): Product {
@@ -41,6 +47,7 @@ function product(overrides: Partial<Product> = {}): Product {
     icon_source: 'lookup',
     created_at: '2026-08-29T00:00:00Z',
     updated_at: '2026-08-29T00:00:00Z',
+    consumed_at: null,
     days_until_expiry: 5,
     status: 'expiring_soon',
     ...overrides,
@@ -256,6 +263,57 @@ describe('deleting a product', () => {
 
     await waitFor(() => expect(mockedDelete).toHaveBeenCalledWith(1))
     await waitFor(() => expect(mockedList).toHaveBeenCalledTimes(2))
+  })
+})
+
+describe('consuming a product', () => {
+  it('removes the card from the list without a full reload', async () => {
+    mockedList.mockResolvedValue({ products: [product()], cachedAt: null })
+    mockedConsume.mockResolvedValue(product({ consumed_at: '2026-08-31T12:00:00Z' }))
+
+    render(<ProductList />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Marcar Leche entera como consumido' }))
+
+    await waitFor(() => expect(mockedConsume).toHaveBeenCalledWith(1))
+    expect(screen.queryByText('Leche entera')).not.toBeInTheDocument()
+    // No dialog opens for this action, and nothing refetches the list — the
+    // row leaving is proof enough, a second listProducts call would mean it
+    // took the reload path instead of the local removal one.
+    expect(mockedList).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('viewing history', () => {
+  it('lists consumed products and restores one back to the active list', async () => {
+    mockedList.mockResolvedValue({ products: [], cachedAt: null })
+    mockedHistory.mockResolvedValue([
+      product({ id: 9, name: 'Yogur caducado', consumed_at: '2026-08-30T09:00:00Z' }),
+    ])
+    mockedRestore.mockResolvedValue(product({ id: 9, name: 'Yogur caducado', consumed_at: null }))
+
+    render(<ProductList />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Historial' }))
+
+    expect(await screen.findByText('Yogur caducado')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restaurar Yogur caducado' }))
+
+    await waitFor(() => expect(mockedRestore).toHaveBeenCalledWith(9))
+    // Restoring a history row must refresh the active list behind the dialog,
+    // same as SettingsDialog's onIconsReassigned — otherwise the product
+    // reappears in history's own list but stays invisible in the fridge view
+    // until something unrelated happens to trigger a reload.
+    await waitFor(() => expect(mockedList).toHaveBeenCalledTimes(2))
+  })
+
+  it('shows an empty message when nothing has been consumed yet', async () => {
+    mockedList.mockResolvedValue({ products: [], cachedAt: null })
+    mockedHistory.mockResolvedValue([])
+
+    render(<ProductList />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Historial' }))
+
+    expect(await screen.findByText('Todavía no has marcado nada como consumido.')).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/pages/ProductList.tsx
+++ b/frontend/src/pages/ProductList.tsx
@@ -4,6 +4,7 @@ import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { ProductCard } from '@/components/ProductCard'
 import { ProductFilters } from '@/components/ProductFilters'
 import { ProductForm } from '@/components/ProductForm'
+import { ProductHistory } from '@/components/ProductHistory'
 import { StaleBanner } from '@/components/StaleBanner'
 import { SettingsDialog } from '@/components/SettingsDialog'
 import {
@@ -27,10 +28,11 @@ type Dialog =
   | { kind: 'edit'; product: Product }
   | { kind: 'delete'; product: Product }
   | { kind: 'settings' }
+  | { kind: 'history' }
 
 /** Main screen: everything in the house, soonest to expire first. */
 export function ProductList() {
-  const { products, loading, error, cachedAt, reload, replaceProduct } = useProducts()
+  const { products, loading, error, cachedAt, reload, replaceProduct, removeProduct } = useProducts()
   const categories = useCategories()
   const [dialog, setDialog] = useState<Dialog>({ kind: 'none' })
   const [deleting, setDeleting] = useState(false)
@@ -72,6 +74,9 @@ export function ProductList() {
   return (
     <>
       <div className="list-header">
+        <button type="button" onClick={() => setDialog({ kind: 'history' })}>
+          Historial
+        </button>
         <button type="button" onClick={() => setDialog({ kind: 'settings' })}>
           Ajustes
         </button>
@@ -138,6 +143,7 @@ export function ProductList() {
                   onEdit={(target) => setDialog({ kind: 'edit', product: target })}
                   onDelete={(target) => setDialog({ kind: 'delete', product: target })}
                   onProductChanged={replaceProduct}
+                  onConsumed={removeProduct}
                 />
               ))}
             </ul>
@@ -159,6 +165,8 @@ export function ProductList() {
       )}
 
       {dialog.kind === 'settings' && <SettingsDialog onClose={close} onIconsReassigned={reload} />}
+
+      {dialog.kind === 'history' && <ProductHistory onClose={close} onRestored={reload} />}
 
       {dialog.kind === 'delete' && (
         <ConfirmDialog

--- a/frontend/src/services/productsService.ts
+++ b/frontend/src/services/productsService.ts
@@ -60,6 +60,34 @@ export async function deleteProduct(id: number): Promise<void> {
 }
 
 /**
+ * Consumed products, most recently consumed first. See #31.
+ */
+export async function listConsumedProducts(): Promise<Product[]> {
+  const { data } = await api.get<Product[]>('/products/history')
+  return data
+}
+
+/**
+ * Mark a product as consumed, moving it from the active list to history.
+ *
+ * Not retried, on the same reasoning as deleteProduct above: a repeat that
+ * follows a consume which actually succeeded gets a 409 (the backend rejects
+ * consuming an already-consumed product), and the user would be shown an
+ * error for an action that worked.
+ */
+export async function consumeProduct(id: number): Promise<Product> {
+  const { data } = await api.post<Product>(`/products/${id}/consume`)
+  return data
+}
+
+/** Undo a consumed mark, returning a product to the active list. Not
+ *  retried, for the same reason as consumeProduct. */
+export async function restoreProduct(id: number): Promise<Product> {
+  const { data } = await api.post<Product>(`/products/${id}/restore`)
+  return data
+}
+
+/**
  * Adjust a product's quantity by a relative amount — never an absolute value,
  * so two taps racing on a slow connection compose correctly regardless of
  * arrival order. See the backend's ProductQuantityDelta and #82.

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -32,6 +32,9 @@ export interface Product {
   icon_source: IconSource
   created_at: string
   updated_at: string
+  /** Null while active. Set only by POST /products/{id}/consume, cleared only
+   *  by POST /products/{id}/restore — see productsService.ts. */
+  consumed_at: string | null
   /** Negative once expired. */
   days_until_expiry: number
   status: ExpiryStatus
@@ -46,7 +49,15 @@ export interface ProductFilters {
 
 export type ProductPayload = Omit<
   Product,
-  'id' | 'category' | 'icon' | 'icon_source' | 'created_at' | 'updated_at' | 'days_until_expiry' | 'status'
+  | 'id'
+  | 'category'
+  | 'icon'
+  | 'icon_source'
+  | 'created_at'
+  | 'updated_at'
+  | 'consumed_at'
+  | 'days_until_expiry'
+  | 'status'
 >
 
 export interface AlertSettings {


### PR DESCRIPTION
## Summary
- Adds `consumed_at` to `Product` (null = active). New `POST /products/{id}/consume` and `POST /products/{id}/restore`, plus `GET /products/history`.
- The active list (`GET /products`) and the daily Telegram alert now exclude consumed products — a consumed item has already left the fridge, so it shouldn't keep nagging.
- Frontend: a "Consumido" button on each card removes the row from the active list without a full reload; a new "Historial" screen lists consumed products with a "Restaurar" undo.
- `consume`/`restore` are not retried on the client, same reasoning as `delete`: a repeat after a success would 409, and the user would see an error for an action that already worked.

Closes #31.

## Test plan
- [x] Backend: `pytest` — 198 passed (12 new), against a real disposable Postgres database (`cadutrack_test`), including a "consuming twice is rejected", a "restoring something never consumed is rejected", and an "actually commits, not just the in-session object" test mirroring the existing icon-reassign one.
- [x] Backend: `ruff check` clean.
- [x] Frontend: `vitest` — 206 passed (11 new: `ProductCard` consume action, `ProductHistory` component, `ProductList` consume + history integration).
- [x] Frontend: `tsc -b` and `eslint` clean.
- [x] Live end-to-end against the real running API: create → active list → consume → excluded from active list, present in history → double-consume rejected (409) → restore → back in the active list, history empty.
- [x] Confirmed via the real dev server + real backend that the rendered DOM matches (button labels, aria-labels, live product data) after the API round-trip above.