### PR TITLE
fix: replace the leaked bot token with a synthetic fixture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# Working in this repository
+
+## Never use a real credential as a test fixture
+
+On 2026-08-30 the Telegram bot token was committed to this public repository in
+`backend/tests/test_config.py`, inside the regression test for #64 — the test
+whose entire purpose is proving that the token never reaches the logs. It was
+named `fake_token`. Someone found it and used the bot; the token was revoked on
+2026-09-01.
+
+Two things made it survive review:
+
+- **The name asserted the opposite of the truth.** `fake_token`, `dummy_`,
+  `test_`, `example_` are claims, not evidence. A reader who trusts the name
+  never looks at the value — and so does a human skimming a diff.
+- **The value was realistic on purpose.** Reaching for the real one is the
+  path of least resistance when a fixture needs to look real, and the real one
+  is sitting in `.env` next to you.
+
+So, when a test needs something credential-shaped:
+
+- **Construct it, do not paste it.** `"1234567890:" + "A" * 35` carries the
+  shape, cannot be a real value, and cannot be quietly replaced with one
+  without the diff making that obvious.
+- **Never read a value out of `.env`, the environment, a password manager, a
+  running container, or the deployed config to put in a test** — not even
+  temporarily while iterating.
+- Assume every value in this repository is public the moment it is committed.
+  This repository *is* public.
+
+The same rule covers fixtures in issues, PR descriptions, and pasted logs.

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -167,18 +167,22 @@ def test_the_http_client_cannot_publish_the_bot_token():
     previous_level = root.level
     root.setLevel(logging.DEBUG)
 
-    fake_token = "8670436717:AAG67gC_ue0EdBGryoKJN4oY6nILucfRMrM"
+    # Built by concatenation, and never pasted as a literal. The value only
+    # has to carry the *shape* of a bot token for this test to mean anything,
+    # and a real one here would be published by the very test that exists to
+    # keep it out of the logs. See CLAUDE.md.
+    token_shaped_value = "1234567890:" + "A" * 35
     try:
         logging.getLogger("httpx").info(
             'HTTP Request: POST https://api.telegram.org/bot%s/sendMessage "HTTP/1.1 200 OK"',
-            fake_token,
+            token_shaped_value,
         )
         logging.getLogger("httpcore").info("connect_tcp.started host='api.telegram.org'")
     finally:
         root.removeHandler(handler)
         root.setLevel(previous_level)
 
-    assert fake_token not in stream.getvalue()
+    assert token_shaped_value not in stream.getvalue()
     # The mechanism, asserted directly: the record is never created at all.
     assert not logging.getLogger("httpx").isEnabledFor(logging.INFO)
 


### PR DESCRIPTION
## What happened

The regression test added for #64 — `test_the_http_client_cannot_publish_the_bot_token`, whose whole purpose is proving the Telegram token never reaches the logs — used the **real bot token** as its fixture, under the name `fake_token`. It has been in this public repository since 2026-08-30 (`064fef3`), and is still on `main`.

Someone found it and started using the bot. The token was revoked on the same bot on 2026-09-01, so the value is dead and the new token is already rolled out to Home Assistant, Uptime Kuma, n8n, Proxmox and this service. The exposure is closed; this PR closes the source.

## What was and was not exposed

Swept before writing this, by value shape rather than by variable name:

| Checked | Result |
|---|---|
| `.env.example`, `backend/.env.example` | placeholders only |
| Issues, PR bodies, review comments, commit messages | clean |
| Published GHCR images | clean — built in Actions from a fresh checkout, and `backend/.dockerignore` excludes both `.env` and `tests/` |
| free-games-notifier, apollo-server-dashboard | clean |

So the leak was this one line, and nothing travelled with it.

## The change

The fixture is now **constructed instead of pasted**:

```python
token_shaped_value = "1234567890:" + "A" * 35
```

It carries the shape the test needs, it cannot be a real credential, and it cannot be quietly replaced with one — the diff would say so.

Adds `CLAUDE.md` with the rule. The name is the part worth writing down: `fake_token` asserted the opposite of the truth, and a reader who trusts the name never looks at the value.

## Verification

- `19 passed` on `tests/test_config.py`.
- Confirmed the test is still load-bearing rather than merely green: with the httpx silencing in `logging_config.py:134` reverted to `INFO`, it fails on `assert token_shaped_value not in stream.getvalue()`; restored, it passes. That check matters here because the docstring records an earlier version of this test passing with the fix removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)