### PR TITLE
chore: ignore ggshield's local cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Added by ggshield
+.cache_ggshield


### PR DESCRIPTION
## Summary
`.cache_ggshield` was untracked cruft left behind by `ggshield install`, done as part of setting up the pre-commit secret-scanning hook. It tracks which findings are already known/resolved so a resolved incident doesn't re-trigger a warning on every commit — local machine state, not something to version.

No code changes.