### PR TITLE
fix: give the toolbar real hierarchy, fix the receipt checklist's layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -10,6 +10,13 @@
   padding: 0.5rem 0 1.25rem;
 }
 
+.app__header-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
 .app__header h1 {
   font-size: 1.5rem;
   letter-spacing: -0.02em;
@@ -18,6 +25,27 @@
 .app__tagline {
   color: var(--text-muted);
   font-size: 0.875rem;
+}
+
+.app__header-actions {
+  display: flex;
+  gap: 0.5rem;
+  /* Lines up with the title's own cap-height instead of the tagline below
+     it — these buttons belong to "CaduTrack", not to the sentence under it. */
+  margin-top: 0.125rem;
+}
+
+.app__icon-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  font-size: 1.05rem;
+  line-height: 1;
+  border-radius: 0.5rem;
+  flex-shrink: 0;
 }
 
 .product-list {
@@ -224,11 +252,18 @@
   }
 }
 
+/* Just the two content-creation actions now — Historial and Ajustes moved
+   into app__header-actions, see App.css's own note there. Equal width
+   rather than flex-end: with only two buttons left, filling the row reads
+   as one deliberate choice instead of two buttons stranded on one side. */
 .list-header {
   display: flex;
-  justify-content: flex-end;
   gap: 0.5rem;
   padding-bottom: 0.875rem;
+}
+
+.list-header > button {
+  flex: 1;
 }
 
 .product-card__side {
@@ -645,6 +680,18 @@
   align-items: center;
   gap: 0.5rem;
   min-width: 0;
+}
+
+/* index.css's global `input { width: 100% }` targets every input, checkbox
+   included — the same conflict form__field--inline already works around for
+   the settings toggles. Without it the checkbox claims most of the row
+   (measured directly: 141px of a 284px-wide label), squeezing the name into
+   a few characters before its own ellipsis and shifting each row's checkbox
+   to a different width depending on how much text is next to it — which is
+   the inconsistent left edge, not a spacing bug. */
+.trip-checklist__label input {
+  width: auto;
+  flex-shrink: 0;
 }
 
 .trip-checklist__name {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,13 @@
 import { ProductList } from '@/pages/ProductList'
 import './App.css'
 
+// The header now lives inside ProductList: its two icon buttons open dialogs
+// ProductList itself owns the state for, and App has nowhere else to put
+// their handlers without threading callbacks back down for no other reason.
 function App() {
   return (
     <div className="app">
-      <header className="app__header">
-        <h1>CaduTrack</h1>
-        <p className="app__tagline">Lo que caduca primero, primero</p>
-      </header>
-      <main>
-        <ProductList />
-      </main>
+      <ProductList />
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -83,6 +83,16 @@ textarea {
   color: var(--text);
 }
 
+/* Left at the browser default otherwise: plain blue, on every theme,
+   checkbox or radio in the app — noticeable now next to the receipt
+   checklist's own row of them, but was already true of the settings
+   toggles too. accent-color is the one-line fix modern browsers support
+   for native controls, no custom-drawn checkbox needed. */
+input[type='checkbox'],
+input[type='radio'] {
+  accent-color: var(--accent);
+}
+
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible,

--- a/frontend/src/pages/ProductList.tsx
+++ b/frontend/src/pages/ProductList.tsx
@@ -133,13 +133,42 @@ export function ProductList() {
 
   return (
     <>
+      {/* Historial and Ajustes are navigation to a different view, not
+          content-creation — visually distinct on purpose, as small icon
+          buttons next to the title, so they stop competing with Recibo and
+          Agregar producto for the same row and the same weight. That
+          crowding is also what was cutting Historial off on a real phone
+          before this. Emoji glyphs, not an icon font: matches how every
+          product icon in this app already communicates meaning, and adds
+          no new dependency for two buttons. */}
+      <header className="app__header">
+        <div className="app__header-top">
+          <div>
+            <h1>CaduTrack</h1>
+            <p className="app__tagline">Lo que caduca primero, primero</p>
+          </div>
+          <div className="app__header-actions">
+            <button
+              type="button"
+              className="app__icon-button"
+              onClick={() => setDialog({ kind: 'history' })}
+              aria-label="Historial"
+            >
+              <span aria-hidden="true">🕘</span>
+            </button>
+            <button
+              type="button"
+              className="app__icon-button"
+              onClick={() => setDialog({ kind: 'settings' })}
+              aria-label="Ajustes"
+            >
+              <span aria-hidden="true">⚙️</span>
+            </button>
+          </div>
+        </div>
+      </header>
+
       <div className="list-header">
-        <button type="button" onClick={() => setDialog({ kind: 'history' })}>
-          Historial
-        </button>
-        <button type="button" onClick={() => setDialog({ kind: 'settings' })}>
-          Ajustes
-        </button>
         {/* A real click on a hidden input, not a wrapping <label>: the label
             text here would otherwise absorb "Leyendo…" into its own
             accessible name while a scan is in flight — see #83's own note


### PR DESCRIPTION
## Summary
Two things reported live, both from real screenshots on a phone.

**1. The toolbar overflowed and had no hierarchy.** Four buttons (Historial, Ajustes, Recibo, Agregar producto) crowded one row and Historial got cut off entirely on a real phone. The deeper issue: all four read as equally important despite being two different kinds of action — Historial/Ajustes are navigation to a different view, Recibo/Agregar producto are the two ways this app's actual content gets created.

Agreed on a direction with a mockup first (Historial/Ajustes as small icon buttons next to the title; Recibo/Agregar producto share the action row, each at half width) before touching code. `App.tsx`'s header now lives inside `ProductList`, since that's who owns the dialog state the icon buttons open — `App.tsx` had nowhere else to put their handlers without threading callbacks back down for no other reason.

**2. The receipt checklist's names were unreadable.** A live screenshot showed every name truncated to 3-4 characters, and each row's checkbox sitting at a different horizontal position. Root cause: `index.css`'s global `input { width: 100% }` targets every input, checkbox included — the exact conflict `.form__field--inline` already works around for the settings toggles, just never applied to the new checklist. Measured directly in a real browser: the checkbox was claiming 141px of a 284px-wide label before the fix, 13px after. The inconsistent left edge on different rows was that same width varying row to row, not a spacing bug.

While in the file: native checkboxes across the whole app (the settings toggles too, not just this new screen) render in the browser's plain blue on every theme, since nothing ever set `accent-color`. Added it so they match the theme instead.

## Test plan
- [x] Frontend: `vitest` — 256 passed, unaffected (existing tests query Historial/Ajustes by `aria-label`, which stayed the same text even though the visible content is now an icon).
- [x] `tsc -b` and `eslint` clean.
- [x] Live in a real browser at 375px width: confirmed the toolbar no longer overflows, both icon buttons open their correct dialogs, and a checklist with the report's own shape of names (long, mixed-length, some ticked and some not) renders every name in full with consistently-aligned, theme-colored checkboxes — measured the checkbox's actual rendered width before (141px) and after (13px) the fix directly in devtools.