### PR TITLE
fix: actually check for a new service worker instead of only registering once

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { registerServiceWorker } from './registerServiceWorker.ts'
+
+registerServiceWorker()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/registerServiceWorker.test.ts
+++ b/frontend/src/registerServiceWorker.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { registerServiceWorker } from '@/registerServiceWorker'
+
+vi.mock('virtual:pwa-register', () => ({
+  registerSW: vi.fn(),
+}))
+
+const { registerSW } = await import('virtual:pwa-register')
+const mockedRegisterSW = vi.mocked(registerSW)
+
+function fakeRegistration(): { registration: ServiceWorkerRegistration; update: ReturnType<typeof vi.fn> } {
+  const update = vi.fn()
+  return { registration: { update } as unknown as ServiceWorkerRegistration, update }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('registerServiceWorker', () => {
+  it('registers immediately, not waiting for the first interaction', () => {
+    mockedRegisterSW.mockImplementation(() => vi.fn())
+
+    registerServiceWorker()
+
+    expect(mockedRegisterSW).toHaveBeenCalledWith(expect.objectContaining({ immediate: true }))
+  })
+
+  it('checks for an update when the tab becomes visible again', () => {
+    const { registration, update } = fakeRegistration()
+    mockedRegisterSW.mockImplementation((options) => {
+      options?.onRegisteredSW?.('/sw.js', registration)
+      return vi.fn()
+    })
+
+    registerServiceWorker()
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    expect(update).toHaveBeenCalled()
+  })
+
+  it('does not check on visibilitychange while the tab is hidden', () => {
+    const { registration, update } = fakeRegistration()
+    mockedRegisterSW.mockImplementation((options) => {
+      options?.onRegisteredSW?.('/sw.js', registration)
+      return vi.fn()
+    })
+
+    registerServiceWorker()
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it('checks for an update when connectivity returns', () => {
+    const { registration, update } = fakeRegistration()
+    mockedRegisterSW.mockImplementation((options) => {
+      options?.onRegisteredSW?.('/sw.js', registration)
+      return vi.fn()
+    })
+
+    registerServiceWorker()
+    window.dispatchEvent(new Event('online'))
+
+    expect(update).toHaveBeenCalled()
+  })
+
+  it('does not throw when registration failed', () => {
+    mockedRegisterSW.mockImplementation((options) => {
+      options?.onRegisteredSW?.('/sw.js', undefined)
+      return vi.fn()
+    })
+
+    expect(() => registerServiceWorker()).not.toThrow()
+  })
+})

--- a/frontend/src/registerServiceWorker.ts
+++ b/frontend/src/registerServiceWorker.ts
@@ -1,0 +1,52 @@
+import { registerSW } from 'virtual:pwa-register'
+
+/**
+ * Registers the service worker and keeps it actually checking for updates.
+ *
+ * vite-plugin-pwa's default registration (a bare `navigator.serviceWorker.
+ * register()` call once on load, wired up automatically when nothing here
+ * imports `virtual:pwa-register` itself) only gets a new version onto the
+ * device the first time. After that, the browser's own "is there an update"
+ * check only runs on a fresh navigation — which a PWA resumed from the home
+ * screen may never trigger again once launched, since resuming isn't a new
+ * navigation. Reproduced directly: a release sat undetected on a phone that
+ * had the app open days earlier, and clearing site data was the only way
+ * found to pick it up short of this.
+ *
+ * registerType: 'autoUpdate' (see vite.config.ts) already means an update,
+ * once *found*, activates and reloads the page with no prompt — that part
+ * needs nothing further, see registerSW's own default `onNeedReload`
+ * behaviour. Finding it in the first place is the only piece that was
+ * missing, so that's the only piece this adds.
+ */
+export function registerServiceWorker(): void {
+  registerSW({
+    immediate: true,
+    // Previously unhandled: a registration failure had nowhere to go and
+    // was silently swallowed — found while verifying this change, in an
+    // environment where registration itself failed. Logged rather than
+    // surfaced to the user: the app already works without a service worker,
+    // just without offline support or background updates, so this is worth
+    // knowing about from the console, not worth interrupting anyone over.
+    onRegisterError(error) {
+      console.error('Service worker registration failed:', error)
+    },
+    onRegisteredSW(_swScriptUrl, registration) {
+      if (!registration) return
+
+      const checkForUpdate = () => {
+        void registration.update()
+      }
+
+      // Same trigger useProducts already refreshes data on, for the same
+      // reason: this app is opened and closed, not left running in the
+      // foreground — phone into pocket, phone out of pocket, in front of
+      // the fridge. Whatever brings the tab back is also the moment worth
+      // asking "is there a newer version yet".
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') checkForUpdate()
+      })
+      window.addEventListener('online', checkForUpdate)
+    },
+  })
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />
 
 interface ImportMetaEnv {
   /** Base URL of the FastAPI backend. Unset means the relative "/api" path. */


### PR DESCRIPTION
## Summary
Reported live: after deploying a new release from the home server, a phone that already had the PWA open didn't pick it up — clearing cookies/site data was the only thing that worked.

Root cause, found by reading the actual generated registration script rather than guessing: vite-plugin-pwa's default auto-injected registration is exactly `if('serviceWorker' in navigator) window.addEventListener('load', () => navigator.serviceWorker.register(...))` — once, on load, nothing more. The browser's own automatic "is there a newer service worker" check only runs on a fresh top-level navigation. A PWA resumed from the home screen icon isn't necessarily a fresh navigation — the process can just resume — so the check may never fire again after the first install, for as long as the app stays "open" in that sense.

`registerType: 'autoUpdate'` (already configured) was never the problem: once an update *is found*, it activates and reloads the page automatically, no prompt. Finding it in the first place was the missing piece.

- Explicit `registerSW()` via `virtual:pwa-register` in a new `registerServiceWorker.ts`, called from `main.tsx` — this also makes vite-plugin-pwa skip its own auto-injected script (confirmed in the build output: `dist/index.html` no longer has it, and `workbox-window` is now bundled where it wasn't before).
- `registration.update()` fires whenever the tab becomes visible again or connectivity returns — same triggers `useProducts` already refreshes data on, same reasoning: this app is opened and closed, not left running.
- Logs a registration failure instead of silently swallowing it (previously the case) — found this gap while verifying the change.

## Test plan
- [x] Frontend: `vitest` — 226 passed (5 new, covering `registerServiceWorker`'s own logic in isolation: registers immediately, checks on visible/online, does *not* check while hidden, doesn't throw if registration failed).
- [x] `tsc -b` and `eslint` clean.
- [x] `npm run build`: confirmed `workbox-window` is now a real bundled chunk (wasn't before), and the plugin's auto-injected `<script>` tag is gone from `dist/index.html` — the wiring is correct, not just present in source.
- [ ] Live SW registration itself: attempted via `vite preview` in the available browser tooling, but service worker registration fails there for what looks like an environment restriction unrelated to this change (`navigator.serviceWorker.register()` rejects with "An unknown error occurred when fetching the script" even called manually, while the exact same script serves fine over plain HTTP). Since the app already runs a service worker successfully in production today, this needs confirming on a real device after deploy rather than in this tool.