### PR TITLE
fix: keep the Cloudflare Access reauth flow in the same window

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.logging_config import setup_logging
-from app.routers import alerts, categories, health, products, vision
+from app.routers import alerts, categories, health, products, reauth, vision
 from app.routers import settings as settings_router
 from app.scheduler import shutdown_scheduler, start_scheduler
 
@@ -47,5 +47,6 @@ app.include_router(products.router)
 app.include_router(alerts.router)
 app.include_router(settings_router.router)
 app.include_router(vision.router)
+app.include_router(reauth.router)
 
 logger.info("CaduTrack API started")

--- a/backend/app/routers/reauth.py
+++ b/backend/app/routers/reauth.py
@@ -1,0 +1,79 @@
+"""Cloudflare Access reauth landing page — see #96/the frontend's apiUrl.
+
+Not a resource endpoint: it exists only as a destination the frontend can
+send a same-window navigation to when the API looks unreachable, most often
+because the Access session backing it expired. A `fetch` can never complete
+Access's own interactive login on its own — only a real top-level navigation
+to a URL under the protected hostname can — and the app's static shell (`/`)
+cannot serve as that URL, since the PWA's service worker precaches and
+serves it straight from storage without ever reaching the network. Anything
+under `/vision`, `/products`, etc. would technically work the same way, but
+would leave the user looking at raw JSON; this exists purely to be
+friendlier than that, and to hand them back to the app in the same window —
+important inside an installed PWA, which typically has nowhere to open a
+second tab in the first place.
+
+Reaching this function at all IS the proof reauthentication worked: it sits
+behind the same Cloudflare Access application as every other route, so an
+unauthenticated request never reaches it — Access intercepts it upstream
+with its own login redirect. There is no auth check here because there is
+nothing left to check.
+"""
+
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+
+router = APIRouter()
+
+_PAGE = """<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="refresh" content="2;url=/">
+<title>Sesión reanudada — CaduTrack</title>
+<style>
+  :root { color-scheme: dark; }
+  body {
+    margin: 0;
+    min-height: 100dvh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #14170f;
+    color: #f4f4f0;
+    font-family: system-ui, -apple-system, sans-serif;
+    text-align: center;
+    padding: 1.5rem;
+  }
+  .card { max-width: 22rem; }
+  .icon { font-size: 2.5rem; margin-bottom: 0.75rem; }
+  h1 { font-size: 1.25rem; margin: 0 0 0.5rem; }
+  p { color: #b7bdae; margin: 0 0 1.5rem; font-size: 0.9375rem; }
+  a {
+    display: inline-block;
+    padding: 0.6rem 1.25rem;
+    background: #3f7d3a;
+    color: #14170f;
+    text-decoration: none;
+    border-radius: 0.5rem;
+    font-weight: 600;
+  }
+</style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon" aria-hidden="true">✅</div>
+    <h1>Sesión reanudada</h1>
+    <p>Ya iniciaste sesión. Volviendo a CaduTrack…</p>
+    <a href="/">Volver ahora</a>
+  </div>
+</body>
+</html>
+"""
+
+
+@router.get("/reauth", response_class=HTMLResponse, include_in_schema=False)
+def reauth_confirmation() -> str:
+    """A friendly confirmation, then back to the app — see the module docstring."""
+    return _PAGE

--- a/backend/tests/test_reauth.py
+++ b/backend/tests/test_reauth.py
@@ -1,0 +1,18 @@
+"""Reauth landing page tests."""
+
+
+def test_serves_a_page_that_sends_the_browser_back_to_the_app(client):
+    response = client.get("/reauth")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert 'http-equiv="refresh" content="2;url=/"' in response.text
+    assert 'href="/"' in response.text
+
+
+def test_is_excluded_from_the_openapi_schema(client):
+    """Not a resource endpoint — see the module docstring — so it has no
+    business appearing next to /products and /categories in the API docs."""
+    schema = client.get("/openapi.json").json()
+
+    assert "/reauth" not in schema["paths"]

--- a/frontend/src/pages/ProductList.test.tsx
+++ b/frontend/src/pages/ProductList.test.tsx
@@ -139,14 +139,19 @@ describe('ProductList', () => {
     expect(screen.queryByText(/reautentícate/i)).not.toBeInTheDocument()
   })
 
-  it('offers a Cloudflare Access reauth link when the backend looks unreachable', async () => {
+  it('offers a same-window Cloudflare Access reauth link when the backend looks unreachable', async () => {
+    // Same window, deliberately: the PWA is the primary way this app is
+    // used, and an installed PWA typically has nowhere to open a second tab
+    // — see ProductList.tsx's own comment. A target="_blank" here would
+    // leave the user stuck switching between two separate apps instead of
+    // just navigating away and back.
     mockedList.mockRejectedValue(new AxiosError('Network Error', 'ERR_NETWORK'))
 
     render(<ProductList />)
 
-    const link = await screen.findByRole('link', { name: /reautentícate en una pestaña nueva/i })
-    expect(link).toHaveAttribute('href', `${window.location.origin}/api/products`)
-    expect(link).toHaveAttribute('target', '_blank')
+    const link = await screen.findByRole('link', { name: /reautentícate aquí/i })
+    expect(link).toHaveAttribute('href', `${window.location.origin}/api/reauth`)
+    expect(link).not.toHaveAttribute('target')
   })
 })
 

--- a/frontend/src/pages/ProductList.tsx
+++ b/frontend/src/pages/ProductList.tsx
@@ -100,16 +100,18 @@ export function ProductList() {
               see api.ts's isUnreachable — which otherwise fails the exact
               same way forever: a fetch can never complete Access's
               interactive login on its own, only a real top-level navigation
-              to a protected URL can. Harmless when the real cause is just
-              the server being down: the link opens, finds nothing useful,
-              and the user is no worse off than before it existed. */}
+              to a protected URL can. Same-window on purpose, not a new tab:
+              the PWA is the primary way this app is used, and an installed
+              PWA typically has nowhere to open a second tab — this instead
+              navigates away and back through /reauth, a small backend page
+              that sends the browser straight back to "/" once Access lets
+              the request through. Harmless when the real cause is just the
+              server being down: the navigation fails to load, and the user
+              is no worse off than before it existed. */}
           {unreachable && (
             <p className="state__hint">
-              Si tu sesión expiró,{' '}
-              <a href={apiUrl('/products')} target="_blank" rel="noopener noreferrer">
-                reautentícate en una pestaña nueva
-              </a>{' '}
-              y vuelve a intentar.
+              Si tu sesión expiró, <a href={apiUrl('/reauth')}>reautentícate aquí</a> — te regresa
+              solo cuando termines.
             </p>
           )}
           <button type="button" onClick={reload}>


### PR DESCRIPTION
## Summary
Follow-up to #96, before it was even tried in production: that PR opened the reauth link with `target="_blank"`, which doesn't hold up inside an installed PWA — the primary way this app is used. A home-screen PWA typically has nowhere to open a second tab; `target="_blank"` there either does nothing or kicks the user into a separate browser app entirely, needing an app-switch to get back instead of a simple return.

- New `GET /reauth`: a small backend-rendered confirmation page. It lives outside the frontend's own build output, so the service worker's precache never touches it — same reason `/api/products` reliably hit the network before, just friendlier than raw JSON as the destination.
- It sits behind the same Cloudflare Access application as every other route, so reaching it at all already proves reauthentication worked — nothing there checks auth again.
- Auto-redirects to `/` after 2s (`<meta http-equiv="refresh">`, no JS dependency) with a manual "Volver ahora" link as a fallback — same window throughout, no tab or app switch needed.
- `ProductList`'s reauth link now points here instead of `/api/products`, without `target="_blank"`.

## Test plan
- [x] Backend: `pytest` — 222 passed (2 new: serves the confirmation page with the redirect meta tag and a link home; excluded from the OpenAPI schema since it isn't a resource).
- [x] Backend: `ruff check` clean.
- [x] Frontend: `vitest` — 221 passed (updated the existing reauth-link test for the new same-window design).
- [x] Frontend: `tsc -b` and `eslint` clean.
- [x] Live: fetched `/reauth` directly and confirmed the rendered page (screenshot) matches the app's dark theme; confirmed via the dev server that `ProductList`'s error state link now points at `/api/reauth` with no `target` attribute.