### PR TITLE
fix: offer a Cloudflare Access reauth link when the API looks unreachable

### DIFF
--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 
-import { toErrorMessage } from '@/services/api'
+import { isUnreachable, toErrorMessage } from '@/services/api'
 import { listProducts } from '@/services/productsService'
 import type { Product, ProductFilters } from '@/services/types'
 
@@ -8,6 +8,13 @@ interface UseProductsResult {
   products: Product[]
   loading: boolean
   error: string | null
+  /**
+   * True when `error` looks like the backend could not be reached at all —
+   * see api.ts's isUnreachable. Lets the UI offer a Cloudflare Access
+   * re-authentication link only where it could plausibly help, rather than
+   * for e.g. a validation error, where it would be noise.
+   */
+  unreachable: boolean
   /** Set when the list came from the offline cache rather than the network. */
   cachedAt: Date | null
   reload: () => void
@@ -45,6 +52,7 @@ export function useProducts(filters: ProductFilters = {}): UseProductsResult {
   const [products, setProducts] = useState<Product[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [unreachable, setUnreachable] = useState(false)
   const [cachedAt, setCachedAt] = useState<Date | null>(null)
   const [reloadNonce, setReloadNonce] = useState(0)
 
@@ -62,9 +70,13 @@ export function useProducts(filters: ProductFilters = {}): UseProductsResult {
           setProducts(result.products)
           setCachedAt(result.cachedAt)
           setError(null)
+          setUnreachable(false)
         }
       } catch (caught) {
-        if (active) setError(toErrorMessage(caught))
+        if (active) {
+          setError(toErrorMessage(caught))
+          setUnreachable(isUnreachable(caught))
+        }
       } finally {
         if (active) setLoading(false)
       }
@@ -81,6 +93,7 @@ export function useProducts(filters: ProductFilters = {}): UseProductsResult {
   const reload = useCallback(() => {
     setLoading(true)
     setError(null)
+    setUnreachable(false)
     setReloadNonce((nonce) => nonce + 1)
   }, [])
 
@@ -114,5 +127,5 @@ export function useProducts(filters: ProductFilters = {}): UseProductsResult {
     setProducts((current) => current.filter((product) => product.id !== id))
   }, [])
 
-  return { products, loading, error, cachedAt, reload, replaceProduct, removeProduct }
+  return { products, loading, error, unreachable, cachedAt, reload, replaceProduct, removeProduct }
 }

--- a/frontend/src/pages/ProductList.test.tsx
+++ b/frontend/src/pages/ProductList.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { AxiosError } from 'axios'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ProductList } from '@/pages/ProductList'
@@ -134,6 +135,18 @@ describe('ProductList', () => {
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
     expect(screen.getByRole('button', { name: 'Reintentar' })).toBeInTheDocument()
+    // Not this failure's cause — no reauth link offered for it.
+    expect(screen.queryByText(/reautentícate/i)).not.toBeInTheDocument()
+  })
+
+  it('offers a Cloudflare Access reauth link when the backend looks unreachable', async () => {
+    mockedList.mockRejectedValue(new AxiosError('Network Error', 'ERR_NETWORK'))
+
+    render(<ProductList />)
+
+    const link = await screen.findByRole('link', { name: /reautentícate en una pestaña nueva/i })
+    expect(link).toHaveAttribute('href', `${window.location.origin}/api/products`)
+    expect(link).toHaveAttribute('target', '_blank')
   })
 })
 

--- a/frontend/src/pages/ProductList.tsx
+++ b/frontend/src/pages/ProductList.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/filters'
 import { useCategories } from '@/hooks/useCategories'
 import { useProducts } from '@/hooks/useProducts'
-import { toErrorMessage } from '@/services/api'
+import { apiUrl, toErrorMessage } from '@/services/api'
 import { deleteProduct } from '@/services/productsService'
 import type { Product } from '@/services/types'
 
@@ -32,7 +32,7 @@ type Dialog =
 
 /** Main screen: everything in the house, soonest to expire first. */
 export function ProductList() {
-  const { products, loading, error, cachedAt, reload, replaceProduct, removeProduct } = useProducts()
+  const { products, loading, error, unreachable, cachedAt, reload, replaceProduct, removeProduct } = useProducts()
   const categories = useCategories()
   const [dialog, setDialog] = useState<Dialog>({ kind: 'none' })
   const [deleting, setDeleting] = useState(false)
@@ -96,6 +96,22 @@ export function ProductList() {
       {!loading && error && (
         <div className="state state--error" role="alert">
           <p>{error}</p>
+          {/* This bucket also covers a Cloudflare Access session expiring —
+              see api.ts's isUnreachable — which otherwise fails the exact
+              same way forever: a fetch can never complete Access's
+              interactive login on its own, only a real top-level navigation
+              to a protected URL can. Harmless when the real cause is just
+              the server being down: the link opens, finds nothing useful,
+              and the user is no worse off than before it existed. */}
+          {unreachable && (
+            <p className="state__hint">
+              Si tu sesión expiró,{' '}
+              <a href={apiUrl('/products')} target="_blank" rel="noopener noreferrer">
+                reautentícate en una pestaña nueva
+              </a>{' '}
+              y vuelve a intentar.
+            </p>
+          )}
           <button type="button" onClick={reload}>
             Reintentar
           </button>

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -1,7 +1,7 @@
 import { AxiosError, AxiosHeaders } from 'axios'
 import { describe, expect, it } from 'vitest'
 
-import { toErrorMessage } from '@/services/api'
+import { apiUrl, isUnreachable, toErrorMessage } from '@/services/api'
 
 function axiosErrorWith(data: unknown, status = 422): AxiosError {
   const error = new AxiosError('Request failed')
@@ -49,5 +49,32 @@ describe('toErrorMessage', () => {
 
   it('falls back for anything that is not an Axios error', () => {
     expect(toErrorMessage(new Error('boom'))).toBe('Ocurrió un error inesperado.')
+  })
+})
+
+describe('isUnreachable', () => {
+  it('is true for a network error', () => {
+    expect(isUnreachable(new AxiosError('Network Error', 'ERR_NETWORK'))).toBe(true)
+  })
+
+  it('is true for a bodyless 500, the same bucket a blocked Cloudflare Access redirect falls into', () => {
+    expect(isUnreachable(axiosErrorWith('', 500))).toBe(true)
+  })
+
+  it('is false for a real error the server explained', () => {
+    expect(isUnreachable(axiosErrorWith({ detail: 'Category 9999 does not exist' }))).toBe(false)
+  })
+
+  it('is false for anything that is not an Axios error', () => {
+    expect(isUnreachable(new Error('boom'))).toBe(false)
+  })
+})
+
+describe('apiUrl', () => {
+  it('resolves a relative API_BASE_URL against the current origin', () => {
+    // The default API_BASE_URL in this test environment is the relative
+    // "/api" path — see api.ts — so this also covers the production shape
+    // (proxied by nginx/Cloudflare) without needing to mock import.meta.env.
+    expect(apiUrl('/products')).toBe(`${window.location.origin}/api/products`)
   })
 })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -9,18 +9,60 @@ interface ApiErrorBody {
 }
 
 /**
- * Shared Axios instance pointing at the FastAPI backend.
+ * The base URL calls go out to, exported so a caller can point a real
+ * top-level navigation (not a fetch) at the same host — see isUnreachable's
+ * docstring for why that distinction matters.
  *
- * The base URL comes from VITE_API_URL so the same build can talk to a local
- * backend or the one behind the Cloudflare tunnel. It defaults to the relative
- * "/api" path — proxied by the Vite dev server, served by the reverse proxy in
- * production — rather than a hardcoded localhost, so a missing env var does not
- * silently break a deployed build.
+ * Comes from VITE_API_URL so the same build can talk to a local backend or
+ * the one behind the Cloudflare tunnel. It defaults to the relative "/api"
+ * path — proxied by the Vite dev server, served by the reverse proxy in
+ * production — rather than a hardcoded localhost, so a missing env var does
+ * not silently break a deployed build.
  */
+export const API_BASE_URL = import.meta.env.VITE_API_URL ?? '/api'
+
+/** Shared Axios instance pointing at the FastAPI backend. */
 export const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL ?? '/api',
+  baseURL: API_BASE_URL,
   headers: { 'Content-Type': 'application/json' },
 })
+
+/**
+ * A full, absolute URL to an API path — for a real top-level navigation
+ * (`<a href>`, `window.location`), never for `api`'s own requests, which
+ * already resolve API_BASE_URL themselves. Resolves against the current
+ * origin so a relative API_BASE_URL (the "/api" default) still produces
+ * something a new tab can open on its own, detached from this page.
+ */
+export function apiUrl(path: string): string {
+  return new URL(`${API_BASE_URL}${path}`, window.location.origin).toString()
+}
+
+/**
+ * True when `error` looks like the backend could not be reached at all,
+ * rather than reached-and-rejected — no response, a network-level failure
+ * code, or a bodyless 5xx from a proxy in between.
+ *
+ * This bucket is deliberately imprecise: it also covers the failure a
+ * Cloudflare Access session expiring produces. Access responds to an
+ * unauthenticated request with a redirect to its own login page; a `fetch`
+ * cannot follow that redirect across origins, so the browser reports it as a
+ * plain blocked request with no status and no body — indistinguishable, from
+ * here, from the backend being genuinely down. Observed directly: the
+ * product list failing to load in production, on every device, with the
+ * browser's console (not this code, which never sees enough to say so)
+ * showing a CORS error against `*.cloudflareaccess.com`. A `fetch` can never
+ * complete Access's interactive login on its own — that needs a real
+ * top-level navigation to the protected URL — so an error in this bucket is
+ * exactly the case worth offering one for, alongside "the server is down",
+ * which the same link is harmless against: it just won't help.
+ */
+export function isUnreachable(error: unknown): boolean {
+  if (!(error instanceof AxiosError)) return false
+  const response = (error as AxiosError<ApiErrorBody>).response
+  const detail = response?.data?.detail
+  return error.code === 'ERR_NETWORK' || response === undefined || (response.status >= 500 && detail === undefined)
+}
 
 /**
  * Turn an Axios failure into a message worth showing a user.
@@ -42,16 +84,5 @@ export function toErrorMessage(error: unknown): string {
       .join('. ')
   }
 
-  // A backend that is simply down is the most likely failure in practice, and
-  // it reaches us in several shapes: no response at all when the browser talks
-  // to the API directly, or a gateway error when a proxy is in between. The
-  // Vite dev server turns a refused connection into a bodyless 500, so that
-  // counts too — telling the user "unexpected error" when the server is off
-  // helps nobody.
-  const unreachable =
-    error.code === 'ERR_NETWORK' ||
-    response === undefined ||
-    (response.status >= 500 && detail === undefined)
-
-  return unreachable ? UNREACHABLE : UNEXPECTED
+  return isUnreachable(error) ? UNREACHABLE : UNEXPECTED
 }


### PR DESCRIPTION
## Summary
Reported live: the product list failing to load on every device, console showing CORS errors against `*.cloudflareaccess.com` for `/api/products` and `/api/categories`. Root cause — a Cloudflare Access session expiring is indistinguishable, from the browser's own JS, from the backend being genuinely down: Access redirects an unauthenticated request to its own login page, a `fetch` cannot follow a cross-origin redirect, and the browser reports a plain blocked request with no status or body. Worse, a `fetch` can never complete Access's interactive login on its own — only a real top-level navigation to the protected URL can — so this previously failed silently **forever**, with no way back in short of manually typing `/api/products` into the address bar (confirmed live: doing exactly that fixed it).

- `api.ts`: extracted the existing "looks unreachable" classification out of `toErrorMessage` into its own `isUnreachable(error)`, and added `apiUrl(path)` — a full absolute URL for a real navigation, as opposed to `api`'s own request path.
- `useProducts`: exposes `unreachable: boolean` alongside `error`, so the UI can offer the reauth affordance only where it could plausibly help — not for e.g. a validation error.
- `ProductList`'s error state now shows a "reautentícate en una pestaña nueva" link pointed at `/api/products` whenever the failure falls in that bucket. Harmless when the real cause is a genuine outage — the link just won't help.

Scoped to the product list's own error state (the primary "can't load anything" screen) rather than every error message in the app — that's the one this actually blocks on.

## Test plan
- [x] `vitest` — 221 passed (7 new: `isUnreachable`, `apiUrl`, and `ProductList`'s reauth-link behavior, including that it does *not* show for an ordinary error).
- [x] `tsc -b` and `eslint` clean.
- [x] Live: ran the dev server with the backend genuinely down, confirmed the product list shows both the existing "No se pudo conectar con el servidor." message and the new reauth link, with the correct href (`{origin}/api/products`) and `target="_blank"`.