### PR TITLE
feat: import a shopping trip from a photo of the receipt

### DIFF
--- a/backend/alembic/versions/b4566f75e1df_create_shopping_trips_tables.py
+++ b/backend/alembic/versions/b4566f75e1df_create_shopping_trips_tables.py
@@ -1,0 +1,52 @@
+"""create shopping trips tables
+
+Revision ID: b4566f75e1df
+Revises: 2e871a12d0b8
+Create Date: 2026-09-01 13:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b4566f75e1df'
+down_revision: str | None = '2e871a12d0b8'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('shopping_trips',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.Column('stated_item_count', sa.Integer(), nullable=True),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_shopping_trips')),
+    schema='cadutrack'
+    )
+    op.create_table('shopping_trip_items',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('trip_id', sa.Integer(), nullable=False),
+    sa.Column('name', sa.String(length=255), nullable=False),
+    sa.Column('quantity', sa.Numeric(precision=10, scale=2), nullable=False),
+    sa.Column('is_food', sa.Boolean(), server_default='true', nullable=False),
+    sa.Column('resolved_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('product_id', sa.Integer(), nullable=True),
+    sa.CheckConstraint('quantity > 0', name=op.f('ck_shopping_trip_items_quantity_positive')),
+    sa.ForeignKeyConstraint(['product_id'], ['cadutrack.products.id'], name=op.f('fk_shopping_trip_items_product_id_products'), ondelete='SET NULL'),
+    sa.ForeignKeyConstraint(['trip_id'], ['cadutrack.shopping_trips.id'], name=op.f('fk_shopping_trip_items_trip_id_shopping_trips'), ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_shopping_trip_items')),
+    schema='cadutrack'
+    )
+    op.create_index(op.f('ix_cadutrack_shopping_trip_items_trip_id'), 'shopping_trip_items', ['trip_id'], unique=False, schema='cadutrack')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_cadutrack_shopping_trip_items_trip_id'), table_name='shopping_trip_items', schema='cadutrack')
+    op.drop_table('shopping_trip_items', schema='cadutrack')
+    op.drop_table('shopping_trips', schema='cadutrack')

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.logging_config import setup_logging
-from app.routers import alerts, categories, health, products, reauth, vision
+from app.routers import alerts, categories, health, products, reauth, trips, vision
 from app.routers import settings as settings_router
 from app.scheduler import shutdown_scheduler, start_scheduler
 
@@ -48,5 +48,6 @@ app.include_router(alerts.router)
 app.include_router(settings_router.router)
 app.include_router(vision.router)
 app.include_router(reauth.router)
+app.include_router(trips.router)
 
 logger.info("CaduTrack API started")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -7,6 +7,7 @@ Base.metadata before autogenerate runs.
 from app.models.category import Category
 from app.models.product import IconSource, Location, Product
 from app.models.setting import AlertSettings, IconNameCache, IconSettings
+from app.models.trip import ShoppingTrip, ShoppingTripItem
 
 __all__ = [
     "AlertSettings",
@@ -16,4 +17,6 @@ __all__ = [
     "IconSource",
     "Location",
     "Product",
+    "ShoppingTrip",
+    "ShoppingTripItem",
 ]

--- a/backend/app/models/trip.py
+++ b/backend/app/models/trip.py
@@ -1,0 +1,70 @@
+"""Shopping trip models — see #84."""
+
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import Boolean, CheckConstraint, DateTime, ForeignKey, Integer, Numeric, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class ShoppingTrip(Base):
+    """A receipt photo's items, staged until each is either turned into a
+    product or explicitly dropped.
+
+    Not itself trusted inventory data: nothing here is a Product, and
+    nothing here reaches the products table until a specific item is
+    resolved through its own endpoint, with a date the receipt never had.
+    """
+
+    __tablename__ = "shopping_trips"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    # What the model read off the receipt's own printed total, e.g.
+    # "ARTICULOS COMPRADOS: 19" — see #84's reconciliation check. Null when
+    # the receipt didn't show one or the model couldn't read it, in which
+    # case there is nothing to reconcile against, not a mismatch.
+    stated_item_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    items: Mapped[list["ShoppingTripItem"]] = relationship(
+        back_populates="trip", cascade="all, delete-orphan", order_by="ShoppingTripItem.id"
+    )
+
+    def __repr__(self) -> str:
+        return f"<ShoppingTrip id={self.id} items={len(self.items)}>"
+
+
+class ShoppingTripItem(Base):
+    """One line read from a receipt photo."""
+
+    __tablename__ = "shopping_trip_items"
+    __table_args__ = (
+        CheckConstraint("quantity > 0", name="ck_shopping_trip_items_quantity_positive"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    trip_id: Mapped[int] = mapped_column(
+        ForeignKey("shopping_trips.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    quantity: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
+    # The model's own guess at whether this line is worth tracking at all —
+    # see #84: "non-food is a real fraction" of a typical receipt. Drives the
+    # checklist's initial tick state; the user can still override it either
+    # way before resolving the item.
+    is_food: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+    # Set once dealt with, one way or the other. product_id distinguishes
+    # which way: still null means the item was dropped, not added.
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    product_id: Mapped[int | None] = mapped_column(
+        ForeignKey("products.id", ondelete="SET NULL"), nullable=True
+    )
+
+    trip: Mapped[ShoppingTrip] = relationship(back_populates="items")
+
+    def __repr__(self) -> str:
+        return f"<ShoppingTripItem id={self.id} name={self.name!r} resolved={self.resolved_at is not None}>"

--- a/backend/app/receipt_client.py
+++ b/backend/app/receipt_client.py
@@ -1,0 +1,187 @@
+"""A local Ollama call for reading a shopping receipt photo — see #84.
+
+Same never-raise contract as app/vision_client.py, for the same reason: an
+unconfigured URL, a refused connection, a timeout, an HTTP error, or a
+response that doesn't parse are all reported as None, and the caller falls
+back to manual entry rather than blocking on a model that might be down,
+slow, or mid-restart.
+
+A separate module rather than folded into vision_client.py: the request
+shape (an array of lines, not one name/date/weight triple) and the failure
+semantics (a single bad line is dropped, not the whole extraction) are
+different enough that sharing one function would mean branching on which
+call this actually is throughout.
+"""
+
+import base64
+import json
+import logging
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Same reasoning as vision_client.py's own budget: a downscaled real-photo
+# request measured in the tens of seconds, not the sub-2s a tiny synthetic
+# image suggested early on. A receipt has more lines to read than a single
+# label, so it gets the same generous number rather than a tighter one.
+TIMEOUT_SECONDS = 45.0
+
+_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "items": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "quantity": {"type": "number"},
+                    "is_food": {"type": "boolean"},
+                },
+                "required": ["name", "quantity", "is_food"],
+            },
+        },
+        "stated_item_count": {"type": ["integer", "null"]},
+    },
+    "required": ["items", "stated_item_count"],
+}
+
+_PROMPT = (
+    "Analiza esta foto de un recibo o ticket de compra de supermercado.\n\n"
+    "Para cada línea de producto, extrae:\n"
+    "- name: el nombre del producto, expandido y corregido a partir del "
+    "texto impreso (los recibos abrevian y truncan nombres — por ejemplo "
+    "'CHAMP CREMINI' es 'Champiñones cremini', 'HEB MILANESA DE PULPA NEG' "
+    "es 'Milanesa de pulpa negra'). Usa el nombre más natural en español.\n"
+    "- quantity: la cantidad comprada de ese producto (la columna de "
+    "cantidad, no el precio).\n"
+    "- is_food: true si es algo que se come o se bebe — esto incluye "
+    "frutas, verduras y otros productos frescos sin empaque (nopal, "
+    "plátano, cilantro, etc.), carnes, lácteos, botanas y bebidas. false "
+    "solo si es un producto de limpieza, higiene personal, ferretería u "
+    "otro artículo que claramente no se come.\n\n"
+    "Ignora líneas que no sean productos (subtotales, forma de pago, "
+    "dirección de la tienda, etc.).\n\n"
+    "Si el recibo muestra un total de artículos comprados (por ejemplo "
+    "'ARTICULOS COMPRADOS: 19'), captúralo en stated_item_count. Si no "
+    "aparece, usa null."
+)
+
+
+@dataclass
+class ReceiptItem:
+    name: str
+    quantity: Decimal
+    is_food: bool
+
+
+@dataclass
+class ReceiptExtraction:
+    items: list[ReceiptItem]
+    stated_item_count: int | None
+
+
+def _parse_item(raw: object) -> ReceiptItem | None:
+    """One line of the model's own response, or None if it doesn't hold
+    together — dropped rather than failing the whole receipt, so one bad
+    line costs one line, not the trip. #84's reconciliation check is what
+    surfaces that a line went missing this way, rather than it happening
+    silently."""
+    if not isinstance(raw, dict):
+        return None
+
+    name = raw.get("name")
+    name = name.strip() if isinstance(name, str) else ""
+    if not name:
+        return None
+
+    quantity = raw.get("quantity")
+    if not isinstance(quantity, (int, float)) or isinstance(quantity, bool):
+        return None
+    try:
+        quantity = Decimal(str(quantity)).quantize(Decimal("0.01"))
+    except InvalidOperation:
+        return None
+    if quantity <= 0:
+        return None
+
+    is_food = raw.get("is_food")
+    if not isinstance(is_food, bool):
+        return None
+
+    return ReceiptItem(name=name, quantity=quantity, is_food=is_food)
+
+
+def _parse_stated_item_count(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if value > 0 else None
+
+
+def extract_receipt(image_bytes: bytes) -> ReceiptExtraction | None:
+    """Best-effort line items read from a receipt photo, or None on total
+    failure — see the module docstring for what "total failure" means here
+    versus a single dropped line."""
+    if not settings.ollama_url:
+        return None
+
+    try:
+        response = httpx.post(
+            f"{settings.ollama_url}/api/generate",
+            json={
+                "model": settings.ollama_model,
+                "prompt": _PROMPT,
+                "images": [base64.b64encode(image_bytes).decode("ascii")],
+                "stream": False,
+                "think": False,
+                "format": _RESPONSE_SCHEMA,
+                # Same reasoning as vision_client.py: the model's configured
+                # defaults are tuned for varied icon picks, not consequential
+                # extraction. Determinism over variety here too.
+                "options": {"temperature": 0},
+            },
+            timeout=TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        logger.warning(
+            "Ollama receipt extraction returned %s: %r",
+            exc.response.status_code,
+            exc.response.text[:500],
+        )
+        return None
+    except httpx.HTTPError as exc:
+        logger.warning("Ollama receipt extraction failed: %s", exc.__class__.__name__)
+        return None
+
+    try:
+        raw = json.loads(response.json()["response"])
+    except (KeyError, TypeError, ValueError) as exc:
+        logger.warning(
+            "Ollama returned an unparsable receipt response (%s): %r",
+            exc.__class__.__name__,
+            response.text[:200],
+        )
+        return None
+
+    raw_items = raw.get("items")
+    if not isinstance(raw_items, list):
+        return None
+
+    items = [parsed for entry in raw_items if (parsed := _parse_item(entry)) is not None]
+    if not items:
+        # Every line failed to parse, or the model found none — a "receipt"
+        # extraction with nothing on it is not a usable answer, the same
+        # judgement vision_client.py makes for an all-null label.
+        logger.warning("Ollama receipt extraction returned no usable line items")
+        return None
+
+    return ReceiptExtraction(
+        items=items,
+        stated_item_count=_parse_stated_item_count(raw.get("stated_item_count")),
+    )

--- a/backend/app/routers/trips.py
+++ b/backend/app/routers/trips.py
@@ -1,0 +1,170 @@
+"""Shopping trip endpoints — see #84."""
+
+import logging
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from sqlalchemy import exists, func, select
+from sqlalchemy.orm import Session, selectinload
+
+from app.db.session import get_db
+from app.models import Product, ShoppingTrip, ShoppingTripItem
+from app.receipt_client import extract_receipt
+from app.schemas.trip import (
+    ShoppingTripItemRead,
+    ShoppingTripItemResolve,
+    ShoppingTripItemUpdate,
+    ShoppingTripRead,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/trips", tags=["trips"])
+
+# Same ceiling and reasoning as /vision/label: a phone photo is a few MB at
+# most, this is a generous bound against a mistake or abuse, not a limit
+# meant to bind on a real receipt photo.
+_MAX_IMAGE_BYTES = 10 * 1024 * 1024
+
+
+def _with_items(statement):
+    return statement.options(selectinload(ShoppingTrip.items))
+
+
+def _get_trip_or_404(db: Session, trip_id: int) -> ShoppingTrip:
+    trip = db.execute(_with_items(select(ShoppingTrip).where(ShoppingTrip.id == trip_id))).scalar_one_or_none()
+    if trip is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Trip not found")
+    return trip
+
+
+def _get_item_or_404(db: Session, trip_id: int, item_id: int) -> ShoppingTripItem:
+    item = db.get(ShoppingTripItem, item_id)
+    if item is None or item.trip_id != trip_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item not found")
+    return item
+
+
+def _require_unresolved(item: ShoppingTripItem) -> None:
+    if item.resolved_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Item has already been resolved"
+        )
+
+
+@router.get("/current", response_model=ShoppingTripRead | None)
+def get_current_trip(db: Session = Depends(get_db)) -> ShoppingTrip | None:
+    """The most recent trip with at least one unresolved item, or null.
+
+    "Current" is computed, not stored: a trip has no status field of its
+    own, since whether it still needs attention is fully determined by its
+    items and would only be able to drift out of sync as a stored copy of
+    that. Null rather than 404 — nothing went wrong, there is simply
+    nothing to resume, which the client checks unconditionally on load the
+    same way it checks for an empty product list.
+    """
+    statement = _with_items(
+        select(ShoppingTrip)
+        .where(
+            exists().where(
+                ShoppingTripItem.trip_id == ShoppingTrip.id, ShoppingTripItem.resolved_at.is_(None)
+            )
+        )
+        .order_by(ShoppingTrip.created_at.desc())
+        .limit(1)
+    )
+    return db.execute(statement).scalars().first()
+
+
+@router.post("/receipt", response_model=ShoppingTripRead, status_code=status.HTTP_201_CREATED)
+async def create_trip_from_receipt(
+    image: UploadFile = File(...), db: Session = Depends(get_db)
+) -> ShoppingTrip:
+    """Read a receipt photo into a new trip's checklist.
+
+    Persists immediately, unlike /vision/label: the whole point of a trip is
+    surviving a reload without asking for the photo again — see #84's "an
+    unfinished trip is still visible on the next visit". This does not
+    conflict with "nothing is saved without confirmation": that guarantee is
+    about products, and nothing here is one. A trip item only reaches the
+    products table through its own dedicated resolve endpoint, same as
+    every other create in this API going through its own confirmation step.
+    """
+    contents = await image.read()
+    if not contents:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="La imagen está vacía")
+    if len(contents) > _MAX_IMAGE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE, detail="La imagen es demasiado grande"
+        )
+
+    extraction = extract_receipt(contents)
+    if extraction is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="No se pudo leer el recibo. Agrega los productos manualmente.",
+        )
+
+    trip = ShoppingTrip(stated_item_count=extraction.stated_item_count)
+    for item in extraction.items:
+        trip.items.append(ShoppingTripItem(name=item.name, quantity=item.quantity, is_food=item.is_food))
+
+    db.add(trip)
+    db.commit()
+    logger.info("Created shopping trip %s with %d items", trip.id, len(trip.items))
+    return _get_trip_or_404(db, trip.id)
+
+
+@router.patch("/{trip_id}/items/{item_id}", response_model=ShoppingTripItemRead)
+def update_trip_item(
+    trip_id: int, item_id: int, payload: ShoppingTripItemUpdate, db: Session = Depends(get_db)
+) -> ShoppingTripItem:
+    """Correct a line's name, quantity, or food classification before
+    resolving it — a receipt's own text arrives abbreviated and is
+    sometimes misread."""
+    item = _get_item_or_404(db, trip_id, item_id)
+    _require_unresolved(item)
+
+    item.name = payload.name
+    item.quantity = payload.quantity
+    item.is_food = payload.is_food
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.post("/{trip_id}/items/{item_id}/drop", response_model=ShoppingTripItemRead)
+def drop_trip_item(trip_id: int, item_id: int, db: Session = Depends(get_db)) -> ShoppingTripItem:
+    """Mark a line as dealt with without adding a product for it — the
+    checklist's uncheck-and-confirm action for a non-food line, or any
+    other line not worth tracking."""
+    item = _get_item_or_404(db, trip_id, item_id)
+    _require_unresolved(item)
+
+    item.resolved_at = func.now()
+    db.commit()
+    db.refresh(item)
+    logger.info("Dropped trip item %s (%s) from trip %s", item.id, item.name, trip_id)
+    return item
+
+
+@router.post("/{trip_id}/items/{item_id}/resolve", response_model=ShoppingTripItemRead)
+def resolve_trip_item(
+    trip_id: int, item_id: int, payload: ShoppingTripItemResolve, db: Session = Depends(get_db)
+) -> ShoppingTripItem:
+    """Link a line to the product it became, once the client has already
+    created that product through the normal POST /products."""
+    item = _get_item_or_404(db, trip_id, item_id)
+    _require_unresolved(item)
+
+    if db.get(Product, payload.product_id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Product {payload.product_id} does not exist",
+        )
+
+    item.resolved_at = func.now()
+    item.product_id = payload.product_id
+    db.commit()
+    db.refresh(item)
+    logger.info("Resolved trip item %s (%s) into product %s", item.id, item.name, payload.product_id)
+    return item

--- a/backend/app/schemas/trip.py
+++ b/backend/app/schemas/trip.py
@@ -1,0 +1,69 @@
+"""Shopping trip request and response schemas — see #84."""
+
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field, computed_field
+
+
+class ShoppingTripItemRead(BaseModel):
+    """One line read from a receipt photo, as returned by the API."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    quantity: Decimal
+    is_food: bool
+    resolved_at: datetime | None
+    product_id: int | None
+
+
+class ShoppingTripRead(BaseModel):
+    """A shopping trip and its items, as returned by the API."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    created_at: datetime
+    stated_item_count: int | None
+    items: list[ShoppingTripItemRead]
+
+    @computed_field
+    @property
+    def counted_quantity(self) -> Decimal:
+        """The sum of every line's quantity — the free checksum #84 asks
+        for, compared against stated_item_count."""
+        return sum((item.quantity for item in self.items), Decimal(0))
+
+    @computed_field
+    @property
+    def reconciled(self) -> bool | None:
+        """None when there is nothing to reconcile against — the receipt
+        didn't show its own total, or the model couldn't read it — which is
+        a different situation from a real mismatch and must not render as
+        one. Otherwise whether the summed quantities match it."""
+        if self.stated_item_count is None:
+            return None
+        return self.counted_quantity == self.stated_item_count
+
+
+class ShoppingTripItemUpdate(BaseModel):
+    """Payload for correcting a line before resolving it — a receipt's own
+    text arrives abbreviated and sometimes misread; see #84."""
+
+    name: str = Field(min_length=1, max_length=255)
+    quantity: Decimal = Field(gt=0, max_digits=10, decimal_places=2)
+    is_food: bool
+
+
+class ShoppingTripItemResolve(BaseModel):
+    """Payload linking a line to the product it became.
+
+    Deliberately just an id, not a second copy of the product-creation
+    fields: the client creates the product through the normal POST
+    /products first — full validation, icon assignment, everything that
+    already works — and only then reports which product this line became.
+    """
+
+    product_id: int

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -49,7 +49,8 @@ def db_session():
     session = SessionLocal()
     session.execute(
         text(
-            "TRUNCATE products, categories, alert_settings, icon_settings, icon_name_cache "
+            "TRUNCATE products, categories, alert_settings, icon_settings, icon_name_cache, "
+            "shopping_trips, shopping_trip_items "
             "RESTART IDENTITY CASCADE"
         )
     )

--- a/backend/tests/test_receipt_client.py
+++ b/backend/tests/test_receipt_client.py
@@ -1,0 +1,173 @@
+"""Receipt client tests. No network — every case is a mocked httpx call.
+
+Every scenario asserts extract_receipt degrades gracefully — None on total
+failure, a bad individual line simply dropped — rather than raising or
+passing through an unvalidated value. See #84: a dropped line is meant to
+surface through the reconciliation check, not silently.
+"""
+
+import json
+
+import httpx
+import pytest
+
+from app.config import settings
+from app.receipt_client import extract_receipt
+
+_REQUEST = httpx.Request("POST", "http://ollama.example:11434/api/generate")
+_IMAGE = b"\xff\xd8\xff fake bytes, never actually decoded in these tests"
+
+
+@pytest.fixture(autouse=True)
+def ollama_configured(monkeypatch):
+    monkeypatch.setattr(settings, "ollama_url", "http://ollama.example:11434")
+    monkeypatch.setattr(settings, "ollama_model", "qwen3.5:4b")
+
+
+def _ok_response(items: list[dict], stated_item_count: int | None = None) -> httpx.Response:
+    body = {"items": items, "stated_item_count": stated_item_count}
+    return httpx.Response(
+        status_code=200,
+        json={"model": "qwen3.5:4b", "response": json.dumps(body), "done": True},
+        request=_REQUEST,
+    )
+
+
+def _item(name="Nopal limpio", quantity=1, is_food=True) -> dict:
+    return {"name": name, "quantity": quantity, "is_food": is_food}
+
+
+def test_returns_none_when_ollama_is_not_configured(monkeypatch):
+    monkeypatch.setattr(settings, "ollama_url", "")
+
+    assert extract_receipt(_IMAGE) is None
+
+
+def test_extracts_every_line_from_a_well_formed_response(mocker):
+    mocker.patch(
+        "app.receipt_client.httpx.post",
+        return_value=_ok_response(
+            [_item("Nopal limpio", 1, True), _item("Jabón Grisi", 2, False)],
+            stated_item_count=3,
+        ),
+    )
+
+    result = extract_receipt(_IMAGE)
+
+    assert [(i.name, str(i.quantity), i.is_food) for i in result.items] == [
+        ("Nopal limpio", "1.00", True),
+        ("Jabón Grisi", "2.00", False),
+    ]
+    assert result.stated_item_count == 3
+
+
+def test_a_missing_stated_item_count_is_none_not_a_mismatch(mocker):
+    mocker.patch(
+        "app.receipt_client.httpx.post",
+        return_value=_ok_response([_item()], stated_item_count=None),
+    )
+
+    assert extract_receipt(_IMAGE).stated_item_count is None
+
+
+@pytest.mark.parametrize(
+    "bad_item",
+    [
+        {"name": "", "quantity": 1, "is_food": True},
+        {"name": "   ", "quantity": 1, "is_food": True},
+        {"name": "Algo", "quantity": 0, "is_food": True},
+        {"name": "Algo", "quantity": -1, "is_food": True},
+        {"name": "Algo", "quantity": "two", "is_food": True},
+        {"name": "Algo", "quantity": 1, "is_food": "yes"},
+        {"quantity": 1, "is_food": True},
+        "not even an object",
+    ],
+)
+def test_a_malformed_line_is_dropped_not_the_whole_receipt(mocker, bad_item):
+    mocker.patch(
+        "app.receipt_client.httpx.post",
+        return_value=_ok_response([_item("Nopal limpio"), bad_item]),
+    )
+
+    result = extract_receipt(_IMAGE)
+
+    assert [i.name for i in result.items] == ["Nopal limpio"]
+
+
+def test_returns_none_when_every_line_is_malformed(mocker):
+    """A "receipt" extraction with nothing usable on it is not a usable
+    answer — the same judgement vision_client.py makes for an all-null
+    label, applied to "all items invalid" here."""
+    mocker.patch(
+        "app.receipt_client.httpx.post",
+        return_value=_ok_response([{"name": "", "quantity": 1, "is_food": True}]),
+    )
+
+    assert extract_receipt(_IMAGE) is None
+
+
+def test_returns_none_when_items_is_missing_entirely(mocker):
+    mocker.patch(
+        "app.receipt_client.httpx.post",
+        return_value=httpx.Response(
+            status_code=200,
+            json={"model": "qwen3.5:4b", "response": json.dumps({"stated_item_count": 3}), "done": True},
+            request=_REQUEST,
+        ),
+    )
+
+    assert extract_receipt(_IMAGE) is None
+
+
+def test_a_negative_or_zero_stated_item_count_is_treated_as_absent(mocker):
+    mocker.patch(
+        "app.receipt_client.httpx.post",
+        return_value=_ok_response([_item()], stated_item_count=0),
+    )
+
+    assert extract_receipt(_IMAGE).stated_item_count is None
+
+
+def test_sends_think_false_stream_false_and_temperature_zero(mocker):
+    post = mocker.patch("app.receipt_client.httpx.post", return_value=_ok_response([_item()]))
+
+    extract_receipt(_IMAGE)
+
+    _, kwargs = post.call_args
+    assert kwargs["json"]["think"] is False
+    assert kwargs["json"]["stream"] is False
+    assert kwargs["json"]["options"] == {"temperature": 0}
+
+
+def test_returns_none_on_a_connection_failure(mocker):
+    mocker.patch("app.receipt_client.httpx.post", side_effect=httpx.ConnectError("refused"))
+
+    assert extract_receipt(_IMAGE) is None
+
+
+def test_returns_none_on_a_timeout(mocker):
+    mocker.patch("app.receipt_client.httpx.post", side_effect=httpx.TimeoutException("slow"))
+
+    assert extract_receipt(_IMAGE) is None
+
+
+def test_returns_none_on_an_http_error_status(mocker):
+    mocker.patch(
+        "app.receipt_client.httpx.post",
+        return_value=httpx.Response(status_code=500, text="boom", request=_REQUEST),
+    )
+
+    assert extract_receipt(_IMAGE) is None
+
+
+def test_returns_none_when_the_response_field_is_not_json(mocker):
+    mocker.patch(
+        "app.receipt_client.httpx.post",
+        return_value=httpx.Response(
+            status_code=200,
+            json={"model": "qwen3.5:4b", "response": "not json", "done": True},
+            request=_REQUEST,
+        ),
+    )
+
+    assert extract_receipt(_IMAGE) is None

--- a/backend/tests/test_trips_api.py
+++ b/backend/tests/test_trips_api.py
@@ -1,0 +1,266 @@
+"""Shopping trip endpoint tests."""
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.receipt_client import ReceiptExtraction, ReceiptItem
+
+pytestmark = pytest.mark.integration
+
+
+def _product(**overrides) -> dict:
+    payload = {
+        "name": "Leche entera",
+        "quantity": "2.00",
+        "unit": "litros",
+        "expires_at": str(date.today() + timedelta(days=5)),
+        "location": "fridge",
+        "notes": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _extraction(**overrides) -> ReceiptExtraction:
+    defaults = {
+        "items": [
+            ReceiptItem(name="Nopal limpio", quantity=Decimal("1.00"), is_food=True),
+            ReceiptItem(name="Jabón Grisi", quantity=Decimal("2.00"), is_food=False),
+        ],
+        "stated_item_count": 3,
+    }
+    defaults.update(overrides)
+    return ReceiptExtraction(**defaults)
+
+
+def _upload_receipt(api_client, mocker, **extraction_overrides):
+    mocker.patch("app.routers.trips.extract_receipt", return_value=_extraction(**extraction_overrides))
+    return api_client.post("/trips/receipt", files={"image": ("receipt.jpg", b"fake", "image/jpeg")})
+
+
+def test_a_receipt_photo_creates_a_trip_with_its_items(api_client, mocker):
+    response = _upload_receipt(api_client, mocker)
+
+    assert response.status_code == 201
+    body = response.json()
+    assert [(i["name"], i["quantity"], i["is_food"]) for i in body["items"]] == [
+        ("Nopal limpio", "1.00", True),
+        ("Jabón Grisi", "2.00", False),
+    ]
+    assert body["stated_item_count"] == 3
+    assert all(i["resolved_at"] is None and i["product_id"] is None for i in body["items"])
+
+
+def test_counted_quantity_and_reconciliation_match_when_they_should(api_client, mocker):
+    response = _upload_receipt(api_client, mocker, stated_item_count=3)
+
+    body = response.json()
+    assert body["counted_quantity"] == "3.00"
+    assert body["reconciled"] is True
+
+
+def test_reconciliation_is_false_when_the_sum_does_not_match(api_client, mocker):
+    response = _upload_receipt(api_client, mocker, stated_item_count=99)
+
+    body = response.json()
+    assert body["counted_quantity"] == "3.00"
+    assert body["reconciled"] is False
+
+
+def test_reconciliation_is_null_when_the_receipt_had_no_stated_total(api_client, mocker):
+    response = _upload_receipt(api_client, mocker, stated_item_count=None)
+
+    assert response.json()["reconciled"] is None
+
+
+def test_a_total_extraction_failure_is_reported_as_service_unavailable(api_client, mocker):
+    mocker.patch("app.routers.trips.extract_receipt", return_value=None)
+
+    response = api_client.post("/trips/receipt", files={"image": ("receipt.jpg", b"fake", "image/jpeg")})
+
+    assert response.status_code == 503
+
+
+def test_an_empty_file_is_rejected_without_calling_the_model(api_client, mocker):
+    extract = mocker.patch("app.routers.trips.extract_receipt")
+
+    response = api_client.post("/trips/receipt", files={"image": ("receipt.jpg", b"", "image/jpeg")})
+
+    assert response.status_code == 422
+    extract.assert_not_called()
+
+
+def test_an_oversized_file_is_rejected_without_calling_the_model(api_client, mocker):
+    extract = mocker.patch("app.routers.trips.extract_receipt")
+    oversized = b"x" * (10 * 1024 * 1024 + 1)
+
+    response = api_client.post("/trips/receipt", files={"image": ("receipt.jpg", oversized, "image/jpeg")})
+
+    assert response.status_code == 413
+    extract.assert_not_called()
+
+
+def test_current_trip_is_null_when_there_is_none(api_client):
+    assert api_client.get("/trips/current").json() is None
+
+
+def test_current_trip_returns_one_with_an_unresolved_item(api_client, mocker):
+    created = _upload_receipt(api_client, mocker).json()
+
+    response = api_client.get("/trips/current")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == created["id"]
+
+
+def test_current_trip_is_null_once_every_item_is_resolved(api_client, mocker):
+    trip = _upload_receipt(api_client, mocker).json()
+    for item in trip["items"]:
+        api_client.post(f"/trips/{trip['id']}/items/{item['id']}/drop")
+
+    assert api_client.get("/trips/current").json() is None
+
+
+def test_current_trip_is_the_most_recently_created_unresolved_one(api_client, mocker):
+    older = _upload_receipt(api_client, mocker).json()
+    newer = _upload_receipt(api_client, mocker).json()
+
+    assert api_client.get("/trips/current").json()["id"] == newer["id"]
+    assert older["id"] != newer["id"]
+
+
+def test_updating_an_item_corrects_its_fields(api_client, mocker):
+    trip = _upload_receipt(api_client, mocker).json()
+    item = trip["items"][0]
+
+    response = api_client.patch(
+        f"/trips/{trip['id']}/items/{item['id']}",
+        json={"name": "Nopal", "quantity": "0.59", "is_food": True},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "Nopal"
+    assert body["quantity"] == "0.59"
+
+
+def test_updating_a_resolved_item_is_rejected(api_client, mocker):
+    trip = _upload_receipt(api_client, mocker).json()
+    item = trip["items"][0]
+    api_client.post(f"/trips/{trip['id']}/items/{item['id']}/drop")
+
+    response = api_client.patch(
+        f"/trips/{trip['id']}/items/{item['id']}",
+        json={"name": "Nopal", "quantity": "1.00", "is_food": True},
+    )
+
+    assert response.status_code == 409
+
+
+def test_dropping_an_item_resolves_it_without_a_product(api_client, mocker):
+    trip = _upload_receipt(api_client, mocker).json()
+    item = trip["items"][0]
+
+    response = api_client.post(f"/trips/{trip['id']}/items/{item['id']}/drop")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["resolved_at"] is not None
+    assert body["product_id"] is None
+
+
+def test_dropping_an_already_resolved_item_is_rejected(api_client, mocker):
+    trip = _upload_receipt(api_client, mocker).json()
+    item = trip["items"][0]
+    api_client.post(f"/trips/{trip['id']}/items/{item['id']}/drop")
+
+    response = api_client.post(f"/trips/{trip['id']}/items/{item['id']}/drop")
+
+    assert response.status_code == 409
+
+
+def test_resolving_an_item_links_it_to_a_real_product(api_client, mocker):
+    trip = _upload_receipt(api_client, mocker).json()
+    item = trip["items"][0]
+    product = api_client.post("/products", json=_product(name=item["name"])).json()
+
+    response = api_client.post(
+        f"/trips/{trip['id']}/items/{item['id']}/resolve", json={"product_id": product["id"]}
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["resolved_at"] is not None
+    assert body["product_id"] == product["id"]
+
+
+def test_resolving_against_a_nonexistent_product_is_rejected(api_client, mocker):
+    trip = _upload_receipt(api_client, mocker).json()
+    item = trip["items"][0]
+
+    response = api_client.post(f"/trips/{trip['id']}/items/{item['id']}/resolve", json={"product_id": 9999})
+
+    assert response.status_code == 422
+
+
+def test_resolving_an_already_resolved_item_is_rejected(api_client, mocker):
+    trip = _upload_receipt(api_client, mocker).json()
+    item = trip["items"][0]
+    api_client.post(f"/trips/{trip['id']}/items/{item['id']}/drop")
+    product = api_client.post("/products", json=_product()).json()
+
+    response = api_client.post(
+        f"/trips/{trip['id']}/items/{item['id']}/resolve", json={"product_id": product["id"]}
+    )
+
+    assert response.status_code == 409
+
+
+def test_an_item_from_another_trip_is_not_found(api_client, mocker):
+    trip_a = _upload_receipt(api_client, mocker).json()
+    trip_b = _upload_receipt(api_client, mocker).json()
+    item_from_a = trip_a["items"][0]
+
+    response = api_client.post(f"/trips/{trip_b['id']}/items/{item_from_a['id']}/drop")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "method,path_suffix",
+    [
+        ("patch", "/items/9999"),
+        ("post", "/items/9999/drop"),
+        ("post", "/items/9999/resolve"),
+    ],
+)
+def test_missing_item_is_404(api_client, mocker, method, path_suffix):
+    trip = _upload_receipt(api_client, mocker).json()
+    kwargs = {}
+    if path_suffix.endswith("/items/9999"):
+        kwargs = {"json": {"name": "x", "quantity": "1.00", "is_food": True}}
+    elif path_suffix.endswith("/resolve"):
+        kwargs = {"json": {"product_id": 1}}
+
+    response = getattr(api_client, method)(f"/trips/{trip['id']}{path_suffix}", **kwargs)
+
+    assert response.status_code == 404
+
+
+@pytest.mark.integration
+def test_resolving_actually_commits_not_just_the_in_session_object(api_client, db_session, mocker):
+    """Same reasoning as products' own reassign-commit test: api_client and
+    db_session share one SQLAlchemy session in this fixture, so only a fresh
+    read after expiring the identity map proves the UPDATE reached the
+    database rather than just this test's in-memory object."""
+    trip = _upload_receipt(api_client, mocker).json()
+    item, other_item = trip["items"]
+    product = api_client.post("/products", json=_product(name=item["name"])).json()
+
+    api_client.post(f"/trips/{trip['id']}/items/{item['id']}/resolve", json={"product_id": product["id"]})
+    api_client.post(f"/trips/{trip['id']}/items/{other_item['id']}/drop")
+    db_session.expire_all()
+
+    assert api_client.get("/trips/current").json() is None

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -604,3 +604,57 @@
   color: var(--text);
   font-weight: 600;
 }
+
+/* Shopping trip */
+
+.trip-banner {
+  display: block;
+  width: 100%;
+  margin-bottom: 0.75rem;
+  padding: 0.5rem 0.7rem;
+  border: 1px solid var(--accent);
+  border-radius: 0.5rem;
+  background: none;
+  color: var(--accent);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-align: left;
+}
+
+.trip-checklist {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.trip-checklist__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.625rem;
+  padding: 0.625rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.trip-checklist__row:last-child {
+  border-bottom: none;
+}
+
+.trip-checklist__label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.trip-checklist__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trip-checklist__quantity {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+}

--- a/frontend/src/components/ProductForm.tsx
+++ b/frontend/src/components/ProductForm.tsx
@@ -12,10 +12,22 @@ import { extractLabel } from '@/services/visionService'
 interface ProductFormProps {
   /** Omit to create; pass a product to edit it. */
   product?: Product
+  /** Seeds name and quantity when creating from a shopping trip item's own
+   *  reading of the receipt — see #84. Ignored when editing, and only ever
+   *  a starting point: both fields stay fully editable, same as a photo
+   *  scan's own prefill. */
+  prefill?: { name: string; quantity: string }
   /** Passed in rather than fetched here, so opening the form costs no request. */
   categories: Category[]
-  onSaved: () => void
+  /** Called with the server's own response, so a caller that needs the new
+   *  product's id — resolving a shopping trip item into it, see #84 — has
+   *  it without a second request. */
+  onSaved: (product: Product) => void
   onCancel: () => void
+  /** Overrides the default "Agregar producto"/"Editar producto" title —
+   *  used when this form is one step of a larger flow (adding items from a
+   *  shopping trip, see #84) so the user can see progress through it. */
+  title?: string
 }
 
 /** Common units, offered as suggestions without restricting what can be typed. */
@@ -31,12 +43,12 @@ interface FormState {
   notes: string
 }
 
-function initialState(product?: Product): FormState {
+function initialState(product?: Product, prefill?: { name: string; quantity: string }): FormState {
   return {
-    name: product?.name ?? '',
+    name: product?.name ?? prefill?.name ?? '',
     category_id: product?.category_id?.toString() ?? '',
     // Strip the trailing zeros the API sends so the field is not "2.00".
-    quantity: product ? product.quantity.replace(/\.?0+$/, '') : '1',
+    quantity: product ? product.quantity.replace(/\.?0+$/, '') : (prefill?.quantity ?? '1'),
     unit: product?.unit ?? '',
     expires_at: product?.expires_at ?? '',
     location: product?.location ?? 'fridge',
@@ -45,8 +57,8 @@ function initialState(product?: Product): FormState {
 }
 
 /** Create or edit a product. The same form serves both. */
-export function ProductForm({ product, categories, onSaved, onCancel }: ProductFormProps) {
-  const [form, setForm] = useState<FormState>(() => initialState(product))
+export function ProductForm({ product, prefill, categories, onSaved, onCancel, title }: ProductFormProps) {
+  const [form, setForm] = useState<FormState>(() => initialState(product, prefill))
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -130,12 +142,8 @@ export function ProductForm({ product, categories, onSaved, onCancel }: ProductF
 
     void (async () => {
       try {
-        if (product) {
-          await replaceProduct(product.id, payload)
-        } else {
-          await createProduct(payload)
-        }
-        onSaved()
+        const saved = product ? await replaceProduct(product.id, payload) : await createProduct(payload)
+        onSaved(saved)
       } catch (caught) {
         setError(toErrorMessage(caught))
       } finally {
@@ -145,7 +153,7 @@ export function ProductForm({ product, categories, onSaved, onCancel }: ProductF
   }
 
   return (
-    <Modal title={isEdit ? 'Editar producto' : 'Agregar producto'} onClose={onCancel}>
+    <Modal title={title ?? (isEdit ? 'Editar producto' : 'Agregar producto')} onClose={onCancel}>
       <form className="form" onSubmit={handleSubmit}>
         {/* The photo is the entry point, not an afterthought — see #83 — so
             it comes first, above manual entry rather than buried below it.

--- a/frontend/src/components/ReceiptTripDialog.test.tsx
+++ b/frontend/src/components/ReceiptTripDialog.test.tsx
@@ -1,0 +1,273 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ReceiptTripDialog } from '@/components/ReceiptTripDialog'
+import type { Product, ShoppingTrip, ShoppingTripItem } from '@/services/types'
+
+vi.mock('@/services/productsService', () => ({
+  createProduct: vi.fn(),
+  replaceProduct: vi.fn(),
+}))
+
+vi.mock('@/services/visionService', () => ({
+  extractLabel: vi.fn(),
+}))
+
+vi.mock('@/services/tripsService', () => ({
+  dropTripItem: vi.fn(),
+  resolveTripItem: vi.fn(),
+}))
+
+const products = await import('@/services/productsService')
+const trips = await import('@/services/tripsService')
+const mockedCreate = vi.mocked(products.createProduct)
+const mockedDrop = vi.mocked(trips.dropTripItem)
+const mockedResolve = vi.mocked(trips.resolveTripItem)
+
+function tripItem(overrides: Partial<ShoppingTripItem> = {}): ShoppingTripItem {
+  return {
+    id: 1,
+    name: 'Nopal limpio',
+    quantity: '1.00',
+    is_food: true,
+    resolved_at: null,
+    product_id: null,
+    ...overrides,
+  }
+}
+
+function trip(overrides: Partial<ShoppingTrip> = {}): ShoppingTrip {
+  return {
+    id: 1,
+    created_at: '2026-09-01T00:00:00Z',
+    stated_item_count: null,
+    items: [tripItem()],
+    counted_quantity: '1.00',
+    reconciled: null,
+    ...overrides,
+  }
+}
+
+function product(overrides: Partial<Product> = {}): Product {
+  return {
+    id: 5,
+    name: 'Nopal limpio',
+    category_id: null,
+    quantity: '1.00',
+    unit: null,
+    expires_at: '2026-09-10',
+    location: 'fridge',
+    notes: null,
+    category: null,
+    icon: '\u{1F955}',
+    icon_source: 'lookup',
+    created_at: '2026-08-29T00:00:00Z',
+    updated_at: '2026-08-29T00:00:00Z',
+    consumed_at: null,
+    days_until_expiry: 9,
+    status: 'fresh',
+    ...overrides,
+  }
+}
+
+function renderDialog(overrides: Partial<ShoppingTrip> = {}) {
+  const onClose = vi.fn()
+  const onTripChanged = vi.fn()
+  render(
+    <ReceiptTripDialog trip={trip(overrides)} categories={[]} onClose={onClose} onTripChanged={onTripChanged} />,
+  )
+  return { onClose, onTripChanged }
+}
+
+/** ProductForm's own required fields — filling only what this dialog does
+ *  not already prefill from the trip item. */
+function fillDateAndSubmit() {
+  fireEvent.change(screen.getByLabelText('Caduca el'), { target: { value: '2026-09-10' } })
+  fireEvent.click(screen.getByRole('button', { name: /guardar/i }))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ReceiptTripDialog review', () => {
+  it('shows every pending item pre-ticked by is_food', () => {
+    renderDialog({
+      items: [tripItem({ id: 1, name: 'Nopal limpio', is_food: true }), tripItem({ id: 2, name: 'Jabón Grisi', is_food: false })],
+    })
+
+    const nopal = screen.getByRole('checkbox', { name: /nopal limpio/i })
+    const jabon = screen.getByRole('checkbox', { name: /jabón grisi/i })
+    expect(nopal).toBeChecked()
+    expect(jabon).not.toBeChecked()
+  })
+
+  it('toggles a tick on click', () => {
+    renderDialog({ items: [tripItem({ is_food: false })] })
+
+    const checkbox = screen.getByRole('checkbox')
+    expect(checkbox).not.toBeChecked()
+    fireEvent.click(checkbox)
+    expect(checkbox).toBeChecked()
+  })
+
+  it('warns when the reconciliation does not match', () => {
+    renderDialog({ reconciled: false, counted_quantity: '3.00', stated_item_count: 5 })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('3.00')
+    expect(screen.getByRole('alert')).toHaveTextContent('5')
+  })
+
+  it('shows nothing extra when there is nothing to reconcile against', () => {
+    renderDialog({ reconciled: null })
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('does not show already-resolved items', () => {
+    renderDialog({
+      items: [
+        tripItem({ id: 1, name: 'Nopal limpio' }),
+        tripItem({ id: 2, name: 'Jabón Grisi', resolved_at: '2026-09-01T00:00:00Z' }),
+      ],
+    })
+
+    expect(screen.getByText('Nopal limpio')).toBeInTheDocument()
+    expect(screen.queryByText('Jabón Grisi')).not.toBeInTheDocument()
+  })
+})
+
+describe('ReceiptTripDialog continue', () => {
+  it('drops every unticked item and notifies the parent', async () => {
+    mockedDrop.mockResolvedValue(tripItem({ resolved_at: '2026-09-01T00:00:00Z' }))
+    const { onTripChanged } = renderDialog({ items: [tripItem({ is_food: false })] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continuar' }))
+
+    await waitFor(() => expect(mockedDrop).toHaveBeenCalledWith(1, 1))
+    expect(onTripChanged).toHaveBeenCalled()
+  })
+
+  it('does not drop a ticked item', async () => {
+    mockedCreate.mockReturnValue(new Promise(() => {})) // leave the add phase pending
+    renderDialog({ items: [tripItem({ is_food: true })] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continuar' }))
+
+    await waitFor(() => expect(screen.getByLabelText('Nombre')).toBeInTheDocument())
+    expect(mockedDrop).not.toHaveBeenCalled()
+  })
+
+  it('opens ProductForm pre-filled with the first ticked item, showing how many remain', async () => {
+    mockedCreate.mockReturnValue(new Promise(() => {}))
+    renderDialog({
+      items: [
+        tripItem({ id: 1, name: 'Nopal limpio', quantity: '1.00', is_food: true }),
+        tripItem({ id: 2, name: 'Plátano', quantity: '3.00', is_food: true }),
+      ],
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continuar' }))
+
+    expect(await screen.findByText('Agregar producto (quedan 2)')).toBeInTheDocument()
+    expect(screen.getByLabelText('Nombre')).toHaveValue('Nopal limpio')
+    expect(screen.getByLabelText('Cantidad')).toHaveValue(1)
+  })
+
+  it('goes straight to the done screen when nothing was ticked', async () => {
+    mockedDrop.mockResolvedValue(tripItem({ resolved_at: '2026-09-01T00:00:00Z' }))
+    renderDialog({ items: [tripItem({ is_food: false })] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continuar' }))
+
+    expect(await screen.findByText('Listo — se procesó todo el recibo.')).toBeInTheDocument()
+  })
+})
+
+describe('ReceiptTripDialog adding', () => {
+  it('resolves the item once the product is saved, then advances to the next one', async () => {
+    mockedCreate.mockResolvedValue(product({ id: 5 }))
+    mockedResolve.mockResolvedValue(tripItem({ id: 1, resolved_at: '2026-09-01T00:00:00Z', product_id: 5 }))
+    const { onTripChanged } = renderDialog({
+      items: [
+        tripItem({ id: 1, name: 'Nopal limpio', is_food: true }),
+        tripItem({ id: 2, name: 'Plátano', is_food: true }),
+      ],
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Continuar' }))
+    await screen.findByText('Agregar producto (quedan 2)')
+
+    fillDateAndSubmit()
+
+    await waitFor(() => expect(mockedResolve).toHaveBeenCalledWith(1, 1, 5))
+    expect(await screen.findByLabelText('Nombre')).toHaveValue('Plátano')
+    expect(onTripChanged).toHaveBeenCalled()
+  })
+
+  it('advances without resolving when the user cancels a step', async () => {
+    renderDialog({
+      items: [
+        tripItem({ id: 1, name: 'Nopal limpio', is_food: true }),
+        tripItem({ id: 2, name: 'Plátano', is_food: true }),
+      ],
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Continuar' }))
+    await waitFor(() => expect(screen.getByLabelText('Nombre')).toHaveValue('Nopal limpio'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(await screen.findByLabelText('Nombre')).toHaveValue('Plátano')
+    expect(mockedResolve).not.toHaveBeenCalled()
+  })
+
+  it('shows the done screen after the last item, and closing keeps a skipped item pending', async () => {
+    renderDialog({ items: [tripItem({ id: 1, name: 'Nopal limpio', is_food: true })] })
+    fireEvent.click(screen.getByRole('button', { name: 'Continuar' }))
+    await waitFor(() => expect(screen.getByLabelText('Nombre')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(
+      await screen.findByText(
+        'Los productos que agregaste ya están en tu lista. Los que dejaste pendientes seguirán apareciendo aquí.',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('closes the whole dialog from the done screen', async () => {
+    mockedDrop.mockResolvedValue(tripItem({ resolved_at: '2026-09-01T00:00:00Z' }))
+    const { onClose } = renderDialog({ items: [tripItem({ is_food: false })] })
+    fireEvent.click(screen.getByRole('button', { name: 'Continuar' }))
+    await screen.findByText('Listo — se procesó todo el recibo.')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Entendido' }))
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('falls back to the review screen on a resolve failure, so the error is somewhere visible', async () => {
+    // The product itself was already created by this point — only the
+    // bookkeeping link failed. Advancing straight to the next item's own
+    // ProductForm would leave this error with nowhere in the tree that
+    // ever renders it; the review screen is the one place in this dialog
+    // that does, regardless of which item comes next.
+    mockedCreate.mockResolvedValue(product({ id: 5 }))
+    mockedResolve.mockRejectedValue(new Error('nope'))
+    renderDialog({
+      items: [
+        tripItem({ id: 1, name: 'Nopal limpio', is_food: true }),
+        tripItem({ id: 2, name: 'Plátano', is_food: true }),
+      ],
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Continuar' }))
+    await screen.findByText('Agregar producto (quedan 2)')
+
+    fillDateAndSubmit()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
+    // Both items are back on the checklist — the one that failed and the
+    // one never reached yet — rather than silently losing either.
+    expect(screen.getByText('Nopal limpio')).toBeInTheDocument()
+    expect(screen.getByText('Plátano')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ReceiptTripDialog.tsx
+++ b/frontend/src/components/ReceiptTripDialog.tsx
@@ -1,0 +1,205 @@
+import { useState } from 'react'
+
+import { Modal } from '@/components/Modal'
+import { ProductForm } from '@/components/ProductForm'
+import { quantityLabel } from '@/labels'
+import { toErrorMessage } from '@/services/api'
+import { dropTripItem, resolveTripItem } from '@/services/tripsService'
+import type { Category, Product, ShoppingTrip, ShoppingTripItem } from '@/services/types'
+
+interface ReceiptTripDialogProps {
+  trip: ShoppingTrip
+  categories: Category[]
+  onClose: () => void
+  /** Called whenever an item is dropped or resolved, so the active product
+   *  list and the "current trip" banner stay in sync without a second
+   *  request driving both independently. */
+  onTripChanged: () => void
+}
+
+/** Where the item currently sits in the checklist: unresolved (its tick
+ *  reflects the model's own is_food guess until the user overrides it),
+ *  dropped, or resolved into a product. */
+type ItemState = 'pending' | 'dropped' | 'added'
+
+function itemState(item: ShoppingTripItem): ItemState {
+  if (item.resolved_at === null) return 'pending'
+  return item.product_id === null ? 'dropped' : 'added'
+}
+
+/**
+ * A receipt's checklist: review what was read, tick or untick each line,
+ * then walk through the ticked ones one at a time — each needs its own
+ * date, which a shared bulk form cannot give it — via the same ProductForm
+ * used everywhere else. See #84.
+ *
+ * Two phases, not one screen: "review" lets the whole list be corrected
+ * before anything is committed; "adding" commits one line at a time,
+ * because #83's own photo-of-the-label scan is exactly what a user reaches
+ * for here, and that only makes sense pointed at a single product.
+ */
+export function ReceiptTripDialog({ trip, categories, onClose, onTripChanged }: ReceiptTripDialogProps) {
+  const [items, setItems] = useState(trip.items)
+  // Only the pending items need a tick; a dropped or added item does not
+  // come back to this map even if a later action revisits it.
+  const [ticked, setTicked] = useState<Record<number, boolean>>(() =>
+    Object.fromEntries(trip.items.filter((item) => item.resolved_at === null).map((item) => [item.id, item.is_food])),
+  )
+  const [queue, setQueue] = useState<ShoppingTripItem[] | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const pending = items.filter((item) => itemState(item) === 'pending')
+
+  const toggle = (itemId: number) =>
+    setTicked((current) => ({ ...current, [itemId]: !current[itemId] }))
+
+  const replaceItem = (updated: ShoppingTripItem) =>
+    setItems((current) => current.map((item) => (item.id === updated.id ? updated : item)))
+
+  /** Drops every unticked line, then starts walking through the ticked
+   *  ones — see the module docstring for why adding is sequential. */
+  const handleContinue = () => {
+    setSubmitting(true)
+    setError(null)
+    void (async () => {
+      try {
+        const toDrop = pending.filter((item) => !ticked[item.id])
+        const dropped = await Promise.all(toDrop.map((item) => dropTripItem(trip.id, item.id)))
+        dropped.forEach(replaceItem)
+        if (dropped.length > 0) onTripChanged()
+
+        const toAdd = pending.filter((item) => ticked[item.id])
+        setQueue(toAdd)
+      } catch (caught) {
+        setError(toErrorMessage(caught))
+      } finally {
+        setSubmitting(false)
+      }
+    })()
+  }
+
+  /** After a product is created for the item at the front of the queue,
+   *  resolved or not — advancing must not get stuck on one line the user
+   *  can no longer act on. */
+  const advanceQueue = () => setQueue((current) => (current ? current.slice(1) : current))
+
+  const handleItemSaved = (product: Product) => {
+    if (!queue || queue.length === 0) return
+    const current = queue[0]
+    void (async () => {
+      try {
+        const resolved = await resolveTripItem(trip.id, current.id, product.id)
+        replaceItem(resolved)
+        onTripChanged()
+        advanceQueue()
+      } catch (caught) {
+        // The product itself was already created successfully — only the
+        // bookkeeping link failed. The review screen's error banner is the
+        // only place in this dialog visible regardless of which item comes
+        // next, so this drops back to it instead of silently advancing to
+        // the next item's form, where nothing would ever render this at
+        // all — see #84's own "say so instead of silently dropping a line"
+        // for why that matters here too. The item stays ticked, since the
+        // user's own choice to add it has not changed, only this attempt.
+        setError(toErrorMessage(caught))
+        setQueue(null)
+      }
+    })()
+  }
+
+  if (queue !== null && queue.length > 0) {
+    const current = queue[0]
+    const remaining = queue.length
+    return (
+      // Keyed on the item's own id, not left to reconciliation: ProductForm
+      // seeds its editable state from `prefill` exactly once, on mount, the
+      // same as it does from `product` — without a key that ties each
+      // queue item to its own instance, advancing the queue would change
+      // the prop but reuse the already-mounted component, leaving the
+      // previous item's name showing under a new one. Reproduced directly.
+      <ProductForm
+        key={current.id}
+        categories={categories}
+        prefill={{ name: current.name, quantity: current.quantity }}
+        title={remaining === 1 ? 'Agregar producto' : `Agregar producto (quedan ${remaining})`}
+        onSaved={handleItemSaved}
+        onCancel={advanceQueue}
+      />
+    )
+  }
+
+  if (queue !== null) {
+    // The queue ran out — everything ticked has been either added or
+    // skipped. Skipped items are still pending, so pending.length here
+    // only reaches 0 when every line was truly dealt with.
+    return (
+      <Modal title="Recibo" onClose={onClose}>
+        <p className="state state--empty">
+          {pending.length === 0
+            ? 'Listo — se procesó todo el recibo.'
+            : 'Los productos que agregaste ya están en tu lista. Los que dejaste pendientes seguirán apareciendo aquí.'}
+        </p>
+        <div className="form__actions">
+          {/* Not "Cerrar": the modal's own × close button already carries
+              that label, and two controls sharing one accessible name is
+              exactly the kind of thing a screen reader user cannot tell
+              apart. */}
+          <button type="button" className="button--primary" onClick={onClose}>
+            Entendido
+          </button>
+        </div>
+      </Modal>
+    )
+  }
+
+  return (
+    <Modal title="Recibo" onClose={onClose}>
+      {trip.reconciled === false && (
+        <p className="form__error" role="alert">
+          La suma de cantidades ({trip.counted_quantity}) no coincide con el total del recibo (
+          {trip.stated_item_count}) — puede que falte un producto por revisar.
+        </p>
+      )}
+
+      {pending.length === 0 ? (
+        <p className="state state--empty">Ya no quedan productos pendientes en este recibo.</p>
+      ) : (
+        <ul className="trip-checklist">
+          {pending.map((item) => (
+            <li key={item.id} className="trip-checklist__row">
+              <label className="trip-checklist__label">
+                <input
+                  type="checkbox"
+                  checked={ticked[item.id] ?? item.is_food}
+                  onChange={() => toggle(item.id)}
+                />
+                <span className="trip-checklist__name">{item.name}</span>
+              </label>
+              <span className="trip-checklist__quantity">{quantityLabel(item.quantity, null)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {error && (
+        <p className="form__error" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="form__actions">
+        {/* "Cancelar", not "Cerrar": the modal's own × close button already
+            carries that label — see the done screen's own note. */}
+        <button type="button" onClick={onClose} disabled={submitting}>
+          Cancelar
+        </button>
+        {pending.length > 0 && (
+          <button type="button" className="button--primary" onClick={handleContinue} disabled={submitting}>
+            {submitting ? 'Procesando…' : 'Continuar'}
+          </button>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/src/pages/ProductList.test.tsx
+++ b/frontend/src/pages/ProductList.test.tsx
@@ -21,8 +21,16 @@ vi.mock('@/services/categoriesService', () => ({
   listCategories: vi.fn(),
 }))
 
+vi.mock('@/services/tripsService', () => ({
+  getCurrentTrip: vi.fn(),
+  uploadReceipt: vi.fn(),
+  dropTripItem: vi.fn(),
+  resolveTripItem: vi.fn(),
+}))
+
 const products = await import('@/services/productsService')
 const categories = await import('@/services/categoriesService')
+const trips = await import('@/services/tripsService')
 
 const mockedList = vi.mocked(products.listProducts)
 const mockedCreate = vi.mocked(products.createProduct)
@@ -32,6 +40,8 @@ const mockedConsume = vi.mocked(products.consumeProduct)
 const mockedHistory = vi.mocked(products.listConsumedProducts)
 const mockedRestore = vi.mocked(products.restoreProduct)
 const mockedCategories = vi.mocked(categories.listCategories)
+const mockedCurrentTrip = vi.mocked(trips.getCurrentTrip)
+const mockedUploadReceipt = vi.mocked(trips.uploadReceipt)
 
 function product(overrides: Partial<Product> = {}): Product {
   return {
@@ -70,6 +80,7 @@ beforeEach(() => {
   mockedCategories.mockResolvedValue([
     { id: 3, name: 'Lácteos', created_at: '2026-08-29T00:00:00Z' },
   ])
+  mockedCurrentTrip.mockResolvedValue(null)
 })
 
 describe('ProductList', () => {
@@ -332,6 +343,97 @@ describe('viewing history', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Historial' }))
 
     expect(await screen.findByText('Todavía no has marcado nada como consumido.')).toBeInTheDocument()
+  })
+})
+
+describe('scanning a receipt', () => {
+  function selectReceipt(container: HTMLElement) {
+    const input = container.querySelector('input[type="file"]')
+    if (!input) throw new Error('receipt file input not found')
+    const file = new File(['fake'], 'receipt.jpg', { type: 'image/jpeg' })
+    fireEvent.change(input, { target: { files: [file] } })
+  }
+
+  it('uploads the photo and opens the checklist on success', async () => {
+    mockedList.mockResolvedValue({ products: [], cachedAt: null })
+    mockedUploadReceipt.mockResolvedValue({
+      id: 1,
+      created_at: '2026-09-01T00:00:00Z',
+      stated_item_count: null,
+      items: [
+        { id: 1, name: 'Nopal limpio', quantity: '1.00', is_food: true, resolved_at: null, product_id: null },
+      ],
+      counted_quantity: '1.00',
+      reconciled: null,
+    })
+
+    const { container } = render(<ProductList />)
+    await screen.findByRole('button', { name: 'Recibo' })
+    selectReceipt(container)
+
+    await waitFor(() => expect(mockedUploadReceipt).toHaveBeenCalledTimes(1))
+    expect(await screen.findByText('Nopal limpio')).toBeInTheDocument()
+  })
+
+  it('shows a readable error when the upload fails', async () => {
+    mockedList.mockResolvedValue({ products: [], cachedAt: null })
+    mockedUploadReceipt.mockRejectedValue(new Error('boom'))
+
+    const { container } = render(<ProductList />)
+    await screen.findByRole('button', { name: 'Recibo' })
+    selectReceipt(container)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
+  })
+
+  it('shows a banner for a trip left over from a previous visit', async () => {
+    mockedList.mockResolvedValue({ products: [], cachedAt: null })
+    mockedCurrentTrip.mockResolvedValue({
+      id: 4,
+      created_at: '2026-08-31T00:00:00Z',
+      stated_item_count: null,
+      items: [
+        { id: 1, name: 'Nopal limpio', quantity: '1.00', is_food: true, resolved_at: null, product_id: null },
+        { id: 2, name: 'Plátano', quantity: '2.00', is_food: true, resolved_at: null, product_id: null },
+      ],
+      counted_quantity: '3.00',
+      reconciled: null,
+    })
+
+    render(<ProductList />)
+
+    const banner = await screen.findByRole('button', { name: /recibo pendiente/i })
+    expect(banner).toHaveTextContent('2 productos')
+
+    fireEvent.click(banner)
+
+    expect(await screen.findByText('Plátano')).toBeInTheDocument()
+  })
+
+  it('does not show a banner once every item in the leftover trip is already resolved', async () => {
+    mockedList.mockResolvedValue({ products: [], cachedAt: null })
+    mockedCurrentTrip.mockResolvedValue({
+      id: 4,
+      created_at: '2026-08-31T00:00:00Z',
+      stated_item_count: null,
+      items: [
+        {
+          id: 1,
+          name: 'Nopal limpio',
+          quantity: '1.00',
+          is_food: true,
+          resolved_at: '2026-08-31T00:05:00Z',
+          product_id: 9,
+        },
+      ],
+      counted_quantity: '1.00',
+      reconciled: null,
+    })
+
+    render(<ProductList />)
+    await screen.findByRole('button', { name: 'Recibo' })
+
+    expect(screen.queryByRole('button', { name: /recibo pendiente/i })).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/pages/ProductList.tsx
+++ b/frontend/src/pages/ProductList.tsx
@@ -1,12 +1,14 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
 
 import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { ProductCard } from '@/components/ProductCard'
 import { ProductFilters } from '@/components/ProductFilters'
 import { ProductForm } from '@/components/ProductForm'
 import { ProductHistory } from '@/components/ProductHistory'
+import { ReceiptTripDialog } from '@/components/ReceiptTripDialog'
 import { StaleBanner } from '@/components/StaleBanner'
 import { SettingsDialog } from '@/components/SettingsDialog'
+import { downscaleImage } from '@/downscaleImage'
 import {
   NO_FILTERS,
   applyFilters,
@@ -19,7 +21,8 @@ import { useCategories } from '@/hooks/useCategories'
 import { useProducts } from '@/hooks/useProducts'
 import { apiUrl, toErrorMessage } from '@/services/api'
 import { deleteProduct } from '@/services/productsService'
-import type { Product } from '@/services/types'
+import { getCurrentTrip, uploadReceipt } from '@/services/tripsService'
+import type { Product, ShoppingTrip } from '@/services/types'
 
 /** What the screen is currently doing, beyond showing the list. */
 type Dialog =
@@ -29,6 +32,7 @@ type Dialog =
   | { kind: 'delete'; product: Product }
   | { kind: 'settings' }
   | { kind: 'history' }
+  | { kind: 'trip' }
 
 /** Main screen: everything in the house, soonest to expire first. */
 export function ProductList() {
@@ -40,10 +44,35 @@ export function ProductList() {
   const [filters, setFilters] = useState<Filters>(NO_FILTERS)
   const [sort, setSort] = useState<SortKey>('expiry')
 
+  const [currentTrip, setCurrentTrip] = useState<ShoppingTrip | null>(null)
+  const [scanningReceipt, setScanningReceipt] = useState(false)
+  const [receiptError, setReceiptError] = useState<string | null>(null)
+  const receiptInputRef = useRef<HTMLInputElement>(null)
+
   const visible = useMemo(
     () => sortProducts(applyFilters(products, filters), sort),
     [products, filters, sort],
   )
+
+  // Resuming an unfinished trip is a "next visit" concern, not something a
+  // reload of the active list itself would ever surface on its own — see
+  // #84's own "an unfinished trip is still visible on the next visit".
+  useEffect(() => {
+    let active = true
+    void (async () => {
+      try {
+        const trip = await getCurrentTrip()
+        if (active) setCurrentTrip(trip)
+      } catch {
+        // Non-critical: the banner just does not show. A genuinely
+        // unreachable backend is already covered by the product list's own
+        // error state below.
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [])
 
   const close = () => {
     setDialog({ kind: 'none' })
@@ -53,6 +82,37 @@ export function ProductList() {
   const handleSaved = () => {
     close()
     reload()
+  }
+
+  const handleReceiptSelected = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    // Cleared immediately so scanning another receipt right after a
+    // failure fires a change event the second time too.
+    event.target.value = ''
+    if (!file) return
+
+    setScanningReceipt(true)
+    setReceiptError(null)
+    void (async () => {
+      try {
+        const trip = await uploadReceipt(await downscaleImage(file))
+        setCurrentTrip(trip)
+        setDialog({ kind: 'trip' })
+      } catch (caught) {
+        setReceiptError(toErrorMessage(caught))
+      } finally {
+        setScanningReceipt(false)
+      }
+    })()
+  }
+
+  // Refetched, not assumed from what the dialog already knows: the banner
+  // and the active product list are both driven from here, so this is the
+  // one place responsible for keeping either in sync after a drop or a
+  // resolve, whether the trip dialog is still open or already closed.
+  const handleTripChanged = () => {
+    reload()
+    void getCurrentTrip().then(setCurrentTrip)
   }
 
   const handleDelete = (product: Product) => {
@@ -80,6 +140,25 @@ export function ProductList() {
         <button type="button" onClick={() => setDialog({ kind: 'settings' })}>
           Ajustes
         </button>
+        {/* A real click on a hidden input, not a wrapping <label>: the label
+            text here would otherwise absorb "Leyendo…" into its own
+            accessible name while a scan is in flight — see #83's own note
+            on ProductForm for the exact same fix, same reason. */}
+        <button
+          type="button"
+          onClick={() => receiptInputRef.current?.click()}
+          disabled={scanningReceipt}
+        >
+          {scanningReceipt ? 'Leyendo…' : 'Recibo'}
+        </button>
+        <input
+          ref={receiptInputRef}
+          type="file"
+          accept="image/*"
+          capture="environment"
+          onChange={handleReceiptSelected}
+          hidden
+        />
         <button
           type="button"
           className="button--primary"
@@ -88,6 +167,20 @@ export function ProductList() {
           Agregar producto
         </button>
       </div>
+
+      {receiptError && (
+        <p className="form__error" role="alert">
+          {receiptError}
+        </p>
+      )}
+
+      {dialog.kind !== 'trip' && currentTrip && currentTrip.items.some((item) => item.resolved_at === null) && (
+        <button type="button" className="trip-banner" onClick={() => setDialog({ kind: 'trip' })}>
+          Recibo pendiente: {currentTrip.items.filter((item) => item.resolved_at === null).length} producto
+          {currentTrip.items.filter((item) => item.resolved_at === null).length === 1 ? '' : 's'} por revisar —
+          continuar
+        </button>
+      )}
 
       {cachedAt && <StaleBanner cachedAt={cachedAt} />}
 
@@ -185,6 +278,15 @@ export function ProductList() {
       {dialog.kind === 'settings' && <SettingsDialog onClose={close} onIconsReassigned={reload} />}
 
       {dialog.kind === 'history' && <ProductHistory onClose={close} onRestored={reload} />}
+
+      {dialog.kind === 'trip' && currentTrip && (
+        <ReceiptTripDialog
+          trip={currentTrip}
+          categories={categories}
+          onClose={close}
+          onTripChanged={handleTripChanged}
+        />
+      )}
 
       {dialog.kind === 'delete' && (
         <ConfirmDialog

--- a/frontend/src/services/tripsService.test.ts
+++ b/frontend/src/services/tripsService.test.ts
@@ -1,0 +1,96 @@
+import { AxiosError } from 'axios'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  dropTripItem,
+  getCurrentTrip,
+  resolveTripItem,
+  updateTripItem,
+  uploadReceipt,
+} from '@/services/tripsService'
+
+vi.mock('@/services/api', () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn() },
+}))
+
+const { api } = await import('@/services/api')
+const mockedApi = vi.mocked(api)
+
+function networkError(): AxiosError {
+  return new AxiosError('Network Error', AxiosError.ERR_NETWORK)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('uploadReceipt', () => {
+  it('posts the image as multipart form data with the JSON content type overridden', async () => {
+    mockedApi.post.mockResolvedValue({ data: { id: 1, items: [] } })
+    const image = new File(['fake'], 'receipt.jpg', { type: 'image/jpeg' })
+
+    const result = await uploadReceipt(image)
+
+    expect(result).toEqual({ id: 1, items: [] })
+    const [path, body, config] = mockedApi.post.mock.calls[0]
+    expect(path).toBe('/trips/receipt')
+    expect(body).toBeInstanceOf(FormData)
+    expect(config?.headers?.['Content-Type']).not.toMatch(/json/i)
+  })
+
+  it('is not retried — it already creates records, not just reads them', async () => {
+    mockedApi.post.mockRejectedValue(networkError())
+
+    await expect(uploadReceipt(new File(['x'], 'r.jpg'))).rejects.toThrow('Network Error')
+    expect(mockedApi.post.mock.calls).toHaveLength(1)
+  })
+})
+
+describe('getCurrentTrip', () => {
+  it('returns the trip the API reports', async () => {
+    mockedApi.get.mockResolvedValue({ data: { id: 7, items: [] } })
+
+    expect(await getCurrentTrip()).toEqual({ id: 7, items: [] })
+  })
+
+  it('passes through null when there is nothing to resume', async () => {
+    mockedApi.get.mockResolvedValue({ data: null })
+
+    expect(await getCurrentTrip()).toBeNull()
+  })
+})
+
+describe('updateTripItem', () => {
+  it('sends the corrected fields and retries a dropped connection', async () => {
+    mockedApi.patch
+      .mockRejectedValueOnce(networkError())
+      .mockResolvedValue({ data: { id: 2, name: 'Nopal' } })
+
+    const result = await updateTripItem(1, 2, { name: 'Nopal', quantity: '1.00', is_food: true })
+
+    expect(result).toEqual({ id: 2, name: 'Nopal' })
+    expect(mockedApi.patch.mock.calls).toHaveLength(2)
+    expect(mockedApi.patch.mock.calls[0]).toEqual([
+      '/trips/1/items/2',
+      { name: 'Nopal', quantity: '1.00', is_food: true },
+    ])
+  })
+})
+
+describe('dropTripItem', () => {
+  it('posts to the drop endpoint and does not retry a failure', async () => {
+    mockedApi.post.mockRejectedValue(networkError())
+
+    await expect(dropTripItem(1, 2)).rejects.toThrow('Network Error')
+    expect(mockedApi.post.mock.calls).toEqual([['/trips/1/items/2/drop']])
+  })
+})
+
+describe('resolveTripItem', () => {
+  it('posts the product id to the resolve endpoint and does not retry a failure', async () => {
+    mockedApi.post.mockRejectedValue(networkError())
+
+    await expect(resolveTripItem(1, 2, 99)).rejects.toThrow('Network Error')
+    expect(mockedApi.post.mock.calls).toEqual([['/trips/1/items/2/resolve', { product_id: 99 }]])
+  })
+})

--- a/frontend/src/services/tripsService.ts
+++ b/frontend/src/services/tripsService.ts
@@ -1,0 +1,70 @@
+import { api } from '@/services/api'
+import { withRetry } from '@/services/retry'
+import type { ShoppingTrip, ShoppingTripItem } from '@/services/types'
+
+/**
+ * Read a receipt photo into a new trip's checklist — see #84 and
+ * POST /trips/receipt. Persists immediately, unlike extractLabel: the
+ * checklist has to survive a reload without asking for the photo again.
+ *
+ * Not retried, same reasoning as extractLabel: a receipt photo can be
+ * several MB, and this call already creates real (if provisional) records
+ * server-side — a second attempt after a slow connection risks a duplicate
+ * trip, not just wasted time.
+ */
+export async function uploadReceipt(image: Blob): Promise<ShoppingTrip> {
+  const form = new FormData()
+  form.append('image', image, 'receipt.jpg')
+  const { data } = await api.post<ShoppingTrip>('/trips/receipt', form, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
+  return data
+}
+
+/** The trip still awaiting attention, or null when there isn't one. */
+export async function getCurrentTrip(): Promise<ShoppingTrip | null> {
+  const { data } = await api.get<ShoppingTrip | null>('/trips/current')
+  return data
+}
+
+/** Correct a line's name, quantity, or food classification before
+ *  resolving it. */
+export async function updateTripItem(
+  tripId: number,
+  itemId: number,
+  payload: { name: string; quantity: string; is_food: boolean },
+): Promise<ShoppingTripItem> {
+  const { data } = await withRetry(() =>
+    api.patch<ShoppingTripItem>(`/trips/${tripId}/items/${itemId}`, payload),
+  )
+  return data
+}
+
+/**
+ * Mark a line dealt with without adding a product for it.
+ *
+ * Not retried, same reasoning as consumeProduct: dropping is a one-way
+ * transition, not a value being set, so a repeat that follows a success
+ * gets a 409 — an error shown for an action that already worked.
+ */
+export async function dropTripItem(tripId: number, itemId: number): Promise<ShoppingTripItem> {
+  const { data } = await api.post<ShoppingTripItem>(`/trips/${tripId}/items/${itemId}/drop`)
+  return data
+}
+
+/**
+ * Link a line to the product it became — call only after that product
+ * already exists, via the normal createProduct.
+ *
+ * Not retried, same reasoning as dropTripItem above.
+ */
+export async function resolveTripItem(
+  tripId: number,
+  itemId: number,
+  productId: number,
+): Promise<ShoppingTripItem> {
+  const { data } = await api.post<ShoppingTripItem>(`/trips/${tripId}/items/${itemId}/resolve`, {
+    product_id: productId,
+  })
+  return data
+}

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -120,3 +120,37 @@ export interface LabelExtraction {
   quantity: string | null
   unit: string | null
 }
+
+/** One line read from a receipt photo — see #84 and POST /trips/receipt. */
+export interface ShoppingTripItem {
+  id: number
+  name: string
+  quantity: string
+  /** The model's own guess at whether this line is worth tracking — drives
+   *  the checklist's initial tick state, not a final answer. */
+  is_food: boolean
+  /** Null while still awaiting a decision. Set once the item was either
+   *  turned into a product or explicitly dropped — see product_id. */
+  resolved_at: string | null
+  /** Set only when resolved_at is set and the item became a product;
+   *  resolved with this still null means it was dropped instead. */
+  product_id: number | null
+}
+
+/** A shopping trip's checklist — see #84. Persists across reloads: the
+ *  photo is analyzed once, then the trip stays visible until every item is
+ *  either added as a product or dropped. */
+export interface ShoppingTrip {
+  id: number
+  created_at: string
+  /** What the receipt's own printed total said, e.g. from "ARTICULOS
+   *  COMPRADOS: 19" — null when the receipt didn't show one or the model
+   *  couldn't read it, which is different from a mismatch. */
+  stated_item_count: number | null
+  items: ShoppingTripItem[]
+  /** The sum of every line's quantity — the free checksum #84 asks for. */
+  counted_quantity: string
+  /** Null when there is nothing to reconcile against (stated_item_count is
+   *  null); otherwise whether counted_quantity actually matches it. */
+  reconciled: boolean | null
+}


### PR DESCRIPTION
## Summary
Photograph a receipt once and get a persisted checklist — name, quantity, and a pre-ticked guess at whether each line is worth tracking — that survives a reload instead of asking for the photo again. Reuses #83's vision infrastructure directly: same Ollama client pattern, same client-side downscale, same never-silently-guess philosophy, now applied to a receipt's own distinct failure mode (one bad line dropped, not the whole receipt).

### Backend
- New `ShoppingTrip`/`ShoppingTripItem` tables. A trip is "current" by query (at least one unresolved item), not a stored status that could drift out of sync with its own items.
- `receipt_client.py`: extracts `{name, quantity, is_food}` per line plus the receipt's own stated item count where visible, for the free reconciliation checksum the issue asks for.
- `POST /trips/receipt` persists immediately (unlike `/vision/label`) — the whole point is surviving a reload. This doesn't conflict with "nothing is saved without confirmation": that guarantee is about products, and a trip item only reaches the products table through its own resolve endpoint, after the client has already created that product through the normal, already-confirmed `POST /products`.

### Frontend
- `ReceiptTripDialog`: review phase (tick/untick, batch-drop the rest) then a sequential add phase — one `ProductForm` per ticked item, since each needs its own date, which a shared bulk form cannot give it.
- `ProductForm` gains `prefill` and `title` props to support being one step of this larger flow, and `onSaved` now passes back the server's own response so resolving a trip item doesn't need a second request.
- A "current trip" banner on the product list surfaces a leftover trip next visit, per the issue's own acceptance criterion.

## Notable while building this
- Verified the extraction prompt against the real Ollama server with a receipt built from the issue's own real HEB example — caught and fixed a real misclassification along the way: **nopal (a vegetable) initially came back non-food**. The prompt needed to spell out that fresh unpackaged produce counts as food, not just packaged/branded items.
- Found and fixed two real bugs while writing the dialog's own tests, not just reasoning about it: advancing the queue without a React `key` reused the same `ProductForm` instance across items and left the previous item's name showing under the next one; and a resolve failure was being set into state that only the review phase's JSX ever rendered, so it was silently invisible during the add phase — where it actually happens.

## Test plan
- [x] Backend: `pytest` — 265 passed (42 new: `receipt_client`'s own extraction/validation edge cases, and the full `trips` router — creation, reconciliation, current-trip lookup, update/drop/resolve, 404/409 conflicts, and an actually-commits-to-the-database check mirroring the existing icon-reassign one).
- [x] Backend: `ruff check` clean.
- [x] Frontend: `vitest` — 256 passed (24 new: `tripsService`, `ReceiptTripDialog`'s full review→add→done flow including both bugs above, and `ProductList`'s scan button/banner/dialog wiring).
- [x] Frontend: `tsc -b` and `eslint` clean.
- [x] Live end-to-end through the actual running app, real backend, and real Ollama server: uploaded a real receipt photo (built from the issue's own example), confirmed correct extraction and food/non-food classification, correct reconciliation, walked through the checklist, created and linked a real product, and confirmed the trip survives a full browser close-and-reopen until every item is resolved.