### PR TITLE
fix: raise the receipt extraction timeout for large receipts

### DIFF
--- a/backend/app/receipt_client.py
+++ b/backend/app/receipt_client.py
@@ -25,11 +25,20 @@ from app.config import settings
 
 logger = logging.getLogger(__name__)
 
-# Same reasoning as vision_client.py's own budget: a downscaled real-photo
-# request measured in the tens of seconds, not the sub-2s a tiny synthetic
-# image suggested early on. A receipt has more lines to read than a single
-# label, so it gets the same generous number rather than a tighter one.
-TIMEOUT_SECONDS = 45.0
+# A receipt's output scales with line count in a way a single label's never
+# does: extracting one {name, date, weight} costs a roughly fixed number of
+# output tokens regardless of the photo, but a receipt generates one
+# {name, quantity, is_food} per line. Measured directly against the real
+# server, cold: a 20-item receipt took 24.4s total, a 36-item receipt took
+# 33.2s — generation alone ran 9.1s and 18.6s respectively, essentially
+# linear at ~49 tokens/s. 45s — sized for #83's single-item case — is
+# exactly what a real receipt hit in production (nginx logged
+# request_time: 45.124 against this timeout, to the millisecond). 120s
+# leaves real headroom for a large trip (60-80 lines) plus a cold load,
+# without leaving a genuinely unreachable Ollama able to stall for long.
+# nginx's own proxy_read_timeout for /api/ has to stay above this — see
+# nginx.conf — or it becomes the new, blunter cutoff instead.
+TIMEOUT_SECONDS = 120.0
 
 _RESPONSE_SCHEMA = {
     "type": "object",

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -129,6 +129,18 @@ server {
         # else in /api/ is small JSON, unaffected either way.
         client_max_body_size 12m;
 
+        # nginx's own default (60s) is below app/receipt_client.py's own
+        # TIMEOUT_SECONDS (120s, sized for a large receipt's real generation
+        # time — see that constant's own comment). Left at the default here,
+        # nginx becomes the cutoff instead: a blunter 504 with no body,
+        # instead of the API's own graceful 503 with a message the UI can
+        # show. Reproduced directly in production: a receipt scan failing at
+        # exactly the old, lower backend timeout, nginx's own 60s default
+        # never even in play that time only because it was still higher —
+        # raising the backend's budget without raising this would have
+        # inverted which one cuts the connection first.
+        proxy_read_timeout 150s;
+
         # Held in a variable on purpose: a literal here is resolved once at
         # startup, and the resolver above is only consulted when the upstream
         # name comes from a variable.


### PR DESCRIPTION
## Summary
Reported live: `POST /trips/receipt` failing with `Ollama receipt extraction failed: ReadTimeout` in the logs — nginx logged `request_time: 45.124`, matching the old `TIMEOUT_SECONDS` budget to the millisecond.

45s was sized for #83's single-item label extraction, where the output is a roughly fixed `{name, date, weight}` regardless of the photo. A receipt generates one `{name, quantity, is_food}` **per line**, so its generation time scales with how many items are on it — not something the label-extraction timing carried over correctly.

Measured directly against the real Ollama server, forcing a cold model each time:
| Receipt size | Total | Generation time | Output tokens |
|---|---|---|---|
| 20 items | 24.4s | 9.1s | 445 |
| 36 items | 33.2s | 18.6s | 912 |

Essentially linear at ~49 tokens/s. A real shopping trip larger than either of those was enough to cross 45s in production.

- `receipt_client.py`: `TIMEOUT_SECONDS` 45s → 120s — real headroom for a 60-80 line trip plus a cold load.
- `nginx.conf`: `/api/` now sets `proxy_read_timeout 150s`. nginx's own default (60s) was already below the *new* backend budget and would have become the new, blunter cutoff — a 504 with no body, instead of the API's own graceful 503 with a message the UI can actually show.

## Test plan
- [x] Backend: `pytest` — 265 passed, unaffected (the change is a single constant).
- [x] Backend: `ruff check` clean.
- [x] `nginx -t` inside a real build of `frontend/Dockerfile` — config syntax valid, `proxy_read_timeout 150s;` present in the rendered config.
- [x] Live, against the real Ollama server with the model forced cold: the same 36-item receipt that motivated the 120s figure now completes end-to-end through the real running API in 33.4s — well inside the new budget, where it would previously have been getting close to the old 45s ceiling on a real trip with more items than that.