### PR TITLE
fix: send explicit Cache-Control so the service worker's update check can't see a stale sw.js

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -146,8 +146,28 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
+    # Vite content-hashes every filename under /assets — a new deploy is a
+    # new filename, so nothing already cached under an old one is ever
+    # served stale. Safe, and worth doing, to cache these forever.
+    location ^~ /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
     # Serve the SPA — fall back to index.html so a refresh on any path works.
+    #
+    # no-cache (revalidate every time, not "never cache") on purpose: nginx's
+    # default was no Cache-Control at all here, which left every layer
+    # between here and a phone — including Cloudflare's own edge cache, the
+    # thing actually in front of this in production — free to keep answering
+    # sw.js and index.html with an old copy on its own schedule. That silently
+    # defeats registerServiceWorker.ts's own update check: it can only see a
+    # new version by fetching a byte-different sw.js, which does nothing if
+    # what it fetches is a cached copy of the one already installed.
+    # Reproduced live: the backend already serving a new release, the
+    # frontend stuck on the old one, on two separate devices, for several
+    # minutes, nothing self-correcting.
     location / {
+        add_header Cache-Control "no-cache";
         try_files $uri $uri/ /index.html;
     }
 }


### PR DESCRIPTION
## Summary
Follow-up to #98. Reported live: after deploying a new release, the backend served the new version immediately but the frontend stayed on the old one — on two separate devices, for several minutes, nothing self-correcting.

`registerServiceWorker.ts` (#98) does its half correctly: it asks the browser to check for a new service worker whenever the tab becomes visible or connectivity returns. What it can't do anything about is what actually answers that check. `nginx.conf` sent no `Cache-Control` at all for `sw.js` or `index.html`, leaving every layer between the server and a phone — including Cloudflare's own edge cache, the thing actually in front of this in production — free to keep answering with an old cached copy on its own schedule. Two devices going stale **at the same time**, not independently, is the signature of a shared edge cache, not a per-device browser cache — which is what pointed here rather than back at #98's own logic.

- `sw.js`, `index.html`, and everything else `location /` falls back to: `Cache-Control: no-cache` — always revalidate, never serve a locally-cached copy without checking first.
- `/assets/*`: `Cache-Control: public, max-age=31536000, immutable` — Vite content-hashes every filename here, so a new deploy is a new filename and nothing cached under an old one is ever served stale. Caching these forever is what makes the `no-cache` rule above affordable rather than a step backwards for load time.

No application code changed — this is nginx config only.

## Test plan
- [x] Built the actual `frontend/Dockerfile` image and ran it standalone.
- [x] `curl -I /sw.js` → `Cache-Control: no-cache`.
- [x] `curl -I /` → `Cache-Control: no-cache`.
- [x] `curl -I` a real hashed `/assets/index-*.js` → `Cache-Control: public, max-age=31536000, immutable`.
- [x] Confirmed the SPA client-route fallback (`try_files ... /index.html`) still works and also gets `no-cache`.