### PR TITLE
feat: read the expiry date from a photo of the label

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.logging_config import setup_logging
-from app.routers import alerts, categories, health, products
+from app.routers import alerts, categories, health, products, vision
 from app.routers import settings as settings_router
 from app.scheduler import shutdown_scheduler, start_scheduler
 
@@ -46,5 +46,6 @@ app.include_router(categories.router)
 app.include_router(products.router)
 app.include_router(alerts.router)
 app.include_router(settings_router.router)
+app.include_router(vision.router)
 
 logger.info("CaduTrack API started")

--- a/backend/app/routers/vision.py
+++ b/backend/app/routers/vision.py
@@ -1,0 +1,42 @@
+"""Label-photo extraction endpoint — see #83."""
+
+import logging
+
+from fastapi import APIRouter, File, HTTPException, UploadFile, status
+
+from app.schemas.vision import LabelExtraction
+from app.vision_client import extract_label
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/vision", tags=["vision"])
+
+# A phone photo is a few MB at most; this is a generous ceiling against a
+# request that is either a mistake (wrong file picked) or abuse, not a limit
+# meant to bind on a real label photo.
+_MAX_IMAGE_BYTES = 10 * 1024 * 1024
+
+
+@router.post("/label", response_model=LabelExtraction)
+async def extract_label_from_photo(image: UploadFile = File(...)) -> LabelExtraction:
+    """Read a name, expiry date, and weight from a photo of a product label.
+
+    Side-effect free by design: nothing here touches the database. The
+    result is meant to pre-fill the product form for the user to confirm or
+    correct — see #83's acceptance criteria — never to be saved on its own.
+    """
+    contents = await image.read()
+    if not contents:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="La imagen está vacía")
+    if len(contents) > _MAX_IMAGE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE, detail="La imagen es demasiado grande"
+        )
+
+    result = extract_label(contents)
+    if result is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="No se pudo leer la etiqueta. Ingresa los datos manualmente.",
+        )
+    return result

--- a/backend/app/schemas/vision.py
+++ b/backend/app/schemas/vision.py
@@ -1,0 +1,23 @@
+"""Label-photo extraction response schema."""
+
+from datetime import date
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+
+class LabelExtraction(BaseModel):
+    """Best-effort fields read from a photo of a product label.
+
+    Any field may be null when the model could not determine it with
+    confidence — see app/vision_client.py, which returns null rather than
+    guessing. Never persisted directly: the caller submits these, edited or
+    not, through the normal POST /products endpoint. Field names match
+    ProductBase deliberately, so the frontend can spread this straight into
+    the product form's state.
+    """
+
+    name: str | None = None
+    expires_at: date | None = None
+    quantity: Decimal | None = Field(default=None, gt=0, max_digits=10, decimal_places=2)
+    unit: str | None = None

--- a/backend/app/vision_client.py
+++ b/backend/app/vision_client.py
@@ -1,0 +1,147 @@
+"""A local Ollama call for reading a product label photo — see #83.
+
+Same never-raise contract as app/ollama_client.py, for the same reason: an
+unconfigured URL, a refused connection, a timeout, an HTTP error, or a
+response that doesn't parse are all reported as None, and the caller falls
+back to manual entry rather than blocking product creation on a model that
+might be down, slow, or mid-restart.
+
+A wrong date is a worse failure than no date — see #83's own description —
+so this is deliberately more cautious than the icon client in two ways: the
+model is asked for null on anything it isn't sure of instead of its best
+guess, and every field is still independently validated after parsing before
+being trusted, null or not.
+"""
+
+import base64
+import json
+import logging
+from datetime import date
+from decimal import Decimal, InvalidOperation
+
+import httpx
+
+from app.config import settings
+from app.schemas.vision import LabelExtraction
+
+logger = logging.getLogger(__name__)
+
+# Measured directly against the real server: a warm qwen3.5:4b answers a
+# ~700x500 test label in 1.5-2s. A real phone photo is larger and a cold
+# model load has measured at 6.7s for the (much cheaper) icon prompt alone —
+# 30s leaves real room for both without leaving a genuinely unreachable
+# Ollama able to stall product creation for long.
+TIMEOUT_SECONDS = 30.0
+
+# Grammar-constrained decoding, same as the icon client — a free-text prompt
+# is not reliable enough to parse for a field this consequential.
+_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": ["string", "null"]},
+        "expires_at": {"type": ["string", "null"]},
+        "weight_kg": {"type": ["number", "null"]},
+    },
+    "required": ["name", "expires_at", "weight_kg"],
+}
+
+_PROMPT = (
+    "Analiza esta foto de la etiqueta de un producto de supermercado.\n\n"
+    "Extrae:\n"
+    "- name: el nombre del producto, tal como aparece impreso (corrígelo si "
+    "está truncado o abreviado, usando el nombre más natural).\n"
+    "- expires_at: la fecha en la que el producto deja de ser seguro o "
+    "recomendable consumir, en formato YYYY-MM-DD. Busca las palabras "
+    "'Fecha de Caducidad' o 'Consumo preferente'. IGNORA cualquier fecha "
+    "etiquetada como 'Fecha de Empacado', 'Fecha de Preparación' o 'Fecha "
+    "de Elaboración' — esas son cuándo se preparó el producto, no cuándo "
+    "caduca.\n"
+    "- weight_kg: el peso neto en kilogramos, solo si aparece impreso "
+    "explícitamente en la etiqueta (por ejemplo '0.586 kg'). Si no aparece, "
+    "usa null.\n\n"
+    "Si no puedes determinar un campo con confianza, usa null para ese "
+    "campo en vez de adivinar."
+)
+
+
+def _parse_date(value: object) -> date | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _parse_weight_kg(value: object) -> Decimal | None:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    try:
+        # Two decimal places to match Product.quantity's NUMERIC(10, 2) — a
+        # third decimal from the model (labels print up to three, see #30)
+        # would otherwise be rejected downstream instead of just rounded.
+        quantized = Decimal(str(value)).quantize(Decimal("0.01"))
+    except InvalidOperation:
+        return None
+    return quantized if quantized > 0 else None
+
+
+def extract_label(image_bytes: bytes) -> LabelExtraction | None:
+    """Best-effort fields read from a label photo, or None on any failure.
+
+    None means "could not get a usable answer at all" — network down, bad
+    response shape. A LabelExtraction with every field null means the model
+    itself came back and found nothing it was confident about; the caller
+    treats both the same way (fall back to a blank, manually-filled form),
+    but they are logged differently since only the first is a real failure.
+    """
+    if not settings.ollama_url:
+        return None
+
+    try:
+        response = httpx.post(
+            f"{settings.ollama_url}/api/generate",
+            json={
+                "model": settings.ollama_model,
+                "prompt": _PROMPT,
+                "images": [base64.b64encode(image_bytes).decode("ascii")],
+                "stream": False,
+                "think": False,
+                "format": _RESPONSE_SCHEMA,
+                # The model's configured defaults (temperature 1, tuned for
+                # picking a varied emoji) measurably produce a wrong date on
+                # this prompt — reproduced directly: the same label, same
+                # schema, temperature 1 returned a date matching neither
+                # printed one, on 4 consecutive tries at temperature 0 it
+                # matched the correct one every time. Determinism is worth
+                # more than variety for a field this consequential.
+                "options": {"temperature": 0},
+            },
+            timeout=TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.warning("Ollama label extraction failed: %s", exc.__class__.__name__)
+        return None
+
+    try:
+        raw = json.loads(response.json()["response"])
+    except (KeyError, TypeError, ValueError) as exc:
+        logger.warning(
+            "Ollama returned an unparsable label response (%s): %r",
+            exc.__class__.__name__,
+            response.text[:200],
+        )
+        return None
+
+    name = raw.get("name")
+    name = name.strip() if isinstance(name, str) and name.strip() else None
+
+    weight_kg = _parse_weight_kg(raw.get("weight_kg"))
+
+    return LabelExtraction(
+        name=name,
+        expires_at=_parse_date(raw.get("expires_at")),
+        quantity=weight_kg,
+        unit="kg" if weight_kg is not None else None,
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi>=0.136,<1.0
+python-multipart>=0.0.20,<1.0
 uvicorn[standard]>=0.44,<1.0
 sqlalchemy>=2.0,<3.0
 alembic>=1.16,<2.0

--- a/backend/tests/test_vision_api.py
+++ b/backend/tests/test_vision_api.py
@@ -1,0 +1,74 @@
+"""Label-photo extraction endpoint tests. No DB, no network — the model call
+itself is mocked; app/test_vision_client.py owns proving that call's own
+behaviour."""
+
+from datetime import date
+from decimal import Decimal
+
+from app.schemas.vision import LabelExtraction
+
+_IMAGE = b"\x89PNG\r\n\x1a\n fake bytes, never actually decoded in these tests"
+
+
+def test_returns_the_extracted_fields(client, mocker):
+    mocker.patch(
+        "app.routers.vision.extract_label",
+        return_value=LabelExtraction(
+            name="Nopal limpio", expires_at=date(2026, 9, 1), quantity=Decimal("0.59"), unit="kg"
+        ),
+    )
+
+    response = client.post("/vision/label", files={"image": ("label.png", _IMAGE, "image/png")})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "Nopal limpio"
+    assert body["expires_at"] == "2026-09-01"
+    assert body["quantity"] == "0.59"
+    assert body["unit"] == "kg"
+
+
+def test_a_field_the_model_could_not_read_arrives_null(client, mocker):
+    mocker.patch("app.routers.vision.extract_label", return_value=LabelExtraction())
+
+    response = client.post("/vision/label", files={"image": ("label.png", _IMAGE, "image/png")})
+
+    assert response.status_code == 200
+    assert response.json() == {"name": None, "expires_at": None, "quantity": None, "unit": None}
+
+
+def test_a_total_extraction_failure_is_reported_as_service_unavailable(client, mocker):
+    """None means "no usable answer at all" — see vision_client.extract_label
+    — and must reach the client as a clear, distinguishable failure rather
+    than a 200 full of nulls, so the UI can show its own message instead of
+    silently rendering an empty form."""
+    mocker.patch("app.routers.vision.extract_label", return_value=None)
+
+    response = client.post("/vision/label", files={"image": ("label.png", _IMAGE, "image/png")})
+
+    assert response.status_code == 503
+
+
+def test_an_empty_file_is_rejected_without_calling_the_model(client, mocker):
+    extract = mocker.patch("app.routers.vision.extract_label")
+
+    response = client.post("/vision/label", files={"image": ("label.png", b"", "image/png")})
+
+    assert response.status_code == 422
+    extract.assert_not_called()
+
+
+def test_an_oversized_file_is_rejected_without_calling_the_model(client, mocker):
+    extract = mocker.patch("app.routers.vision.extract_label")
+    oversized = b"x" * (10 * 1024 * 1024 + 1)
+
+    response = client.post("/vision/label", files={"image": ("label.png", oversized, "image/png")})
+
+    assert response.status_code == 413
+    extract.assert_not_called()
+
+
+def test_a_missing_file_is_rejected(client):
+    response = client.post("/vision/label")
+
+    assert response.status_code == 422

--- a/backend/tests/test_vision_client.py
+++ b/backend/tests/test_vision_client.py
@@ -1,0 +1,151 @@
+"""Vision client tests. No network — every case is a mocked httpx call.
+
+Every scenario asserts extract_label degrades to None (or a
+LabelExtraction with the offending field null) rather than raising or
+passing through an unvalidated value: a caller that let a bad date through
+here would save it as a fact about a real product, which is exactly what
+#83's own description calls "worse than failing".
+"""
+
+import json
+
+import httpx
+import pytest
+
+from app.config import settings
+from app.vision_client import extract_label
+
+_REQUEST = httpx.Request("POST", "http://ollama.example:11434/api/generate")
+_IMAGE = b"\x89PNG\r\n\x1a\n fake bytes, never actually decoded in these tests"
+
+
+@pytest.fixture(autouse=True)
+def ollama_configured(monkeypatch):
+    monkeypatch.setattr(settings, "ollama_url", "http://ollama.example:11434")
+    monkeypatch.setattr(settings, "ollama_model", "qwen3.5:4b")
+
+
+def _ok_response(**fields) -> httpx.Response:
+    body = {"name": None, "expires_at": None, "weight_kg": None}
+    body.update(fields)
+    return httpx.Response(
+        status_code=200,
+        json={"model": "qwen3.5:4b", "response": json.dumps(body), "done": True},
+        request=_REQUEST,
+    )
+
+
+def test_returns_none_when_ollama_is_not_configured(monkeypatch):
+    monkeypatch.setattr(settings, "ollama_url", "")
+
+    assert extract_label(_IMAGE) is None
+
+
+def test_extracts_every_field_from_a_well_formed_response(mocker):
+    mocker.patch(
+        "app.vision_client.httpx.post",
+        return_value=_ok_response(name="Nopal limpio", expires_at="2026-09-01", weight_kg=0.586),
+    )
+
+    result = extract_label(_IMAGE)
+
+    assert result.name == "Nopal limpio"
+    assert str(result.expires_at) == "2026-09-01"
+    assert str(result.quantity) == "0.59"  # quantized to match NUMERIC(10, 2)
+    assert result.unit == "kg"
+
+
+def test_a_field_the_model_could_not_determine_arrives_null(mocker):
+    mocker.patch("app.vision_client.httpx.post", return_value=_ok_response(name="Leche"))
+
+    result = extract_label(_IMAGE)
+
+    assert result.name == "Leche"
+    assert result.expires_at is None
+    assert result.quantity is None
+    assert result.unit is None
+
+
+def test_sends_think_false_stream_false_and_temperature_zero(mocker):
+    """temperature 0 is not cosmetic here — see the module docstring: the
+    model's configured default (tuned for varied icon picks) reproducibly
+    returned a wrong date on the same label this test's siblings use as a
+    reference, and temperature 0 did not, across repeated real calls."""
+    post = mocker.patch("app.vision_client.httpx.post", return_value=_ok_response())
+
+    extract_label(_IMAGE)
+
+    _, kwargs = post.call_args
+    assert kwargs["json"]["think"] is False
+    assert kwargs["json"]["stream"] is False
+    assert kwargs["json"]["model"] == "qwen3.5:4b"
+    assert kwargs["json"]["options"] == {"temperature": 0}
+
+
+def test_sends_the_image_base64_encoded(mocker):
+    import base64
+
+    post = mocker.patch("app.vision_client.httpx.post", return_value=_ok_response())
+
+    extract_label(_IMAGE)
+
+    _, kwargs = post.call_args
+    assert kwargs["json"]["images"] == [base64.b64encode(_IMAGE).decode("ascii")]
+
+
+@pytest.mark.parametrize(
+    "bad_date",
+    ["31/08/26", "2026-13-40", "not a date", "", 20260901],
+)
+def test_an_unparsable_date_arrives_null_rather_than_a_guess(mocker, bad_date):
+    mocker.patch("app.vision_client.httpx.post", return_value=_ok_response(expires_at=bad_date))
+
+    assert extract_label(_IMAGE).expires_at is None
+
+
+def test_a_zero_or_negative_weight_arrives_null(mocker):
+    mocker.patch("app.vision_client.httpx.post", return_value=_ok_response(weight_kg=0))
+
+    result = extract_label(_IMAGE)
+    assert result.quantity is None
+    assert result.unit is None
+
+
+def test_an_empty_name_arrives_null_rather_than_an_empty_string(mocker):
+    mocker.patch("app.vision_client.httpx.post", return_value=_ok_response(name="   "))
+
+    assert extract_label(_IMAGE).name is None
+
+
+def test_returns_none_on_a_connection_failure(mocker):
+    mocker.patch("app.vision_client.httpx.post", side_effect=httpx.ConnectError("refused"))
+
+    assert extract_label(_IMAGE) is None
+
+
+def test_returns_none_on_a_timeout(mocker):
+    mocker.patch("app.vision_client.httpx.post", side_effect=httpx.TimeoutException("slow"))
+
+    assert extract_label(_IMAGE) is None
+
+
+def test_returns_none_on_an_http_error_status(mocker):
+    mocker.patch(
+        "app.vision_client.httpx.post",
+        return_value=httpx.Response(status_code=500, text="boom", request=_REQUEST),
+    )
+
+    assert extract_label(_IMAGE) is None
+
+
+def test_returns_none_when_the_response_field_is_not_json(mocker):
+    mocker.patch(
+        "app.vision_client.httpx.post",
+        return_value=httpx.Response(
+            status_code=200,
+            json={"model": "qwen3.5:4b", "response": "not json", "done": True},
+            request=_REQUEST,
+        ),
+    )
+
+    assert extract_label(_IMAGE) is None

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -382,6 +382,11 @@
   }
 }
 
+.form__scan {
+  padding-bottom: 0.875rem;
+  border-bottom: 1px solid var(--border);
+}
+
 /* Filters */
 
 .filters {

--- a/frontend/src/components/ProductForm.test.tsx
+++ b/frontend/src/components/ProductForm.test.tsx
@@ -2,15 +2,32 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { ProductForm } from '@/components/ProductForm'
-import type { Product } from '@/services/types'
+import type { LabelExtraction, Product } from '@/services/types'
 
 vi.mock('@/services/productsService', () => ({
   createProduct: vi.fn(),
   replaceProduct: vi.fn(),
 }))
 
+vi.mock('@/services/visionService', () => ({
+  extractLabel: vi.fn(),
+}))
+
 const products = await import('@/services/productsService')
+const vision = await import('@/services/visionService')
 const mockedCreate = vi.mocked(products.createProduct)
+const mockedExtract = vi.mocked(vision.extractLabel)
+
+function labelExtraction(overrides: Partial<LabelExtraction> = {}): LabelExtraction {
+  return { name: null, expires_at: null, quantity: null, unit: null, ...overrides }
+}
+
+function selectPhoto() {
+  const file = new File(['fake'], 'label.png', { type: 'image/png' })
+  fireEvent.change(screen.getByLabelText('Foto de la etiqueta (opcional)'), {
+    target: { files: [file] },
+  })
+}
 
 /**
  * Fill only what the form requires, then submit.
@@ -106,5 +123,102 @@ describe('ProductForm quantity stepper', () => {
     render(<ProductForm product={product} categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
 
     expect(screen.getByRole('button', { name: 'Reducir cantidad' })).toBeInTheDocument()
+  })
+})
+
+describe('ProductForm label scan', () => {
+  it('offers the scan field when creating, not when editing', () => {
+    const product: Product = {
+      id: 1,
+      name: 'Huevos',
+      category_id: null,
+      quantity: '6.00',
+      unit: 'piezas',
+      expires_at: '2026-09-10',
+      location: 'fridge',
+      notes: null,
+      category: null,
+      icon: '\u{1F95A}',
+      icon_source: 'lookup',
+      created_at: '2026-08-29T00:00:00Z',
+      updated_at: '2026-08-29T00:00:00Z',
+      consumed_at: null,
+      days_until_expiry: 5,
+      status: 'expiring_soon',
+    }
+
+    const { unmount } = render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByLabelText('Foto de la etiqueta (opcional)')).toBeInTheDocument()
+    unmount()
+
+    render(<ProductForm product={product} categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.queryByLabelText('Foto de la etiqueta (opcional)')).not.toBeInTheDocument()
+  })
+
+  it('pre-fills every field the model returned', async () => {
+    mockedExtract.mockResolvedValue(
+      labelExtraction({ name: 'Nopal limpio', expires_at: '2026-09-01', quantity: '0.59', unit: 'kg' }),
+    )
+    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+
+    selectPhoto()
+
+    await waitFor(() => expect(screen.getByLabelText('Nombre')).toHaveValue('Nopal limpio'))
+    expect(screen.getByLabelText('Caduca el')).toHaveValue('2026-09-01')
+    expect(screen.getByLabelText('Cantidad')).toHaveValue(0.59)
+    expect(screen.getByLabelText('Unidad')).toHaveValue('kg')
+    expect(screen.getByText('Foto leída. Revisa los datos antes de guardar.')).toBeInTheDocument()
+  })
+
+  it('leaves a field the model could not read untouched', async () => {
+    mockedExtract.mockResolvedValue(labelExtraction({ name: 'Nopal limpio' }))
+    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    fireEvent.change(screen.getByLabelText('Unidad'), { target: { value: 'piezas' } })
+
+    selectPhoto()
+
+    await waitFor(() => expect(screen.getByLabelText('Nombre')).toHaveValue('Nopal limpio'))
+    // Untouched by the scan: still whatever the user had already typed.
+    expect(screen.getByLabelText('Unidad')).toHaveValue('piezas')
+    expect(screen.getByLabelText('Caduca el')).toHaveValue('')
+  })
+
+  it('says so when nothing in the photo could be read', async () => {
+    mockedExtract.mockResolvedValue(labelExtraction())
+    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+
+    selectPhoto()
+
+    expect(
+      await screen.findByText('No se pudo leer nada de la foto. Completa los campos manualmente.'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the failure inline and leaves the rest of the form usable', async () => {
+    mockedExtract.mockRejectedValue(new Error('nope'))
+    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+
+    selectPhoto()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
+    // Manual entry still works — the failure did not block the rest of the form.
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Huevos' } })
+    expect(screen.getByLabelText('Nombre')).toHaveValue('Huevos')
+  })
+
+  it('disables the scan input while a photo is being read', async () => {
+    let resolveRequest: (result: LabelExtraction) => void = () => {}
+    mockedExtract.mockReturnValue(
+      new Promise<LabelExtraction>((resolve) => {
+        resolveRequest = resolve
+      }),
+    )
+    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+
+    selectPhoto()
+
+    expect(screen.getByLabelText('Foto de la etiqueta (opcional)')).toBeDisabled()
+    resolveRequest(labelExtraction())
+    await waitFor(() => expect(screen.getByLabelText('Foto de la etiqueta (opcional)')).not.toBeDisabled())
   })
 })

--- a/frontend/src/components/ProductForm.tsx
+++ b/frontend/src/components/ProductForm.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type FormEvent } from 'react'
+import { useMemo, useState, type ChangeEvent, type FormEvent } from 'react'
 
 import { Modal } from '@/components/Modal'
 import { LOCATION_LABELS } from '@/labels'
@@ -6,6 +6,7 @@ import { canStepDown, stepQuantity } from '@/quantity'
 import { toErrorMessage } from '@/services/api'
 import { createProduct, replaceProduct } from '@/services/productsService'
 import type { Category, Location, Product, ProductPayload } from '@/services/types'
+import { extractLabel } from '@/services/visionService'
 
 interface ProductFormProps {
   /** Omit to create; pass a product to edit it. */
@@ -48,6 +49,10 @@ export function ProductForm({ product, categories, onSaved, onCancel }: ProductF
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  const [scanning, setScanning] = useState(false)
+  const [scanError, setScanError] = useState<string | null>(null)
+  const [scanHint, setScanHint] = useState<string | null>(null)
+
   const isEdit = product !== undefined
 
   // Categories arrive asynchronously. Until they do, a select whose value has
@@ -64,6 +69,48 @@ export function ProductForm({ product, categories, onSaved, onCancel }: ProductF
 
   const update = <K extends keyof FormState>(field: K, value: FormState[K]) =>
     setForm((current) => ({ ...current, [field]: value }))
+
+  /**
+   * The photo is an accuracy shortcut, not a separate flow: it fills in
+   * whatever the model was confident about and leaves the rest exactly as
+   * it was, so the same "confirm in the form, then Guardar" path handles a
+   * photo, a fully typed entry, and everything in between — never a silent
+   * save. Only fields the model actually returned are overwritten, so a
+   * partial read (say, a date but no readable weight) does not clobber a
+   * quantity the user already typed by hand.
+   */
+  const handleScan = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    // Cleared immediately so scanning the same photo again — e.g. after a
+    // failure — fires a change event the second time too.
+    event.target.value = ''
+    if (!file) return
+
+    setScanning(true)
+    setScanError(null)
+    setScanHint(null)
+    void (async () => {
+      try {
+        const extracted = await extractLabel(file)
+        setForm((current) => ({
+          ...current,
+          name: extracted.name ?? current.name,
+          expires_at: extracted.expires_at ?? current.expires_at,
+          quantity: extracted.quantity ?? current.quantity,
+          unit: extracted.unit ?? current.unit,
+        }))
+        setScanHint(
+          extracted.name || extracted.expires_at || extracted.quantity
+            ? 'Foto leída. Revisa los datos antes de guardar.'
+            : 'No se pudo leer nada de la foto. Completa los campos manualmente.',
+        )
+      } catch (caught) {
+        setScanError(toErrorMessage(caught))
+      } finally {
+        setScanning(false)
+      }
+    })()
+  }
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault()
@@ -99,6 +146,37 @@ export function ProductForm({ product, categories, onSaved, onCancel }: ProductF
   return (
     <Modal title={isEdit ? 'Editar producto' : 'Agregar producto'} onClose={onCancel}>
       <form className="form" onSubmit={handleSubmit}>
+        {/* The photo is the entry point, not an afterthought — see #83 — so
+            it comes first, above manual entry rather than buried below it.
+            Only offered when creating: an edit already has real values, and
+            re-scanning over them is not a flow this covers. */}
+        {!isEdit && (
+          // Explicit htmlFor/id rather than wrapping in a <label>, same
+          // reasoning as Cantidad below: a wrapping label's accessible name
+          // is its full text content, and the status paragraphs here change
+          // while scanning — wrapped, the label's name would grow to include
+          // "Leyendo etiqueta…" while a scan is in flight instead of naming
+          // the control. See #91's IconPicker for the same fix, same reason.
+          <div className="form__field form__scan">
+            <label htmlFor="product-scan">Foto de la etiqueta (opcional)</label>
+            <input
+              id="product-scan"
+              type="file"
+              accept="image/*"
+              capture="environment"
+              onChange={handleScan}
+              disabled={scanning}
+            />
+            {scanning && <p className="settings__hint">Leyendo etiqueta…</p>}
+            {scanError && (
+              <p className="form__error" role="alert">
+                {scanError}
+              </p>
+            )}
+            {scanHint && <p className="settings__hint">{scanHint}</p>}
+          </div>
+        )}
+
         <label className="form__field">
           <span>Nombre</span>
           <input

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -107,3 +107,16 @@ export interface IconReassignmentResult {
   updated: number
   still_default: number
 }
+
+/**
+ * Best-effort fields read from a photo of a product label — see #83 and
+ * POST /vision/label. Any field may be null when the model could not
+ * determine it with confidence. Field names match ProductPayload
+ * deliberately so a caller can spread this straight into form state.
+ */
+export interface LabelExtraction {
+  name: string | null
+  expires_at: string | null
+  quantity: string | null
+  unit: string | null
+}

--- a/frontend/src/services/visionService.test.ts
+++ b/frontend/src/services/visionService.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { extractLabel } from '@/services/visionService'
+
+vi.mock('@/services/api', () => ({
+  api: { post: vi.fn() },
+}))
+
+const { api } = await import('@/services/api')
+const mockedApi = vi.mocked(api)
+
+const image = new File(['fake'], 'label.png', { type: 'image/png' })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('visionService', () => {
+  it('posts the image as multipart form data', async () => {
+    mockedApi.post.mockResolvedValue({
+      data: { name: 'Nopal limpio', expires_at: '2026-09-01', quantity: '0.59', unit: 'kg' },
+    })
+
+    const result = await extractLabel(image)
+
+    expect(result).toEqual({ name: 'Nopal limpio', expires_at: '2026-09-01', quantity: '0.59', unit: 'kg' })
+    const [path, body] = mockedApi.post.mock.calls[0]
+    expect(path).toBe('/vision/label')
+    expect(body).toBeInstanceOf(FormData)
+    expect((body as FormData).get('image')).toBe(image)
+  })
+
+  it('overrides the default JSON content type, or axios silently stringifies the file away', async () => {
+    /**
+     * Reproduced directly against the real backend before this existed: the
+     * shared `api` instance defaults to "application/json", and axios's
+     * FormData handling only sends a real multipart body when the request's
+     * Content-Type does not already look like JSON. Without this override
+     * the backend received a 422 "field required" for `image` — the file
+     * never left as multipart at all, just a JSON-stringified husk of the
+     * FormData object. See visionService.ts's own comment.
+     */
+    mockedApi.post.mockResolvedValue({ data: { name: null, expires_at: null, quantity: null, unit: null } })
+
+    await extractLabel(image)
+
+    const [, , config] = mockedApi.post.mock.calls[0]
+    expect(config?.headers?.['Content-Type']).not.toMatch(/json/i)
+  })
+
+  it('is not retried — a repeat costs real time and data on a read-only call', async () => {
+    mockedApi.post.mockRejectedValue(new Error('boom'))
+
+    await expect(extractLabel(image)).rejects.toThrow('boom')
+    expect(mockedApi.post.mock.calls).toHaveLength(1)
+  })
+})

--- a/frontend/src/services/visionService.ts
+++ b/frontend/src/services/visionService.ts
@@ -1,0 +1,28 @@
+import { api } from '@/services/api'
+import type { LabelExtraction } from '@/services/types'
+
+/**
+ * Read a name, expiry date, and weight from a photo of a product label —
+ * see #83 and POST /vision/label. Never saves anything; the result is meant
+ * to pre-fill the product form for the user to confirm or correct.
+ *
+ * Not retried: a label photo can be several MB, so a second attempt after a
+ * slow or dropped connection costs real time and mobile data on a call that
+ * is read-only anyway — the user can just try again if it fails, in which
+ * case an automatic retry would only be racing them.
+ *
+ * The explicit Content-Type override matters: the shared `api` instance
+ * defaults to "application/json", and axios's FormData handling only skips
+ * JSON-stringifying the body when the request's Content-Type does *not*
+ * already look like JSON — reproduced directly against the real backend,
+ * which received a 422 "field required" for `image` without this override,
+ * because the file never left as multipart at all.
+ */
+export async function extractLabel(image: File): Promise<LabelExtraction> {
+  const form = new FormData()
+  form.append('image', image)
+  const { data } = await api.post<LabelExtraction>('/vision/label', form, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
+  return data
+}


### PR DESCRIPTION
## Summary
- New `POST /vision/label`: takes a photo (multipart), sends it to the local Ollama vision model (`qwen3.5:4b` — confirmed to have a real vision encoder against the actual server, not assumed), returns a best-effort `{name, expires_at, quantity, unit}`. Side-effect free, nothing is ever saved by this endpoint.
- The prompt explicitly tells the model to prefer "Fecha de Caducidad"/"Consumo preferente" and ignore "Fecha de Empacado"/"Fecha de Preparación" — the exact reading-comprehension problem #83 describes.
- `ProductForm`'s new "Foto de la etiqueta (opcional)" field is the entry point when creating a product, above manual entry. Extracted fields pre-fill the form; nothing saves until Guardar; any field the model wasn't confident about (returned null) is left for the user to fill in and does not clobber whatever they'd already typed.
- Any total failure (model unreachable, unconfigured, bad response) degrades to a clear inline message — the rest of the form stays fully usable for manual entry.

## Notable while building this
- Reproduced the exact two-date trap from the issue (`Fecha de Empacado` vs `Consumo preferente`, and `Fecha de Preparacion` vs `Fecha de Caducidad`) against synthetic labels built from the issue's own real HEB examples, run through the real Ollama server — not just designed against the spec.
- Found a real bug empirically rather than assuming: at the model's configured default temperature (1, tuned for varied icon picks), the same label reproducibly returned a date matching neither one printed on it. Forcing `temperature: 0` for this call fixed it — verified correct across repeated real calls afterward. `vision_client.py`'s own comment has the numbers.
- Found and fixed a second real bug before it shipped: the shared `api` axios instance's default `Content-Type: application/json` silently made axios JSON-stringify the FormData instead of sending a real multipart body — reproduced against the real backend (a 422 "field required" for `image`), fixed with an explicit per-request header override. `visionService.ts` and its test carry the explanation.
- Fixed a real (if minor) accessibility issue the test suite surfaced: the scan field's status text was rendered inside the same `<label>` as the control, so the label's accessible name grew to include "Leyendo etiqueta…" while a scan was in flight. Same shape IconPicker already hit — fixed the same way, explicit `htmlFor`/`id` instead of wrapping.

## Test plan
- [x] Backend: `pytest` — 220 passed (22 new: `vision_client` unit tests including the temperature/date-parsing/weight-quantization edge cases, `vision` router tests including size limits and the 503-on-total-failure path).
- [x] Backend: `ruff check` clean.
- [x] Frontend: `vitest` — 215 passed (13 new: `visionService`, and `ProductForm`'s new scan section — pre-fill, partial-extraction no-clobber, failure message, disabled-while-scanning, hidden while editing).
- [x] Frontend: `tsc -b` and `eslint` clean.
- [x] Live end-to-end against the real running API and the real Ollama server: uploaded two synthetic label photos reproducing the issue's real HEB examples (produce label with a packing-date trap, meat label with a preparation-date trap) through the actual `/vision/label` endpoint — both resolved to the correct date, not the trap date.
- [x] Confirmed via the real dev server that the rendered form shows the scan field correctly labeled and positioned above manual entry.