### PR TITLE
fix: downscale a label photo before upload, log Ollama's real error

### DIFF
--- a/backend/app/vision_client.py
+++ b/backend/app/vision_client.py
@@ -26,12 +26,15 @@ from app.schemas.vision import LabelExtraction
 
 logger = logging.getLogger(__name__)
 
-# Measured directly against the real server: a warm qwen3.5:4b answers a
-# ~700x500 test label in 1.5-2s. A real phone photo is larger and a cold
-# model load has measured at 6.7s for the (much cheaper) icon prompt alone —
-# 30s leaves real room for both without leaving a genuinely unreachable
-# Ollama able to stall product creation for long.
-TIMEOUT_SECONDS = 30.0
+# Measured directly against the real server, at the resolution the frontend
+# now actually sends (downscaled to 1600px on the long edge — see
+# downscaleImage.ts; a full 3024x4032 phone photo measured 61.5s on this same
+# server, more than double this whole budget, which is what motivated
+# downscaling in the first place rather than just raising this further): a
+# cold model load answered a downscaled real label in 23.8s, warm in 1.4s.
+# 45s leaves real headroom over that cold measurement without leaving a
+# genuinely unreachable Ollama able to stall product creation for long.
+TIMEOUT_SECONDS = 45.0
 
 # Grammar-constrained decoding, same as the icon client — a free-text prompt
 # is not reliable enough to parse for a field this consequential.
@@ -120,6 +123,18 @@ def extract_label(image_bytes: bytes) -> LabelExtraction | None:
             timeout=TIMEOUT_SECONDS,
         )
         response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        # Previously logged as just "HTTPStatusError" — the class name alone,
+        # with the actual status and Ollama's own explanation of it thrown
+        # away. Found live: a real photo failing with no way to tell whether
+        # Ollama rejected the request outright or crashed trying to process
+        # it, without shelling into the server to read its own logs.
+        logger.warning(
+            "Ollama label extraction returned %s: %r",
+            exc.response.status_code,
+            exc.response.text[:500],
+        )
+        return None
     except httpx.HTTPError as exc:
         logger.warning("Ollama label extraction failed: %s", exc.__class__.__name__)
         return None

--- a/backend/tests/test_vision_client.py
+++ b/backend/tests/test_vision_client.py
@@ -8,6 +8,7 @@ here would save it as a fact about a real product, which is exactly what
 """
 
 import json
+import logging
 
 import httpx
 import pytest
@@ -136,6 +137,24 @@ def test_returns_none_on_an_http_error_status(mocker):
     )
 
     assert extract_label(_IMAGE) is None
+
+
+def test_an_http_error_status_logs_the_status_and_ollamas_own_explanation(mocker, caplog):
+    """Previously logged only the exception's class name — "HTTPStatusError"
+    — with the actual status and Ollama's own error body thrown away, which
+    is exactly the detail needed to tell "Ollama rejected this outright"
+    apart from "Ollama crashed processing it" without shelling into the
+    server to read its own logs. See #83's live bug report."""
+    mocker.patch(
+        "app.vision_client.httpx.post",
+        return_value=httpx.Response(status_code=500, text="model crashed decoding image", request=_REQUEST),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="app.vision_client"):
+        extract_label(_IMAGE)
+
+    assert "500" in caplog.records[0].getMessage()
+    assert "model crashed decoding image" in caplog.records[0].getMessage()
 
 
 def test_returns_none_when_the_response_field_is_not_json(mocker):

--- a/frontend/src/components/ProductForm.tsx
+++ b/frontend/src/components/ProductForm.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, type ChangeEvent, type FormEvent } from 'react'
 
 import { Modal } from '@/components/Modal'
+import { downscaleImage } from '@/downscaleImage'
 import { LOCATION_LABELS } from '@/labels'
 import { canStepDown, stepQuantity } from '@/quantity'
 import { toErrorMessage } from '@/services/api'
@@ -91,7 +92,7 @@ export function ProductForm({ product, categories, onSaved, onCancel }: ProductF
     setScanHint(null)
     void (async () => {
       try {
-        const extracted = await extractLabel(file)
+        const extracted = await extractLabel(await downscaleImage(file))
         setForm((current) => ({
           ...current,
           name: extracted.name ?? current.name,

--- a/frontend/src/downscaleImage.test.ts
+++ b/frontend/src/downscaleImage.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeTargetDimensions, downscaleImage } from '@/downscaleImage'
+
+describe('computeTargetDimensions', () => {
+  it('leaves an image already within the limit untouched', () => {
+    expect(computeTargetDimensions(800, 600, 1600)).toEqual({ width: 800, height: 600 })
+  })
+
+  it('leaves an image exactly at the limit untouched', () => {
+    expect(computeTargetDimensions(1600, 1600, 1600)).toEqual({ width: 1600, height: 1600 })
+  })
+
+  it('scales a portrait photo down by its longer edge', () => {
+    // The exact shape of the real phone photo that motivated this — see the
+    // module docstring. Cross-checked against Pillow's own thumbnail() on
+    // the same dimensions: (1200, 1600).
+    expect(computeTargetDimensions(3024, 4032, 1600)).toEqual({ width: 1200, height: 1600 })
+  })
+
+  it('scales a landscape photo down by its longer edge', () => {
+    expect(computeTargetDimensions(4032, 3024, 1600)).toEqual({ width: 1600, height: 1200 })
+  })
+})
+
+describe('downscaleImage', () => {
+  it('falls back to the original file when resizing is not available', async () => {
+    // jsdom has neither createImageBitmap nor a real <canvas> — exercising
+    // exactly the fallback path a real browser would also take if either
+    // failed, per the module's own reasoning: a resize that cannot happen
+    // must not block the scan.
+    const file = new File(['fake'], 'label.jpg', { type: 'image/jpeg' })
+
+    const result = await downscaleImage(file)
+
+    expect(result).toBe(file)
+  })
+})

--- a/frontend/src/downscaleImage.ts
+++ b/frontend/src/downscaleImage.ts
@@ -1,0 +1,66 @@
+/**
+ * Shrink a photo before it ever leaves the device — see #83's live bug
+ * report.
+ *
+ * A real phone photo (3024x4032 measured directly) took 61.5s against the
+ * vision model on the actual server, more than double the API's own
+ * timeout, and vision models don't read text any more accurately past a
+ * point their own patch size already sets — sending the full resolution was
+ * pure cost with no upside. 1600px on the long edge measured 23.8s cold,
+ * 1.4s warm, on the same server, same label, extracted every field
+ * correctly. Re-encoding through canvas is also a forced conversion to
+ * JPEG, incidentally ruling out a source format server-side decoding
+ * struggles with (HEIC, notably, on an iPhone that didn't convert on
+ * capture) as a second, independent way this was failing.
+ */
+
+const MAX_DIMENSION = 1600
+const JPEG_QUALITY = 0.85
+
+/** Pure and cheap to test: the actual pixel math, without any canvas or
+ *  image-decoding dependency. */
+export function computeTargetDimensions(
+  width: number,
+  height: number,
+  maxDimension: number = MAX_DIMENSION,
+): { width: number; height: number } {
+  if (width <= maxDimension && height <= maxDimension) return { width, height }
+  const scale = maxDimension / Math.max(width, height)
+  return { width: Math.round(width * scale), height: Math.round(height * scale) }
+}
+
+/**
+ * Downscale and re-encode `file` as a JPEG Blob, or return it unchanged if
+ * anything about that fails — a resize that cannot happen must not block
+ * the scan entirely, the same reasoning #83's whole feature already applies
+ * to a failed model call: degrade towards manual entry, never towards a
+ * dead end.
+ */
+export async function downscaleImage(file: File): Promise<Blob> {
+  try {
+    const bitmap = await createImageBitmap(file)
+    try {
+      const { width, height } = computeTargetDimensions(bitmap.width, bitmap.height)
+
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return file
+
+      ctx.drawImage(bitmap, 0, 0, width, height)
+
+      return await new Promise<Blob>((resolve) => {
+        canvas.toBlob(
+          (blob) => resolve(blob ?? file),
+          'image/jpeg',
+          JPEG_QUALITY,
+        )
+      })
+    } finally {
+      bitmap.close()
+    }
+  } catch {
+    return file
+  }
+}

--- a/frontend/src/services/visionService.test.ts
+++ b/frontend/src/services/visionService.test.ts
@@ -27,7 +27,13 @@ describe('visionService', () => {
     const [path, body] = mockedApi.post.mock.calls[0]
     expect(path).toBe('/vision/label')
     expect(body).toBeInstanceOf(FormData)
-    expect((body as FormData).get('image')).toBe(image)
+    // Not toBe(image): a caller may pass a plain Blob (downscaleImage.ts's
+    // canvas output has no filename of its own), so this always attaches
+    // one explicitly — the appended value is a fresh File wrapping the same
+    // bytes, not the original reference.
+    const attached = (body as FormData).get('image') as File
+    expect(attached.name).toBe('label.jpg')
+    expect(await attached.text()).toBe(await image.text())
   })
 
   it('overrides the default JSON content type, or axios silently stringifies the file away', async () => {

--- a/frontend/src/services/visionService.ts
+++ b/frontend/src/services/visionService.ts
@@ -17,10 +17,14 @@ import type { LabelExtraction } from '@/services/types'
  * already look like JSON — reproduced directly against the real backend,
  * which received a 422 "field required" for `image` without this override,
  * because the file never left as multipart at all.
+ *
+ * Takes a Blob, not specifically a File: the caller downscales through
+ * downscaleImage.ts first, which produces a plain Blob — canvas re-encoding
+ * has no filename to preserve, so one is supplied here instead.
  */
-export async function extractLabel(image: File): Promise<LabelExtraction> {
+export async function extractLabel(image: Blob): Promise<LabelExtraction> {
   const form = new FormData()
-  form.append('image', image)
+  form.append('image', image, 'label.jpg')
   const { data } = await api.post<LabelExtraction>('/vision/label', form, {
     headers: { 'Content-Type': 'multipart/form-data' },
   })


### PR DESCRIPTION
## Summary
Reported live: `POST /vision/label` failing with `Ollama label extraction failed: HTTPStatusError` in the logs and a generic "Ocurrió un error inesperado." in the UI — not the API's own more specific message, and the logged exception name alone gave no way to tell *why* Ollama returned an error status.

Couldn't perfectly reproduce the exact `HTTPStatusError` (my attempt at a real phone-camera-resolution photo timed out rather than erroring, on the same server) — but reproducing at that resolution surfaced a serious, closely related problem regardless: a 3024x4032 label (real phone resolution, not this feature's earlier small synthetic test images) took **61.5s** against the real Ollama server, more than double the API's own 30s timeout, for zero accuracy benefit. A vision model doesn't read text more accurately past its own patch size; 1600px on the long edge extracted every field correctly in 23.8s cold / 1.4s warm on the same server, same label.

- New `downscaleImage.ts`: resizes to 1600px on the long edge, re-encodes as JPEG via canvas, before the photo ever leaves the device. Falls back to the original file if resizing fails for any reason. Incidentally forces a universally-decodable format regardless of source — plausibly the original `HTTPStatusError` on its own, if the source was HEIC (default iPhone camera format) and Ollama's image decoder doesn't support it.
- `vision_client.py`: an `HTTPStatusError` now logs the actual status code and Ollama's own response body (truncated), not just the exception class name.
- `TIMEOUT_SECONDS`: 30s → 45s, real headroom over the 23.8s cold measurement at the resolution now actually sent.

## Test plan
- [x] Backend: `pytest` — 223 passed (1 new: the `HTTPStatusError` branch logs the real status and body).
- [x] Backend: `ruff check` clean.
- [x] Frontend: `vitest` — 231 passed (5 new: `computeTargetDimensions`'s pixel math against real measured dimensions, cross-checked against Pillow's own `thumbnail()` on the same numbers; `downscaleImage`'s fallback behavior).
- [x] Frontend: `tsc -b` and `eslint` clean.
- [x] Live, in a real browser (canvas/`createImageBitmap` don't exist in the jsdom test environment): ran `downscaleImage` directly against a real 3024x4032 synthetic photo — confirmed 1200x1600 JPEG output, correct dimensions, smaller size, genuinely a new object.
- [x] Live, end-to-end through the actual running app: dispatched that same real-resolution photo through the real file input, confirmed the network request succeeded, and the real Ollama server correctly extracted and disambiguated the date, populating the form.