### PR TITLE
feat: scan a barcode to identify a product (#30)

### DIFF
--- a/backend/alembic/versions/1c3f3dcfbd63_create_barcode_lookups_table.py
+++ b/backend/alembic/versions/1c3f3dcfbd63_create_barcode_lookups_table.py
@@ -1,0 +1,36 @@
+"""create barcode lookups table
+
+Revision ID: 1c3f3dcfbd63
+Revises: b4566f75e1df
+Create Date: 2026-09-01 19:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1c3f3dcfbd63'
+down_revision: str | None = 'b4566f75e1df'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('barcode_lookups',
+    sa.Column('code', sa.String(length=32), nullable=False),
+    sa.Column('name', sa.String(length=255), nullable=False),
+    sa.Column('icon', sa.String(length=16), nullable=True),
+    sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.PrimaryKeyConstraint('code', name=op.f('pk_barcode_lookups')),
+    schema='cadutrack'
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('barcode_lookups', schema='cadutrack')

--- a/backend/app/barcode_parser.py
+++ b/backend/app/barcode_parser.py
@@ -1,0 +1,86 @@
+"""Parsing a scanned barcode's raw value — see #30.
+
+BarcodeDetector (and every other scanner) returns a GS1-128 label as a
+plain concatenated digit string with no separators between the
+Application Identifiers this app cares about — verified directly, not
+assumed: a real GS1-128 barcode built from #30's own HEB example, decoded
+independently with zbar, came back as
+"01" + <14-digit GTIN> + "3103" + <6-digit weight> + "3922" + <8-digit
+price> with no parentheses and no FNC1 separator character anywhere in
+it. That is expected, not a decoder quirk: GS1 only requires a separator
+before a *variable*-length field, and every AI this module reads — (01)
+and (310n) — is fixed-length by the GS1 general specification. AI (392n),
+also on a real label, is variable-length; this module does not parse it,
+both because the issue's own acceptance criteria never asks for the price
+and because parsing a variable-length field correctly requires knowing
+where the *next* AI starts, which needs a real AI dictionary this app has
+no other use for.
+"""
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+_GTIN_LENGTH = 14
+_WEIGHT_DIGITS = 6
+# Product.quantity is NUMERIC(10, 2) — see app/models/product.py — while a
+# GS1 net weight can carry a third decimal place (0.586 kg is #30's own
+# worked example). Rounding here rather than widening that column: every
+# other quantity in this app, and the frontend's own cents-based stepper
+# math, already assumes two decimal places, and the app's purpose is
+# tracking roughly how much of something is in the fridge, not weighing to
+# the gram. A user who wants the exact figure can still edit the field
+# after scanning — nothing here is a silent save.
+_QUANTITY_DECIMAL_PLACES = Decimal("0.01")
+
+
+@dataclass
+class ParsedBarcode:
+    """What a scanned code decomposes to.
+
+    item_code is always populated — a barcode with nothing recognizable in
+    it about a GS1 preamble is simply treated as the item code itself,
+    which is exactly what a plain EAN-13/UPC scan already looks like.
+    """
+
+    item_code: str
+    quantity: Decimal | None
+    unit: str | None
+
+
+def parse_barcode(raw: str) -> ParsedBarcode:
+    """A GS1-128 label carrying a (01) GTIN, optionally followed by a
+    (310n) net weight — or, for anything else (a plain EAN-13/UPC), the raw
+    value itself is the item code, with no weight to find."""
+    if raw.startswith("01") and len(raw) >= 2 + _GTIN_LENGTH:
+        gtin = raw[2 : 2 + _GTIN_LENGTH]
+        if gtin.isdigit():
+            quantity, unit = _parse_weight(raw[2 + _GTIN_LENGTH :])
+            return ParsedBarcode(item_code=gtin, quantity=quantity, unit=unit)
+
+    return ParsedBarcode(item_code=raw, quantity=None, unit=None)
+
+
+def _parse_weight(rest: str) -> tuple[Decimal | None, str | None]:
+    """AI (310n): net weight in kilograms, n decimal places, always exactly
+    6 digits — see the module docstring for why no separator precedes it
+    here."""
+    if len(rest) < 4 + _WEIGHT_DIGITS or not rest.startswith("310"):
+        return None, None
+
+    decimal_places = rest[3]
+    digits = rest[4 : 4 + _WEIGHT_DIGITS]
+    if not decimal_places.isdigit() or not digits.isdigit():
+        return None, None
+
+    quantity = Decimal(digits) / (10 ** int(decimal_places))
+    if quantity <= 0:
+        return None, None
+    return quantity.quantize(_QUANTITY_DECIMAL_PLACES), "kg"
+
+
+def is_restricted_circulation(item_code: str) -> bool:
+    """GS1 prefix 2 is reserved for restricted circulation — internal store
+    codes with no meaning outside the store that printed them. Open Food
+    Facts, a global database, has nothing to say about these; asking it
+    anyway just spends a request to learn nothing — see #30."""
+    return item_code.startswith("2")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.logging_config import setup_logging
-from app.routers import alerts, categories, health, products, reauth, trips, vision
+from app.routers import alerts, barcodes, categories, health, products, reauth, trips, vision
 from app.routers import settings as settings_router
 from app.scheduler import shutdown_scheduler, start_scheduler
 
@@ -49,5 +49,6 @@ app.include_router(settings_router.router)
 app.include_router(vision.router)
 app.include_router(reauth.router)
 app.include_router(trips.router)
+app.include_router(barcodes.router)
 
 logger.info("CaduTrack API started")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ Imported wholesale by alembic/env.py so every table is registered on
 Base.metadata before autogenerate runs.
 """
 
+from app.models.barcode import BarcodeLookup
 from app.models.category import Category
 from app.models.product import IconSource, Location, Product
 from app.models.setting import AlertSettings, IconNameCache, IconSettings
@@ -11,6 +12,7 @@ from app.models.trip import ShoppingTrip, ShoppingTripItem
 
 __all__ = [
     "AlertSettings",
+    "BarcodeLookup",
     "Category",
     "IconNameCache",
     "IconSettings",

--- a/backend/app/models/barcode.py
+++ b/backend/app/models/barcode.py
@@ -1,0 +1,33 @@
+"""Barcode lookup model — see #30."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class BarcodeLookup(Base):
+    """What a scanned code was called last time.
+
+    Keyed on the item code — a GTIN or EAN — never the raw scanned string,
+    which for a GS1-128 label also carries a weight that has nothing to do
+    with what the product is called. Populated the first time a product is
+    actually created from this code, not on scan: a scan the user abandons
+    or types straight over must not remember anything.
+    """
+
+    __tablename__ = "barcode_lookups"
+
+    code: Mapped[str] = mapped_column(String(32), primary_key=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    # An icon override kept against the code, same reasoning as the name —
+    # see #30's own "this is also where an icon override is kept".
+    icon: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    def __repr__(self) -> str:
+        return f"<BarcodeLookup code={self.code!r} name={self.name!r}>"

--- a/backend/app/off_client.py
+++ b/backend/app/off_client.py
@@ -1,0 +1,67 @@
+"""Open Food Facts lookup for a real, globally-issued barcode — see #30.
+
+Never called for a GS1 prefix-2 (restricted circulation) code — see
+app/barcode_parser.py's is_restricted_circulation — since those have no
+meaning outside the store that printed them and Open Food Facts, a global
+database, has nothing to say about them.
+
+Same never-raise contract as the app's Ollama clients, for the same
+reason: a network failure, a timeout, or a response that doesn't parse are
+all reported as None, and the caller falls back to manual entry rather
+than blocking product creation on a third-party API that might be down.
+"""
+
+import logging
+from urllib.parse import quote
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+TIMEOUT_SECONDS = 5.0
+
+_BASE_URL = "https://world.openfoodfacts.org/api/v2/product"
+# Required by Open Food Facts' own API usage policy — an unidentified
+# client is the first thing rate-limited during an outage.
+_USER_AGENT = "CaduTrack/1.0 (+https://github.com/JulioMoralesB/CaduTrack)"
+
+
+def lookup_product_name(item_code: str) -> str | None:
+    """The product's own name, in Spanish where Open Food Facts has a
+    Spanish name and English/generic otherwise, or None when the code
+    isn't in their database or the request failed outright."""
+    try:
+        response = httpx.get(
+            # quote(), not an f-string alone: item_code is whatever the
+            # payload's own scan came in as (BarcodeScanPayload places no
+            # charset restriction on it), so it can contain characters that
+            # would otherwise land unescaped in the URL path.
+            f"{_BASE_URL}/{quote(item_code, safe='')}.json",
+            params={"fields": "product_name,product_name_es"},
+            timeout=TIMEOUT_SECONDS,
+            headers={"User-Agent": _USER_AGENT},
+        )
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.warning("Open Food Facts lookup failed for %r: %s", item_code, exc.__class__.__name__)
+        return None
+
+    try:
+        data = response.json()
+        if data.get("status") != 1:
+            return None
+        product = data["product"]
+    except (KeyError, TypeError, ValueError) as exc:
+        logger.warning(
+            "Open Food Facts returned an unparsable response for %r (%s): %r",
+            item_code,
+            exc.__class__.__name__,
+            response.text[:200],
+        )
+        return None
+
+    for field in ("product_name_es", "product_name"):
+        name = product.get(field)
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+    return None

--- a/backend/app/routers/barcodes.py
+++ b/backend/app/routers/barcodes.py
@@ -1,0 +1,66 @@
+"""Barcode lookup endpoints — see #30."""
+
+import logging
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.barcode_parser import is_restricted_circulation, parse_barcode
+from app.db.session import get_db
+from app.models import BarcodeLookup
+from app.off_client import lookup_product_name
+from app.schemas.barcode import BarcodeLookupResult, BarcodeRememberPayload, BarcodeScanPayload
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/barcodes", tags=["barcodes"])
+
+
+@router.post("/lookup", response_model=BarcodeLookupResult)
+def lookup_barcode(payload: BarcodeScanPayload, db: Session = Depends(get_db)) -> BarcodeLookupResult:
+    """Read a scanned code's own GS1 data, and fill in a name from whatever
+    remembers this code or, failing that, Open Food Facts.
+
+    Side-effect free, like #83's and #84's own analysis endpoints: nothing
+    here is saved. Remembering a name is a separate, explicit step — see
+    POST /barcodes/{item_code}/remember — that only happens once a product
+    genuinely gets created, not on every scan.
+    """
+    parsed = parse_barcode(payload.code)
+
+    remembered = db.get(BarcodeLookup, parsed.item_code)
+    if remembered is not None:
+        return BarcodeLookupResult(
+            item_code=parsed.item_code,
+            name=remembered.name,
+            icon=remembered.icon,
+            quantity=parsed.quantity,
+            unit=parsed.unit,
+        )
+
+    name = None if is_restricted_circulation(parsed.item_code) else lookup_product_name(parsed.item_code)
+    return BarcodeLookupResult(
+        item_code=parsed.item_code, name=name, icon=None, quantity=parsed.quantity, unit=parsed.unit
+    )
+
+
+@router.post("/{item_code}/remember", response_model=BarcodeLookupResult)
+def remember_barcode(
+    item_code: str, payload: BarcodeRememberPayload, db: Session = Depends(get_db)
+) -> BarcodeLookupResult:
+    """Record what this code turned out to be, so the next scan of the same
+    code fills itself in — the client's own confirmation that a product
+    was actually created, not a guess made on scan."""
+    row = db.get(BarcodeLookup, item_code)
+    if row is None:
+        row = BarcodeLookup(code=item_code, name=payload.name, icon=payload.icon)
+        db.add(row)
+    else:
+        row.name = payload.name
+        row.icon = payload.icon
+        row.updated_at = func.now()
+
+    db.commit()
+    logger.info("Remembered barcode %s as %r", item_code, payload.name)
+    return BarcodeLookupResult(item_code=item_code, name=payload.name, icon=payload.icon, quantity=None, unit=None)

--- a/backend/app/schemas/barcode.py
+++ b/backend/app/schemas/barcode.py
@@ -1,0 +1,36 @@
+"""Barcode request and response schemas — see #30."""
+
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+
+class BarcodeScanPayload(BaseModel):
+    """The raw value read off a scanned barcode, exactly as the scanner
+    returned it — this app's own GS1 parsing depends on that rawness."""
+
+    code: str = Field(min_length=1, max_length=128)
+
+
+class BarcodeLookupResult(BaseModel):
+    """What a scanned code resolved to. Every field but item_code may be
+    null when nothing could be determined with confidence — never a guess,
+    the same standard #83's label reading and #84's receipt reading hold
+    to. Field names match ProductBase deliberately, same reasoning as
+    #83's LabelExtraction, so the frontend can spread this into form state.
+    """
+
+    item_code: str
+    name: str | None = None
+    icon: str | None = None
+    quantity: Decimal | None = Field(default=None, gt=0, max_digits=10, decimal_places=2)
+    unit: str | None = None
+
+
+class BarcodeRememberPayload(BaseModel):
+    """What a product actually became, once the client has already created
+    it through the normal, already-confirmed POST /products — same
+    resolve-after-the-fact shape as #84's trip items."""
+
+    name: str = Field(min_length=1, max_length=255)
+    icon: str | None = Field(default=None, min_length=1, max_length=16)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -50,7 +50,7 @@ def db_session():
     session.execute(
         text(
             "TRUNCATE products, categories, alert_settings, icon_settings, icon_name_cache, "
-            "shopping_trips, shopping_trip_items "
+            "shopping_trips, shopping_trip_items, barcode_lookups "
             "RESTART IDENTITY CASCADE"
         )
     )

--- a/backend/tests/test_barcode_parser.py
+++ b/backend/tests/test_barcode_parser.py
@@ -1,0 +1,100 @@
+"""Barcode parsing tests.
+
+The GS1-128 shape asserted here — no separators between (01) and (310n) —
+is not assumed: it is exactly what a real GS1-128 barcode built from #30's
+own HEB example decoded to, verified independently with zbar and cross-
+checked against Chrome's BarcodeDetector on the same image.
+"""
+
+from decimal import Decimal
+
+from app.barcode_parser import is_restricted_circulation, parse_barcode
+
+
+def test_a_plain_ean13_is_its_own_item_code_with_no_weight():
+    result = parse_barcode("2520157108483")
+
+    assert result.item_code == "2520157108483"
+    assert result.quantity is None
+    assert result.unit is None
+
+
+def test_a_gs1_gtin_with_a_weight_is_split_apart():
+    """The nopal label from #30's own example: (01) GTIN, (3103) net
+    weight in kg to 3 decimal places -> 0.586 kg, rounded to the 2 decimal
+    places Product.quantity actually stores."""
+    raw = "01" + "29045580000076" + "3103" + "000586"
+
+    result = parse_barcode(raw)
+
+    assert result.item_code == "29045580000076"
+    assert result.quantity == Decimal("0.59")
+    assert result.unit == "kg"
+
+
+def test_a_gs1_gtin_with_a_trailing_field_after_the_weight_is_still_parsed():
+    """A real label also carries (3922) the price — not something this
+    parser reads, see its own module docstring, but its presence after the
+    weight must not break extracting the weight itself."""
+    raw = "01" + "29045580000076" + "3103" + "000586" + "3922" + "00002341"
+
+    result = parse_barcode(raw)
+
+    assert result.item_code == "29045580000076"
+    assert result.quantity == Decimal("0.59")
+
+
+def test_a_gs1_gtin_with_no_weight_field_has_no_quantity():
+    raw = "01" + "29045580000076"
+
+    result = parse_barcode(raw)
+
+    assert result.item_code == "29045580000076"
+    assert result.quantity is None
+    assert result.unit is None
+
+
+def test_a_gtin_prefix_with_a_non_digit_gtin_is_not_treated_as_gs1():
+    """"01" followed by something that isn't a 14-digit number is not a
+    GTIN — the whole raw value is the item code instead of misreading a
+    garbled prefix as one."""
+    raw = "01abcdefghijklmn"
+
+    result = parse_barcode(raw)
+
+    assert result.item_code == raw
+    assert result.quantity is None
+
+
+def test_a_weight_field_that_is_not_actually_6_digits_is_ignored():
+    """A malformed or truncated weight field must not produce a wrong
+    quantity — see #83/#84's own "never guess" standard applied here too."""
+    raw = "01" + "29045580000076" + "3103" + "12"  # too short
+
+    result = parse_barcode(raw)
+
+    assert result.item_code == "29045580000076"
+    assert result.quantity is None
+
+
+def test_a_zero_weight_is_treated_as_absent():
+    raw = "01" + "29045580000076" + "3103" + "000000"
+
+    assert parse_barcode(raw).quantity is None
+
+
+def test_the_milanesa_label_from_30s_own_example_has_no_weight_field():
+    """A plain EAN-13 never carries a GS1 weight — confirmed directly on
+    the issue's own second real example, which has no AIs at all."""
+    result = parse_barcode("2520157108483")
+
+    assert result.quantity is None
+
+
+def test_restricted_circulation_prefix():
+    assert is_restricted_circulation("2520157108483") is True
+    assert is_restricted_circulation("29045580000076") is True
+
+
+def test_a_normal_prefix_is_not_restricted_circulation():
+    assert is_restricted_circulation("5449000000996") is False

--- a/backend/tests/test_barcodes_api.py
+++ b/backend/tests/test_barcodes_api.py
@@ -1,0 +1,100 @@
+"""Barcode endpoint tests."""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_a_restricted_prefix_code_never_calls_open_food_facts(api_client, mocker):
+    off = mocker.patch("app.routers.barcodes.lookup_product_name")
+
+    response = api_client.post("/barcodes/lookup", json={"code": "2520157108483"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["item_code"] == "2520157108483"
+    assert body["name"] is None
+    off.assert_not_called()
+
+
+def test_a_normal_prefix_code_calls_open_food_facts(api_client, mocker):
+    off = mocker.patch("app.routers.barcodes.lookup_product_name", return_value="Coca-Cola")
+
+    response = api_client.post("/barcodes/lookup", json={"code": "5449000000996"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["item_code"] == "5449000000996"
+    assert body["name"] == "Coca-Cola"
+    off.assert_called_once_with("5449000000996")
+
+
+def test_a_gs1_code_extracts_the_weight_and_still_checks_the_restricted_prefix(api_client, mocker):
+    off = mocker.patch("app.routers.barcodes.lookup_product_name")
+    raw = "01" + "29045580000076" + "3103" + "000586"  # GTIN starts with 2
+
+    response = api_client.post("/barcodes/lookup", json={"code": raw})
+
+    body = response.json()
+    assert body["item_code"] == "29045580000076"
+    assert body["quantity"] == "0.59"
+    assert body["unit"] == "kg"
+    assert body["name"] is None
+    off.assert_not_called()
+
+
+def test_a_remembered_code_skips_open_food_facts_and_returns_what_was_saved(api_client, mocker):
+    off = mocker.patch("app.routers.barcodes.lookup_product_name", return_value="Should not be used")
+    api_client.post("/barcodes/5449000000996/remember", json={"name": "Coca-Cola de dieta", "icon": "\U0001F964"})
+
+    response = api_client.post("/barcodes/lookup", json={"code": "5449000000996"})
+
+    body = response.json()
+    assert body["name"] == "Coca-Cola de dieta"
+    assert body["icon"] == "\U0001F964"
+    off.assert_not_called()
+
+
+def test_a_remembered_code_still_reports_a_weight_read_off_the_current_scan(api_client):
+    """Remembering is about the name/icon, not the weight — a second
+    purchase of the same product can weigh differently, and the barcode's
+    own (310n) field is the authority on that, every time."""
+    api_client.post("/barcodes/29045580000076/remember", json={"name": "Nopal limpio"})
+    raw = "01" + "29045580000076" + "3103" + "000750"
+
+    response = api_client.post("/barcodes/lookup", json={"code": raw})
+
+    body = response.json()
+    assert body["name"] == "Nopal limpio"
+    assert body["quantity"] == "0.75"
+
+
+def test_remembering_twice_updates_rather_than_duplicates(api_client):
+    api_client.post("/barcodes/123/remember", json={"name": "Primer nombre"})
+    api_client.post("/barcodes/123/remember", json={"name": "Nombre corregido"})
+
+    response = api_client.post("/barcodes/lookup", json={"code": "123"})
+
+    assert response.json()["name"] == "Nombre corregido"
+
+
+def test_remembering_again_without_an_icon_clears_the_previous_icon(api_client):
+    api_client.post("/barcodes/123/remember", json={"name": "Algo", "icon": "\U0001F34C"})
+    api_client.post("/barcodes/123/remember", json={"name": "Algo"})
+
+    response = api_client.post("/barcodes/lookup", json={"code": "123"})
+
+    assert response.json()["icon"] is None
+
+
+def test_remembering_actually_commits_not_just_the_in_session_object(api_client, db_session, mocker):
+    """Same reasoning as products' own reassign-commit test: api_client and
+    db_session share one SQLAlchemy session in this fixture, so only a
+    fresh read after expiring the identity map proves the write reached
+    the database rather than just this test's in-memory object."""
+    mocker.patch("app.routers.barcodes.lookup_product_name", return_value="Should not be used")
+
+    api_client.post("/barcodes/123/remember", json={"name": "Nombre guardado"})
+    db_session.expire_all()
+
+    assert api_client.post("/barcodes/lookup", json={"code": "123"}).json()["name"] == "Nombre guardado"

--- a/backend/tests/test_off_client.py
+++ b/backend/tests/test_off_client.py
@@ -1,0 +1,101 @@
+"""Open Food Facts client tests. No network — every case is a mocked
+httpx call."""
+
+import httpx
+import pytest
+
+from app.off_client import lookup_product_name
+
+_REQUEST = httpx.Request("GET", "https://world.openfoodfacts.org/api/v2/product/123.json")
+
+
+def _response(**body) -> httpx.Response:
+    return httpx.Response(status_code=200, json=body, request=_REQUEST)
+
+
+def test_returns_the_spanish_name_when_present(mocker):
+    mocker.patch(
+        "app.off_client.httpx.get",
+        return_value=_response(status=1, product={"product_name": "Coca-Cola", "product_name_es": "Coca-Cola"}),
+    )
+
+    assert lookup_product_name("5449000000996") == "Coca-Cola"
+
+
+def test_falls_back_to_the_generic_name_when_no_spanish_name(mocker):
+    mocker.patch(
+        "app.off_client.httpx.get",
+        return_value=_response(status=1, product={"product_name": "Chobani Yogurt", "product_name_es": ""}),
+    )
+
+    assert lookup_product_name("123") == "Chobani Yogurt"
+
+
+def test_returns_none_when_the_product_is_not_found(mocker):
+    mocker.patch(
+        "app.off_client.httpx.get",
+        return_value=_response(status=0, status_verbose="product not found"),
+    )
+
+    assert lookup_product_name("123") is None
+
+
+def test_returns_none_when_neither_name_field_is_usable(mocker):
+    mocker.patch(
+        "app.off_client.httpx.get",
+        return_value=_response(status=1, product={"product_name": "", "product_name_es": None}),
+    )
+
+    assert lookup_product_name("123") is None
+
+
+def test_sends_a_user_agent(mocker):
+    get = mocker.patch("app.off_client.httpx.get", return_value=_response(status=0))
+
+    lookup_product_name("123")
+
+    _, kwargs = get.call_args
+    assert "User-Agent" in kwargs["headers"]
+
+
+def test_escapes_a_code_with_characters_that_are_not_safe_in_a_url_path(mocker):
+    """BarcodeScanPayload places no charset restriction on the raw scanned
+    code, so a garbled scan can land here with characters that would
+    otherwise break the request's own path segment."""
+    get = mocker.patch("app.off_client.httpx.get", return_value=_response(status=0))
+
+    lookup_product_name("01/29045580000076")
+
+    (url,), _ = get.call_args
+    assert url == "https://world.openfoodfacts.org/api/v2/product/01%2F29045580000076.json"
+
+
+def test_returns_none_on_a_connection_failure(mocker):
+    mocker.patch("app.off_client.httpx.get", side_effect=httpx.ConnectError("refused"))
+
+    assert lookup_product_name("123") is None
+
+
+def test_returns_none_on_a_timeout(mocker):
+    mocker.patch("app.off_client.httpx.get", side_effect=httpx.TimeoutException("slow"))
+
+    assert lookup_product_name("123") is None
+
+
+def test_returns_none_on_an_http_error_status(mocker):
+    mocker.patch(
+        "app.off_client.httpx.get",
+        return_value=httpx.Response(status_code=500, text="boom", request=_REQUEST),
+    )
+
+    assert lookup_product_name("123") is None
+
+
+@pytest.mark.parametrize("bad_body", ['not json', '{"status": 1}'])
+def test_returns_none_when_the_response_is_unparsable(mocker, bad_body):
+    mocker.patch(
+        "app.off_client.httpx.get",
+        return_value=httpx.Response(status_code=200, content=bad_body, request=_REQUEST),
+    )
+
+    assert lookup_product_name("123") is None

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cadutrack",
       "version": "0.0.0",
       "dependencies": {
+        "@zxing/browser": "^0.2.1",
         "axios": "^1.20.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
@@ -4097,6 +4098,41 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@zxing/browser": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.2.1.tgz",
+      "integrity": "sha512-92pVfVDUXbc15xu9vIEmhNyqIEASMEkDF92CwT6T+7sg2EHXJRktH9CQKoQSXe51UtbNsj+Fm09H/JBWHMs/Sw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@zxing/text-encoding": "^0.9.0"
+      },
+      "peerDependencies": {
+        "@zxing/library": "^0.23.0"
+      }
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.23.0.tgz",
+      "integrity": "sha512-6fkkoFwP8CHxl6ugnPsj74PLJgX2iRv5zczGAyt5OBzQgxFhuhF0NCEc4t4OvSr8xAv2MRLlI0Iu9ZGDZQ2urA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "ts-custom-error": "^3.3.1"
+      },
+      "engines": {
+        "node": ">= 24.0.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -8448,6 +8484,16 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@zxing/browser": "^0.2.1",
     "axios": "^1.20.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -418,8 +418,25 @@
 }
 
 .form__scan {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
   padding-bottom: 0.875rem;
   border-bottom: 1px solid var(--border);
+}
+
+.barcode-scanner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.barcode-scanner__video {
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  background: #000;
 }
 
 /* Filters */

--- a/frontend/src/barcodeDetector.d.ts
+++ b/frontend/src/barcodeDetector.d.ts
@@ -1,0 +1,18 @@
+/**
+ * The Barcode Detection API — Chrome/Android only as of writing, which is
+ * exactly why #30 needs the zxing-js fallback in BarcodeScanner.tsx. Not
+ * shipped in TypeScript's own lib.dom.d.ts (checked against 6.0.3), so it
+ * has to be declared here instead of coming for free.
+ */
+interface DetectedBarcode {
+  rawValue: string
+}
+
+declare class BarcodeDetector {
+  constructor(options?: { formats?: string[] })
+  detect(source: HTMLVideoElement): Promise<DetectedBarcode[]>
+}
+
+interface Window {
+  BarcodeDetector?: typeof BarcodeDetector
+}

--- a/frontend/src/components/BarcodeScanner.test.tsx
+++ b/frontend/src/components/BarcodeScanner.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BarcodeScanner } from '@/components/BarcodeScanner'
+
+type DecodeCallback = (result: { getText: () => string } | undefined) => void
+
+const zxingControlsStop = vi.fn()
+const decodeFromConstraints = vi.fn()
+
+vi.mock('@zxing/browser', () => ({
+  // A plain function, not an arrow function: the component calls this with
+  // `new`, and an arrow function can never be a constructor — vitest warns
+  // about exactly this ("did not use 'function' or 'class'") and `new`-ing
+  // it throws, which BarcodeScanner's own catch-all then reports as
+  // "No se pudo abrir la cámara.", masking what actually broke.
+  BrowserMultiFormatReader: vi.fn(function BrowserMultiFormatReader() {
+    return { decodeFromConstraints }
+  }),
+}))
+
+vi.mock('@zxing/library', () => ({
+  BarcodeFormat: { CODE_128: 'code_128', EAN_13: 'ean_13', EAN_8: 'ean_8', UPC_E: 'upc_e' },
+  DecodeHintType: { POSSIBLE_FORMATS: 'possible_formats' },
+}))
+
+function fakeStream() {
+  const stop = vi.fn()
+  return { stream: { getTracks: () => [{ stop }] } as unknown as MediaStream, stop }
+}
+
+/** jsdom implements neither — both are exercised by the component whenever
+ *  the native path runs at all. */
+function stubVideoPlayback() {
+  vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined)
+}
+
+beforeEach(() => {
+  decodeFromConstraints.mockReset()
+  zxingControlsStop.mockReset()
+  stubVideoPlayback()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete (window as { BarcodeDetector?: unknown }).BarcodeDetector
+  Object.defineProperty(navigator, 'mediaDevices', { value: undefined, configurable: true })
+})
+
+describe('BarcodeScanner, native BarcodeDetector available', () => {
+  it('reports the first decoded value and stops the camera', async () => {
+    const { stream, stop } = fakeStream()
+    const getUserMedia = vi.fn().mockResolvedValue(stream)
+    Object.defineProperty(navigator, 'mediaDevices', { value: { getUserMedia }, configurable: true })
+
+    const detect = vi.fn().mockResolvedValue([{ rawValue: '5449000000996' }])
+    // A plain function, not an arrow function — see the @zxing/browser mock
+    // above for why: the component new()s this.
+    window.BarcodeDetector = vi.fn(function FakeBarcodeDetector() {
+      return { detect }
+    }) as unknown as typeof BarcodeDetector
+
+    const onDetected = vi.fn()
+    render(<BarcodeScanner onDetected={onDetected} onCancel={vi.fn()} />)
+
+    await waitFor(() => expect(onDetected).toHaveBeenCalledWith('5449000000996'))
+    expect(getUserMedia).toHaveBeenCalledWith({ video: { facingMode: 'environment' } })
+    expect(stop).toHaveBeenCalled()
+  })
+
+  it('shows a permission message when the camera is denied', async () => {
+    const getUserMedia = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new DOMException('denied', 'NotAllowedError')))
+    Object.defineProperty(navigator, 'mediaDevices', { value: { getUserMedia }, configurable: true })
+    window.BarcodeDetector = vi.fn() as unknown as typeof BarcodeDetector
+
+    render(<BarcodeScanner onDetected={vi.fn()} onCancel={vi.fn()} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Se necesita permiso de cámara para escanear.')
+  })
+
+  it('shows a generic message for any other camera failure', async () => {
+    const getUserMedia = vi.fn().mockRejectedValue(new Error('no camera hardware'))
+    Object.defineProperty(navigator, 'mediaDevices', { value: { getUserMedia }, configurable: true })
+    window.BarcodeDetector = vi.fn() as unknown as typeof BarcodeDetector
+
+    render(<BarcodeScanner onDetected={vi.fn()} onCancel={vi.fn()} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('No se pudo abrir la cámara.')
+  })
+
+  it('notifies the caller on cancel, and releases the camera once unmounted', async () => {
+    const { stream, stop } = fakeStream()
+    const getUserMedia = vi.fn().mockResolvedValue(stream)
+    Object.defineProperty(navigator, 'mediaDevices', { value: { getUserMedia }, configurable: true })
+    // Never resolves with a barcode — keeps the scan loop alive for Cancel
+    // to interrupt. A plain function, not an arrow function — see above.
+    window.BarcodeDetector = vi.fn(function FakeBarcodeDetector() {
+      return { detect: vi.fn().mockResolvedValue([]) }
+    }) as unknown as typeof BarcodeDetector
+
+    const onCancel = vi.fn()
+    const { unmount } = render(<BarcodeScanner onDetected={vi.fn()} onCancel={onCancel} />)
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalled())
+
+    // Cancelling itself just notifies the caller — same contract as
+    // Modal's own onClose — it is the caller unmounting in response, as
+    // ProductForm does, that actually tears the camera down.
+    fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }))
+    expect(onCancel).toHaveBeenCalledOnce()
+    expect(stop).not.toHaveBeenCalled()
+
+    unmount()
+
+    expect(stop).toHaveBeenCalled()
+  })
+})
+
+describe('BarcodeScanner, no native BarcodeDetector', () => {
+  it('falls back to zxing and reports its decoded value', async () => {
+    Object.defineProperty(navigator, 'mediaDevices', { value: { getUserMedia: vi.fn() }, configurable: true })
+    decodeFromConstraints.mockImplementation((_constraints, _video, callback: DecodeCallback) => {
+      callback({ getText: () => '2520157108483' })
+      return Promise.resolve({ stop: zxingControlsStop })
+    })
+
+    const onDetected = vi.fn()
+    render(<BarcodeScanner onDetected={onDetected} onCancel={vi.fn()} />)
+
+    await waitFor(() => expect(onDetected).toHaveBeenCalledWith('2520157108483'))
+    expect(decodeFromConstraints).toHaveBeenCalledWith(
+      { video: { facingMode: 'environment' } },
+      expect.anything(),
+      expect.any(Function),
+    )
+  })
+
+  it('ignores a callback fired with no result — a normal miss on one frame', async () => {
+    Object.defineProperty(navigator, 'mediaDevices', { value: { getUserMedia: vi.fn() }, configurable: true })
+    decodeFromConstraints.mockImplementation((_constraints, _video, callback: DecodeCallback) => {
+      callback(undefined)
+      return Promise.resolve({ stop: zxingControlsStop })
+    })
+
+    const onDetected = vi.fn()
+    render(<BarcodeScanner onDetected={onDetected} onCancel={vi.fn()} />)
+
+    await waitFor(() => expect(decodeFromConstraints).toHaveBeenCalled())
+    expect(onDetected).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/BarcodeScanner.tsx
+++ b/frontend/src/components/BarcodeScanner.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { Modal } from '@/components/Modal'
+
+interface BarcodeScannerProps {
+  /** Fired once, with the raw decoded value — GS1-128's own AI-prefixed
+   *  string or a plain EAN/UPC. Parsing that value is barcode_parser.py's
+   *  job, not this component's. */
+  onDetected: (raw: string) => void
+  onCancel: () => void
+}
+
+/**
+ * Formats worth decoding for #30. GS1-128 has no dedicated format of its
+ * own in either decoder — confirmed against a real generated GS1-128 image
+ * cross-checked with zbar — so it has to be requested as plain code_128 and
+ * parsed manually afterwards. upc_a is deliberately left out: it is not in
+ * the set Chrome's real BarcodeDetector reports as supported.
+ */
+const FORMATS = ['code_128', 'ean_13', 'ean_8', 'upc_e']
+
+const VIDEO_CONSTRAINTS: MediaStreamConstraints = { video: { facingMode: 'environment' } }
+
+/**
+ * Live camera barcode scanner — see #30. Prefers the native BarcodeDetector
+ * (already on-device, no bundle weight); falls back to zxing-js when it is
+ * unavailable, which per the issue is required — Safari and Firefox ship
+ * neither BarcodeDetector nor a substitute, so this is the only way #30
+ * works there at all.
+ */
+export function BarcodeScanner({ onDetected, onCancel }: BarcodeScannerProps) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    let stopStream: (() => void) | null = null
+
+    const finish = (code: string) => {
+      if (cancelled) return
+      cancelled = true
+      stopStream?.()
+      onDetected(code)
+    }
+
+    const startNative = async () => {
+      const stream = await navigator.mediaDevices.getUserMedia(VIDEO_CONSTRAINTS)
+      // The permission prompt is exactly where a user cancelling this
+      // dialog races the grant — if we already unmounted while it was
+      // pending, release the camera immediately instead of leaving it on.
+      if (cancelled || !videoRef.current) {
+        stream.getTracks().forEach((track) => track.stop())
+        return
+      }
+      stopStream = () => stream.getTracks().forEach((track) => track.stop())
+      videoRef.current.srcObject = stream
+      await videoRef.current.play()
+
+      const detector = new window.BarcodeDetector!({ formats: FORMATS })
+      const tick = async () => {
+        if (cancelled || !videoRef.current) return
+        try {
+          const results = await detector.detect(videoRef.current)
+          if (results.length > 0) {
+            finish(results[0].rawValue)
+            return
+          }
+        } catch {
+          // A single frame that fails to decode is normal mid-scan, not an
+          // error worth surfacing — the next frame just tries again.
+        }
+        if (!cancelled) requestAnimationFrame(() => void tick())
+      }
+      requestAnimationFrame(() => void tick())
+    }
+
+    const startZxing = async () => {
+      const [{ BrowserMultiFormatReader }, { BarcodeFormat, DecodeHintType }] = await Promise.all([
+        import('@zxing/browser'),
+        import('@zxing/library'),
+      ])
+      const hints = new Map()
+      hints.set(DecodeHintType.POSSIBLE_FORMATS, [
+        BarcodeFormat.CODE_128,
+        BarcodeFormat.EAN_13,
+        BarcodeFormat.EAN_8,
+        BarcodeFormat.UPC_E,
+      ])
+      const reader = new BrowserMultiFormatReader(hints)
+      if (cancelled || !videoRef.current) return
+
+      const controls = await reader.decodeFromConstraints(VIDEO_CONSTRAINTS, videoRef.current, (result) => {
+        if (result) finish(result.getText())
+      })
+      // Same unmount-during-permission-prompt race as startNative, but
+      // decodeFromConstraints only hands back something to stop once it
+      // resolves — stop it right away rather than leaving the camera on.
+      if (cancelled) {
+        controls.stop()
+        return
+      }
+      stopStream = () => controls.stop()
+    }
+
+    void (async () => {
+      try {
+        if (window.BarcodeDetector) {
+          await startNative()
+        } else {
+          await startZxing()
+        }
+      } catch (caught) {
+        if (!cancelled) {
+          setError(
+            caught instanceof DOMException && caught.name === 'NotAllowedError'
+              ? 'Se necesita permiso de cámara para escanear.'
+              : 'No se pudo abrir la cámara.',
+          )
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+      stopStream?.()
+    }
+  }, [onDetected])
+
+  return (
+    <Modal title="Escanear código de barras" onClose={onCancel}>
+      <div className="barcode-scanner">
+        {error ? (
+          <p className="form__error" role="alert">
+            {error}
+          </p>
+        ) : (
+          <>
+            <video ref={videoRef} className="barcode-scanner__video" muted playsInline aria-label="Vista de la cámara" />
+            <p className="settings__hint">Apunta la cámara al código de barras.</p>
+          </>
+        )}
+        <div className="form__actions">
+          <button type="button" onClick={onCancel}>
+            Cancelar
+          </button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/src/components/ProductForm.test.tsx
+++ b/frontend/src/components/ProductForm.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ProductForm } from '@/components/ProductForm'
-import type { LabelExtraction, Product } from '@/services/types'
+import type { BarcodeLookupResult, LabelExtraction, Product } from '@/services/types'
 
 vi.mock('@/services/productsService', () => ({
   createProduct: vi.fn(),
@@ -13,13 +13,41 @@ vi.mock('@/services/visionService', () => ({
   extractLabel: vi.fn(),
 }))
 
+vi.mock('@/services/barcodesService', () => ({
+  lookupBarcode: vi.fn(),
+  rememberBarcode: vi.fn(),
+}))
+
+// Camera access and BarcodeDetector/zxing have their own coverage in
+// BarcodeScanner.test.tsx — here only the detected value matters, so the
+// component is replaced with two buttons standing in for what it reports.
+vi.mock('@/components/BarcodeScanner', () => ({
+  BarcodeScanner: ({ onDetected, onCancel }: { onDetected: (raw: string) => void; onCancel: () => void }) => (
+    <div>
+      <button type="button" onClick={() => onDetected('5449000000996')}>
+        fake-detect
+      </button>
+      <button type="button" onClick={onCancel}>
+        fake-cancel-scan
+      </button>
+    </div>
+  ),
+}))
+
 const products = await import('@/services/productsService')
 const vision = await import('@/services/visionService')
+const barcodes = await import('@/services/barcodesService')
 const mockedCreate = vi.mocked(products.createProduct)
 const mockedExtract = vi.mocked(vision.extractLabel)
+const mockedLookupBarcode = vi.mocked(barcodes.lookupBarcode)
+const mockedRememberBarcode = vi.mocked(barcodes.rememberBarcode)
 
 function labelExtraction(overrides: Partial<LabelExtraction> = {}): LabelExtraction {
   return { name: null, expires_at: null, quantity: null, unit: null, ...overrides }
+}
+
+function barcodeLookupResult(overrides: Partial<BarcodeLookupResult> = {}): BarcodeLookupResult {
+  return { item_code: '5449000000996', name: null, icon: null, quantity: null, unit: null, ...overrides }
 }
 
 function selectPhoto() {
@@ -28,6 +56,34 @@ function selectPhoto() {
     target: { files: [file] },
   })
 }
+
+function scanBarcode() {
+  fireEvent.click(screen.getByRole('button', { name: 'Escanear código de barras' }))
+  fireEvent.click(screen.getByRole('button', { name: 'fake-detect' }))
+}
+
+function fakeProduct(overrides: Partial<Product> = {}): Product {
+  return {
+    id: 1,
+    name: 'Nopal limpio',
+    category_id: null,
+    quantity: '1.00',
+    unit: null,
+    expires_at: '2026-09-10',
+    location: 'fridge',
+    notes: null,
+    category: null,
+    icon: '\u{1F955}',
+    icon_source: 'default',
+    created_at: '2026-08-29T00:00:00Z',
+    updated_at: '2026-08-29T00:00:00Z',
+    consumed_at: null,
+    days_until_expiry: 10,
+    status: 'fresh',
+    ...overrides,
+  }
+}
+
 
 /**
  * Fill only what the form requires, then submit.
@@ -220,5 +276,134 @@ describe('ProductForm label scan', () => {
     expect(screen.getByLabelText('Foto de la etiqueta (opcional)')).toBeDisabled()
     resolveRequest(labelExtraction())
     await waitFor(() => expect(screen.getByLabelText('Foto de la etiqueta (opcional)')).not.toBeDisabled())
+  })
+})
+
+describe('ProductForm barcode scan', () => {
+  // Several of these tests assert call counts on lookupBarcode/rememberBarcode,
+  // which nothing else in this file resets between tests.
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // A bare vi.fn() with no return value resolves to undefined rather than
+    // a Promise, and ProductForm always chains .catch() onto this call — a
+    // test that never overrides it would otherwise crash on a mock, not on
+    // anything the component itself does wrong.
+    mockedRememberBarcode.mockResolvedValue(undefined)
+  })
+
+  it('offers the scan button when creating, not when editing', () => {
+    const { unmount } = render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Escanear código de barras' })).toBeInTheDocument()
+    unmount()
+
+    render(<ProductForm product={fakeProduct()} categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.queryByRole('button', { name: 'Escanear código de barras' })).not.toBeInTheDocument()
+  })
+
+  it('pre-fills what the lookup returned, and never touches the expiry date', async () => {
+    mockedLookupBarcode.mockResolvedValue(
+      barcodeLookupResult({ name: 'Nopal limpio', quantity: '0.59', unit: 'kg' }),
+    )
+    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+
+    scanBarcode()
+
+    await waitFor(() => expect(screen.getByLabelText('Nombre')).toHaveValue('Nopal limpio'))
+    expect(screen.getByLabelText('Cantidad')).toHaveValue(0.59)
+    expect(screen.getByLabelText('Unidad')).toHaveValue('kg')
+    // A barcode never carries an expiry date — see #30 — so this is left
+    // exactly as it started, for the user to fill in by hand.
+    expect(screen.getByLabelText('Caduca el')).toHaveValue('')
+    expect(screen.getByText('Código escaneado. Revisa los datos antes de guardar.')).toBeInTheDocument()
+  })
+
+  it('leaves a field the lookup could not resolve untouched', async () => {
+    mockedLookupBarcode.mockResolvedValue(barcodeLookupResult({ name: 'Nopal limpio' }))
+    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    fireEvent.change(screen.getByLabelText('Unidad'), { target: { value: 'piezas' } })
+
+    scanBarcode()
+
+    await waitFor(() => expect(screen.getByLabelText('Nombre')).toHaveValue('Nopal limpio'))
+    expect(screen.getByLabelText('Unidad')).toHaveValue('piezas')
+  })
+
+  it('says so when a restricted-circulation code carries no known name', async () => {
+    mockedLookupBarcode.mockResolvedValue(barcodeLookupResult())
+    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+
+    scanBarcode()
+
+    expect(
+      await screen.findByText('Código leído, pero sin información conocida. Completa los campos manualmente.'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the failure inline and leaves the rest of the form usable', async () => {
+    mockedLookupBarcode.mockRejectedValue(new Error('nope'))
+    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+
+    scanBarcode()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Huevos' } })
+    expect(screen.getByLabelText('Nombre')).toHaveValue('Huevos')
+  })
+
+  it('closes on cancel without touching the form', () => {
+    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Escanear código de barras' }))
+    fireEvent.click(screen.getByRole('button', { name: 'fake-cancel-scan' }))
+
+    expect(screen.queryByRole('button', { name: 'fake-cancel-scan' })).not.toBeInTheDocument()
+    expect(mockedLookupBarcode).not.toHaveBeenCalled()
+    expect(screen.getByLabelText('Nombre')).toHaveValue('')
+  })
+
+  it('remembers the scanned code once the product it fed is actually saved', async () => {
+    mockedLookupBarcode.mockResolvedValue(barcodeLookupResult({ name: 'Nopal limpio', quantity: '0.59', unit: 'kg' }))
+    const saved = fakeProduct({ name: 'Nopal limpio (confirmado)', icon: '\u{1F955}' })
+    mockedCreate.mockResolvedValue(saved)
+    const onSaved = vi.fn()
+    render(<ProductForm categories={[]} onSaved={onSaved} onCancel={vi.fn()} />)
+
+    scanBarcode()
+    await waitFor(() => expect(screen.getByLabelText('Nombre')).toHaveValue('Nopal limpio'))
+    fireEvent.change(screen.getByLabelText('Caduca el'), { target: { value: '2026-09-10' } })
+    // The name below is what the user actually confirmed in the form —
+    // remember() must reflect that, not the raw lookup result, since the
+    // two can differ once the user edits before saving.
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Nopal limpio (confirmado)' } })
+    fireEvent.click(screen.getByRole('button', { name: /guardar/i }))
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith(saved))
+    expect(mockedRememberBarcode).toHaveBeenCalledWith('5449000000996', 'Nopal limpio (confirmado)', '\u{1F955}')
+  })
+
+  it('does not remember anything when no barcode was ever scanned', async () => {
+    mockedCreate.mockResolvedValue(fakeProduct())
+    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+
+    fillAndSubmit()
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledOnce())
+    expect(mockedRememberBarcode).not.toHaveBeenCalled()
+  })
+
+  it('does not let a failed remember block the save from completing', async () => {
+    mockedLookupBarcode.mockResolvedValue(barcodeLookupResult({ name: 'Nopal limpio' }))
+    mockedRememberBarcode.mockRejectedValue(new Error('boom'))
+    const saved = fakeProduct()
+    mockedCreate.mockResolvedValue(saved)
+    const onSaved = vi.fn()
+    render(<ProductForm categories={[]} onSaved={onSaved} onCancel={vi.fn()} />)
+
+    scanBarcode()
+    await waitFor(() => expect(screen.getByLabelText('Nombre')).toHaveValue('Nopal limpio'))
+    fireEvent.change(screen.getByLabelText('Caduca el'), { target: { value: '2026-09-10' } })
+    fireEvent.click(screen.getByRole('button', { name: /guardar/i }))
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith(saved))
   })
 })

--- a/frontend/src/components/ProductForm.tsx
+++ b/frontend/src/components/ProductForm.tsx
@@ -1,10 +1,12 @@
 import { useMemo, useState, type ChangeEvent, type FormEvent } from 'react'
 
+import { BarcodeScanner } from '@/components/BarcodeScanner'
 import { Modal } from '@/components/Modal'
 import { downscaleImage } from '@/downscaleImage'
 import { LOCATION_LABELS } from '@/labels'
 import { canStepDown, stepQuantity } from '@/quantity'
 import { toErrorMessage } from '@/services/api'
+import { lookupBarcode, rememberBarcode } from '@/services/barcodesService'
 import { createProduct, replaceProduct } from '@/services/productsService'
 import type { Category, Location, Product, ProductPayload } from '@/services/types'
 import { extractLabel } from '@/services/visionService'
@@ -66,6 +68,16 @@ export function ProductForm({ product, prefill, categories, onSaved, onCancel, t
   const [scanError, setScanError] = useState<string | null>(null)
   const [scanHint, setScanHint] = useState<string | null>(null)
 
+  const [barcodeScanning, setBarcodeScanning] = useState(false)
+  const [barcodeLookupPending, setBarcodeLookupPending] = useState(false)
+  const [barcodeError, setBarcodeError] = useState<string | null>(null)
+  const [barcodeHint, setBarcodeHint] = useState<string | null>(null)
+  // What to remember() once the save this scan feeds into actually
+  // succeeds — see #30. A scan the user abandons or types straight over
+  // must not remember anything, so this only ever gets read from
+  // handleSubmit, never used on its own.
+  const [pendingBarcode, setPendingBarcode] = useState<{ itemCode: string; icon: string | null } | null>(null)
+
   const isEdit = product !== undefined
 
   // Categories arrive asynchronously. Until they do, a select whose value has
@@ -125,6 +137,40 @@ export function ProductForm({ product, prefill, categories, onSaved, onCancel, t
     })()
   }
 
+  /**
+   * A barcode never carries a name by itself — only what a previous
+   * remember() or Open Food Facts said the code was, plus whatever a
+   * GS1-128 label's own (310n) field reads as weight. Same merge rule as
+   * handleScan: only fields the lookup actually returned are overwritten.
+   */
+  const handleBarcodeDetected = (raw: string) => {
+    setBarcodeScanning(false)
+    setBarcodeLookupPending(true)
+    setBarcodeError(null)
+    setBarcodeHint(null)
+    void (async () => {
+      try {
+        const result = await lookupBarcode(raw)
+        setForm((current) => ({
+          ...current,
+          name: result.name ?? current.name,
+          quantity: result.quantity ?? current.quantity,
+          unit: result.unit ?? current.unit,
+        }))
+        setPendingBarcode({ itemCode: result.item_code, icon: result.icon })
+        setBarcodeHint(
+          result.name || result.quantity
+            ? 'Código escaneado. Revisa los datos antes de guardar.'
+            : 'Código leído, pero sin información conocida. Completa los campos manualmente.',
+        )
+      } catch (caught) {
+        setBarcodeError(toErrorMessage(caught))
+      } finally {
+        setBarcodeLookupPending(false)
+      }
+    })()
+  }
+
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault()
     setSaving(true)
@@ -143,6 +189,11 @@ export function ProductForm({ product, prefill, categories, onSaved, onCancel, t
     void (async () => {
       try {
         const saved = product ? await replaceProduct(product.id, payload) : await createProduct(payload)
+        if (pendingBarcode) {
+          // Best-effort — see rememberBarcode's own contract. A failed cache
+          // write must not undo an already-successful save.
+          void rememberBarcode(pendingBarcode.itemCode, saved.name, saved.icon).catch(() => {})
+        }
         onSaved(saved)
       } catch (caught) {
         setError(toErrorMessage(caught))
@@ -160,29 +211,60 @@ export function ProductForm({ product, prefill, categories, onSaved, onCancel, t
             Only offered when creating: an edit already has real values, and
             re-scanning over them is not a flow this covers. */}
         {!isEdit && (
-          // Explicit htmlFor/id rather than wrapping in a <label>, same
-          // reasoning as Cantidad below: a wrapping label's accessible name
-          // is its full text content, and the status paragraphs here change
-          // while scanning — wrapped, the label's name would grow to include
-          // "Leyendo etiqueta…" while a scan is in flight instead of naming
-          // the control. See #91's IconPicker for the same fix, same reason.
-          <div className="form__field form__scan">
-            <label htmlFor="product-scan">Foto de la etiqueta (opcional)</label>
-            <input
-              id="product-scan"
-              type="file"
-              accept="image/*"
-              capture="environment"
-              onChange={handleScan}
-              disabled={scanning}
-            />
-            {scanning && <p className="settings__hint">Leyendo etiqueta…</p>}
-            {scanError && (
-              <p className="form__error" role="alert">
-                {scanError}
-              </p>
-            )}
-            {scanHint && <p className="settings__hint">{scanHint}</p>}
+          <div className="form__scan">
+            {/* Explicit htmlFor/id rather than wrapping in a <label>, same
+                reasoning as Cantidad below: a wrapping label's accessible
+                name is its full text content, and the status paragraphs
+                here change while scanning — wrapped, the label's name would
+                grow to include "Leyendo etiqueta…" while a scan is in
+                flight instead of naming the control. See #91's IconPicker
+                for the same fix, same reason. */}
+            <div className="form__field">
+              <label htmlFor="product-scan">Foto de la etiqueta (opcional)</label>
+              <input
+                id="product-scan"
+                type="file"
+                accept="image/*"
+                capture="environment"
+                onChange={handleScan}
+                disabled={scanning || barcodeLookupPending}
+              />
+              {scanning && <p className="settings__hint">Leyendo etiqueta…</p>}
+              {scanError && (
+                <p className="form__error" role="alert">
+                  {scanError}
+                </p>
+              )}
+              {scanHint && <p className="settings__hint">{scanHint}</p>}
+            </div>
+
+            {/* A barcode never carries an expiry date — see #30 — so this
+                only ever fills in name/quantity/unit, same partial-
+                overwrite rule as the photo scan above. A separate
+                affordance rather than folded into it: a live camera scan
+                and a photo upload are different enough interactions to
+                need their own button and status. */}
+            <div className="form__field">
+              <span>Código de barras (opcional)</span>
+              <button
+                type="button"
+                onClick={() => {
+                  setBarcodeError(null)
+                  setBarcodeHint(null)
+                  setBarcodeScanning(true)
+                }}
+                disabled={scanning || barcodeLookupPending}
+              >
+                Escanear código de barras
+              </button>
+              {barcodeLookupPending && <p className="settings__hint">Buscando producto…</p>}
+              {barcodeError && (
+                <p className="form__error" role="alert">
+                  {barcodeError}
+                </p>
+              )}
+              {barcodeHint && <p className="settings__hint">{barcodeHint}</p>}
+            </div>
           </div>
         )}
 
@@ -332,6 +414,9 @@ export function ProductForm({ product, prefill, categories, onSaved, onCancel, t
           </button>
         </div>
       </form>
+      {barcodeScanning && (
+        <BarcodeScanner onDetected={handleBarcodeDetected} onCancel={() => setBarcodeScanning(false)} />
+      )}
     </Modal>
   )
 }

--- a/frontend/src/services/barcodesService.test.ts
+++ b/frontend/src/services/barcodesService.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { lookupBarcode, rememberBarcode } from '@/services/barcodesService'
+
+vi.mock('@/services/api', () => ({
+  api: { post: vi.fn() },
+}))
+
+const { api } = await import('@/services/api')
+const mockedApi = vi.mocked(api)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('lookupBarcode', () => {
+  it('posts the scanned code and returns what the backend resolved', async () => {
+    const result = { item_code: '5449000000996', name: 'Coca-Cola', icon: null, quantity: null, unit: null }
+    mockedApi.post.mockResolvedValue({ data: result })
+
+    expect(await lookupBarcode('5449000000996')).toEqual(result)
+    const [path, body] = mockedApi.post.mock.calls[0]
+    expect(path).toBe('/barcodes/lookup')
+    expect(body).toEqual({ code: '5449000000996' })
+  })
+
+  it('is not retried — the user can just point the camera again', async () => {
+    mockedApi.post.mockRejectedValue(new Error('boom'))
+
+    await expect(lookupBarcode('123')).rejects.toThrow('boom')
+    expect(mockedApi.post.mock.calls).toHaveLength(1)
+  })
+})
+
+describe('rememberBarcode', () => {
+  it('posts the name and icon to the code-specific endpoint', async () => {
+    mockedApi.post.mockResolvedValue({ data: {} })
+
+    await rememberBarcode('5449000000996', 'Coca-Cola', '\u{1F964}')
+
+    const [path, body] = mockedApi.post.mock.calls[0]
+    expect(path).toBe('/barcodes/5449000000996/remember')
+    expect(body).toEqual({ name: 'Coca-Cola', icon: '\u{1F964}' })
+  })
+
+  it('escapes a code with characters that are not safe in a URL path', async () => {
+    mockedApi.post.mockResolvedValue({ data: {} })
+
+    await rememberBarcode('01/29045580000076', 'Nopal limpio', null)
+
+    const [path] = mockedApi.post.mock.calls[0]
+    expect(path).toBe('/barcodes/01%2F29045580000076/remember')
+  })
+
+  it('is not retried — a best-effort cache write behind an already-successful save', async () => {
+    mockedApi.post.mockRejectedValue(new Error('boom'))
+
+    await expect(rememberBarcode('123', 'Algo', null)).rejects.toThrow('boom')
+    expect(mockedApi.post.mock.calls).toHaveLength(1)
+  })
+})

--- a/frontend/src/services/barcodesService.ts
+++ b/frontend/src/services/barcodesService.ts
@@ -1,0 +1,28 @@
+import { api } from '@/services/api'
+import type { BarcodeLookupResult } from '@/services/types'
+
+/**
+ * Resolve a scanned code — see #30 and POST /barcodes/lookup. Side-effect
+ * free, same contract as extractLabel: nothing is saved, the result is
+ * only meant to pre-fill the product form for the user to confirm.
+ *
+ * Not retried, same reasoning as extractLabel: the user can just point the
+ * camera again, and a scan happens far more often than it fails.
+ */
+export async function lookupBarcode(code: string): Promise<BarcodeLookupResult> {
+  const { data } = await api.post<BarcodeLookupResult>('/barcodes/lookup', { code })
+  return data
+}
+
+/**
+ * Record what a scanned code turned out to be — call only after the
+ * product it identified was actually created, via the normal createProduct,
+ * same "call only after it already exists" contract as resolveTripItem.
+ *
+ * Not retried, same reasoning as resolveTripItem: this is a best-effort
+ * cache write behind an already-successful save, not something worth
+ * troubling the user over if it fails.
+ */
+export async function rememberBarcode(itemCode: string, name: string, icon: string | null): Promise<void> {
+  await api.post(`/barcodes/${encodeURIComponent(itemCode)}/remember`, { name, icon })
+}

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -137,6 +137,29 @@ export interface ShoppingTripItem {
   product_id: number | null
 }
 
+/**
+ * What a scanned barcode resolved to — see #30 and POST /barcodes/lookup.
+ * Never carries an expiry date: a barcode does not encode one, so the form
+ * this prefills always leaves "Caduca el" for the user to fill in by hand.
+ */
+export interface BarcodeLookupResult {
+  /** The GTIN read from a GS1-128 label, or the raw code as scanned for a
+   *  plain EAN/UPC — what remember() and a repeat scan are both keyed on. */
+  item_code: string
+  /** From a previous remember() call if this code has been scanned before,
+   *  otherwise from Open Food Facts, otherwise null (also always null for a
+   *  restricted-circulation code — see is_restricted_circulation). */
+  name: string | null
+  /** Only ever set by a previous remember() call; OFF has no icon of its
+   *  own to offer. */
+  icon: string | null
+  /** Read straight off a GS1-128 label's own (310n) weight field — never
+   *  from a remembered value, since the same product can weigh differently
+   *  on a later purchase. Null for a plain EAN/UPC, which carries no weight. */
+  quantity: string | null
+  unit: string | null
+}
+
 /** A shopping trip's checklist — see #84. Persists across reloads: the
  *  photo is analyzed once, then the trip stays visible until every item is
  *  either added as a product or dropped. */


### PR DESCRIPTION
## Summary
- Live-camera barcode scan added to the product form (create only) — `BarcodeDetector` first, `zxing-js` fallback for browsers without it.
- Handles both GS1-128 (parses AI `(01)` GTIN and `(310n)` net weight, both fixed-length and concatenated with no separator — verified against a real generated GS1-128 label, cross-checked with zbar) and plain EAN-13/UPC.
- A barcode never carries an expiry date, so the scan only ever pre-fills name/quantity/unit — never "Caduca el".
- Open Food Facts is queried for a name only when the code isn't GS1 prefix `2` (restricted circulation / internal store code, nothing OFF would know about).
- "Remember the code": once a scanned code's product is actually saved, its name and icon are stored (`POST /barcodes/{item_code}/remember`) so the next scan of the same code (`POST /barcodes/lookup`) fills itself in — same "resolve after the product already exists" shape as #84's trip items.

### A trade-off worth flagging
GS1's own `(310n)` weight can carry 3 decimal places — the nopal example in the issue is `0.586 kg`. `Product.quantity` is `NUMERIC(10,2)`, same as every other quantity in the app (and the frontend's cents-based stepper math assumes 2 places), so this rounds to `0.59 kg` rather than widening that column app-wide. Documented in `barcode_parser.py`; the field stays fully editable in the form either way.

## Test plan
- [x] Backend: 294 tests pass (`pytest`), `ruff check` clean.
- [x] Frontend: 276 tests pass (`vitest`), `eslint` and `tsc -b` clean.
- [x] GS1-128 parsing verified against a real generated label (python-barcode/treepoem+Ghostscript), independently cross-checked with zbar/pyzbar.
- [x] Live-verified in the browser: modal stacks correctly over the product form, camera-permission-denied shows the right Spanish message, Cancel closes only the scanner and leaves the form untouched, no console errors.
- [ ] Not verified against a live camera aimed at a real barcode (no camera in this environment) — the acceptance criteria's exact numbers (0.586 kg, restricted-circulation skip, OFF fill, remembered-code reuse) are covered by backend integration tests using the same real wire format instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)