### PR TITLE
fix: raise nginx's upload size limit so label photos actually reach the API

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -118,6 +118,17 @@ server {
     # The API serves /products, not /api/products, so the prefix has to come
     # off. This mirrors the rewrite the Vite dev server does in development.
     location ^~ /api/ {
+        # nginx's own default (1m) rejects a real phone photo long before
+        # the API's own 10 MB check in app/routers/vision.py ever runs, and
+        # with a generic 413 that carries none of that endpoint's error
+        # message — reproduced directly: POST /api/vision/label 413, no
+        # detail, on every device, even a photo well under 10 MB. Kept a
+        # couple MB above the API's own limit so that limit, with its own
+        # clearer message, is what actually decides whether a file is too
+        # large. /vision/label is the only upload this app has; everything
+        # else in /api/ is small JSON, unaffected either way.
+        client_max_body_size 12m;
+
         # Held in a variable on purpose: a literal here is resolved once at
         # startup, and the resolver above is only consulted when the upstream
         # name comes from a variable.


### PR DESCRIPTION
## Summary
Reported live: uploading a label photo (#83) fails on every device with `POST /api/vision/label 413 (Content Too Large)`, and the frontend shows the generic "Ocurrió un error inesperado." instead of the API's own "La imagen es demasiado grande" (from `app/routers/vision.py`'s 10 MB check). That mismatch is the tell: the request never reached FastAPI at all.

Root cause: `frontend/nginx.conf` — the nginx that serves the built SPA and proxies `/api/*` to the backend container — never set `client_max_body_size`, so it uses the compiled-in default of **1 MB**. Any real phone photo is well over that. This app had no file upload before #83, so nothing had ever exercised this before.

Fix: `client_max_body_size 12m;` on the `/api/` location — a couple MB above the API's own 10 MB limit, so *that* check (with its own clear message) is what actually decides whether a photo is too large, not nginx's generic one.

## Test plan
- [x] Built the actual `frontend/Dockerfile` image and ran it standalone.
- [x] Before this change (checked out `main`'s `nginx.conf`): confirmed a 3 MB payload gets `413` directly from nginx.
- [x] After this change: the same 3 MB payload gets `502` (no live upstream in this isolated container-only test — the point is it got *past* nginx's size gate and attempted `proxy_pass`, where before it never did).
- [x] A 13 MB payload (over the new 12 MB ceiling) still correctly gets `413` — the ceiling itself works, just raised to somewhere a real photo actually fits under it.

No frontend/backend code changed — this is nginx config only, so no new unit tests apply.