### PR TITLE
feat: warn about a likely same-day duplicate when adding a product (#108)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -366,6 +366,27 @@
   justify-content: flex-end;
   gap: 0.625rem;
   padding-top: 0.375rem;
+  flex-wrap: wrap;
+}
+
+/* Same status-stripe language as a product card's own expiring-soon
+   border — this is exactly that kind of "look before you proceed" beat. */
+.form__duplicate-warning {
+  padding: 0.75rem 0.875rem;
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--status-expiring-soon);
+  border-radius: 0.625rem;
+  background: var(--surface);
+}
+
+.form__duplicate-warning p {
+  margin: 0 0 0.625rem;
+  font-size: 0.875rem;
+}
+
+.form__duplicate-warning .form__actions {
+  justify-content: flex-start;
+  padding-top: 0;
 }
 
 /* Sized in em so it tracks the button's text, and drawn in currentColor so it
@@ -712,8 +733,24 @@
 }
 
 .trip-checklist__name {
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Same status color as a card's own expiring-soon stripe — a lighter-weight
+   "heads up" than the full form__duplicate-warning box a ticked item's own
+   ProductForm would otherwise be the first place to show this. */
+.trip-checklist__badge {
+  flex-shrink: 0;
+  padding: 0.125rem 0.45rem;
+  border-radius: 999px;
+  background: var(--status-expiring-soon);
+  color: var(--on-fill);
+  font-size: 0.6875rem;
+  font-weight: 600;
   white-space: nowrap;
 }
 

--- a/frontend/src/components/ProductForm.test.tsx
+++ b/frontend/src/components/ProductForm.test.tsx
@@ -7,6 +7,7 @@ import type { BarcodeLookupResult, LabelExtraction, Product } from '@/services/t
 vi.mock('@/services/productsService', () => ({
   createProduct: vi.fn(),
   replaceProduct: vi.fn(),
+  adjustProductQuantity: vi.fn(),
 }))
 
 vi.mock('@/services/visionService', () => ({
@@ -38,6 +39,7 @@ const products = await import('@/services/productsService')
 const vision = await import('@/services/visionService')
 const barcodes = await import('@/services/barcodesService')
 const mockedCreate = vi.mocked(products.createProduct)
+const mockedAdjustQuantity = vi.mocked(products.adjustProductQuantity)
 const mockedExtract = vi.mocked(vision.extractLabel)
 const mockedLookupBarcode = vi.mocked(barcodes.lookupBarcode)
 const mockedRememberBarcode = vi.mocked(barcodes.rememberBarcode)
@@ -109,7 +111,7 @@ describe('ProductForm while saving', () => {
     const onSaved = vi.fn()
 
     const { container } = render(
-      <ProductForm categories={[]} onSaved={onSaved} onCancel={vi.fn()} />,
+      <ProductForm categories={[]} products={[]} onSaved={onSaved} onCancel={vi.fn()} />,
     )
     fillAndSubmit()
 
@@ -129,7 +131,7 @@ describe('ProductForm while saving', () => {
     mockedCreate.mockRejectedValue(new Error('nope'))
 
     const { container } = render(
-      <ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />,
+      <ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />,
     )
     fillAndSubmit()
 
@@ -141,13 +143,13 @@ describe('ProductForm while saving', () => {
 
 describe('ProductForm quantity stepper', () => {
   it('hides "−" at the default quantity of 1', () => {
-    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
 
     expect(screen.queryByRole('button', { name: 'Reducir cantidad' })).not.toBeInTheDocument()
   })
 
   it('shows "−" again once "+" has been pressed, and hides it once stepped back to 1', () => {
-    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Aumentar cantidad' }))
     expect(screen.getByRole('button', { name: 'Reducir cantidad' })).toBeInTheDocument()
@@ -176,7 +178,7 @@ describe('ProductForm quantity stepper', () => {
       status: 'expiring_soon',
     }
 
-    render(<ProductForm product={product} categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm product={product} categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
 
     expect(screen.getByRole('button', { name: 'Reducir cantidad' })).toBeInTheDocument()
   })
@@ -203,11 +205,11 @@ describe('ProductForm label scan', () => {
       status: 'expiring_soon',
     }
 
-    const { unmount } = render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    const { unmount } = render(<ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
     expect(screen.getByLabelText('Foto de la etiqueta (opcional)')).toBeInTheDocument()
     unmount()
 
-    render(<ProductForm product={product} categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm product={product} categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
     expect(screen.queryByLabelText('Foto de la etiqueta (opcional)')).not.toBeInTheDocument()
   })
 
@@ -215,7 +217,7 @@ describe('ProductForm label scan', () => {
     mockedExtract.mockResolvedValue(
       labelExtraction({ name: 'Nopal limpio', expires_at: '2026-09-01', quantity: '0.59', unit: 'kg' }),
     )
-    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
 
     selectPhoto()
 
@@ -228,7 +230,7 @@ describe('ProductForm label scan', () => {
 
   it('leaves a field the model could not read untouched', async () => {
     mockedExtract.mockResolvedValue(labelExtraction({ name: 'Nopal limpio' }))
-    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
     fireEvent.change(screen.getByLabelText('Unidad'), { target: { value: 'piezas' } })
 
     selectPhoto()
@@ -241,7 +243,7 @@ describe('ProductForm label scan', () => {
 
   it('says so when nothing in the photo could be read', async () => {
     mockedExtract.mockResolvedValue(labelExtraction())
-    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
 
     selectPhoto()
 
@@ -252,7 +254,7 @@ describe('ProductForm label scan', () => {
 
   it('shows the failure inline and leaves the rest of the form usable', async () => {
     mockedExtract.mockRejectedValue(new Error('nope'))
-    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
 
     selectPhoto()
 
@@ -269,7 +271,7 @@ describe('ProductForm label scan', () => {
         resolveRequest = resolve
       }),
     )
-    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
 
     selectPhoto()
 
@@ -292,11 +294,11 @@ describe('ProductForm barcode scan', () => {
   })
 
   it('offers the scan button when creating, not when editing', () => {
-    const { unmount } = render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    const { unmount } = render(<ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
     expect(screen.getByRole('button', { name: 'Escanear código de barras' })).toBeInTheDocument()
     unmount()
 
-    render(<ProductForm product={fakeProduct()} categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm product={fakeProduct()} categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
     expect(screen.queryByRole('button', { name: 'Escanear código de barras' })).not.toBeInTheDocument()
   })
 
@@ -304,7 +306,7 @@ describe('ProductForm barcode scan', () => {
     mockedLookupBarcode.mockResolvedValue(
       barcodeLookupResult({ name: 'Nopal limpio', quantity: '0.59', unit: 'kg' }),
     )
-    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
 
     scanBarcode()
 
@@ -319,7 +321,7 @@ describe('ProductForm barcode scan', () => {
 
   it('leaves a field the lookup could not resolve untouched', async () => {
     mockedLookupBarcode.mockResolvedValue(barcodeLookupResult({ name: 'Nopal limpio' }))
-    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
     fireEvent.change(screen.getByLabelText('Unidad'), { target: { value: 'piezas' } })
 
     scanBarcode()
@@ -330,7 +332,7 @@ describe('ProductForm barcode scan', () => {
 
   it('says so when a restricted-circulation code carries no known name', async () => {
     mockedLookupBarcode.mockResolvedValue(barcodeLookupResult())
-    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
 
     scanBarcode()
 
@@ -341,7 +343,7 @@ describe('ProductForm barcode scan', () => {
 
   it('shows the failure inline and leaves the rest of the form usable', async () => {
     mockedLookupBarcode.mockRejectedValue(new Error('nope'))
-    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
 
     scanBarcode()
 
@@ -351,7 +353,7 @@ describe('ProductForm barcode scan', () => {
   })
 
   it('closes on cancel without touching the form', () => {
-    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Escanear código de barras' }))
     fireEvent.click(screen.getByRole('button', { name: 'fake-cancel-scan' }))
@@ -366,7 +368,7 @@ describe('ProductForm barcode scan', () => {
     const saved = fakeProduct({ name: 'Nopal limpio (confirmado)', icon: '\u{1F955}' })
     mockedCreate.mockResolvedValue(saved)
     const onSaved = vi.fn()
-    render(<ProductForm categories={[]} onSaved={onSaved} onCancel={vi.fn()} />)
+    render(<ProductForm categories={[]} products={[]} onSaved={onSaved} onCancel={vi.fn()} />)
 
     scanBarcode()
     await waitFor(() => expect(screen.getByLabelText('Nombre')).toHaveValue('Nopal limpio'))
@@ -383,7 +385,7 @@ describe('ProductForm barcode scan', () => {
 
   it('does not remember anything when no barcode was ever scanned', async () => {
     mockedCreate.mockResolvedValue(fakeProduct())
-    render(<ProductForm categories={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    render(<ProductForm categories={[]} products={[]} onSaved={vi.fn()} onCancel={vi.fn()} />)
 
     fillAndSubmit()
 
@@ -397,7 +399,7 @@ describe('ProductForm barcode scan', () => {
     const saved = fakeProduct()
     mockedCreate.mockResolvedValue(saved)
     const onSaved = vi.fn()
-    render(<ProductForm categories={[]} onSaved={onSaved} onCancel={vi.fn()} />)
+    render(<ProductForm categories={[]} products={[]} onSaved={onSaved} onCancel={vi.fn()} />)
 
     scanBarcode()
     await waitFor(() => expect(screen.getByLabelText('Nombre')).toHaveValue('Nopal limpio'))
@@ -405,5 +407,118 @@ describe('ProductForm barcode scan', () => {
     fireEvent.click(screen.getByRole('button', { name: /guardar/i }))
 
     await waitFor(() => expect(onSaved).toHaveBeenCalledWith(saved))
+  })
+})
+
+describe('ProductForm duplicate check', () => {
+  // Nothing else in this file resets mocks between tests — see the
+  // barcode-scan describe above for the same fix, same reason.
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Real, unmocked "now" throughout — findDuplicateToday compares calendar
+  // days with new Date(), and matching that against a fixed fake date would
+  // put fake timers in the way of every await waitFor(...) below, which
+  // relies on real timers to poll.
+  function createdToday(): string {
+    return new Date().toISOString()
+  }
+
+  function createdYesterday(): string {
+    return new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+  }
+
+  it('shows the three-way choice instead of saving, when the name matches an active product created today', () => {
+    const existing = fakeProduct({ id: 9, name: 'Nopal limpio', quantity: '0.50', unit: 'kg', created_at: createdToday() })
+    render(<ProductForm categories={[]} products={[existing]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+
+    fillAndSubmit()
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Ya agregaste "Nopal limpio" hoy (0.5 kg)')
+    expect(screen.getByRole('button', { name: 'Agregar de todas formas' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Sumar a la cantidad existente' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Omitir' })).toBeInTheDocument()
+    expect(mockedCreate).not.toHaveBeenCalled()
+  })
+
+  it('does not flag a product with the same name created on a previous day', () => {
+    const existing = fakeProduct({ name: 'Nopal limpio', created_at: createdYesterday() })
+    mockedCreate.mockResolvedValue(fakeProduct())
+    render(<ProductForm categories={[]} products={[existing]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+
+    fillAndSubmit()
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(mockedCreate).toHaveBeenCalledOnce()
+  })
+
+  it('does not check for a duplicate when editing — a product can never duplicate itself', async () => {
+    const existing = fakeProduct({ id: 3, name: 'Nopal limpio', created_at: createdToday() })
+    const mockedReplace = vi.mocked(products.replaceProduct)
+    mockedReplace.mockResolvedValue(existing)
+    render(<ProductForm product={existing} categories={[]} products={[existing]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Caduca el'), { target: { value: '2026-09-10' } })
+    fireEvent.click(screen.getByRole('button', { name: /guardar/i }))
+
+    await waitFor(() => expect(mockedReplace).toHaveBeenCalledOnce())
+    expect(screen.queryByRole('button', { name: 'Omitir' })).not.toBeInTheDocument()
+  })
+
+  it('"Agregar de todas formas" creates a second product as normal', async () => {
+    const existing = fakeProduct({ name: 'Nopal limpio', created_at: createdToday() })
+    const saved = fakeProduct({ id: 20 })
+    mockedCreate.mockResolvedValue(saved)
+    const onSaved = vi.fn()
+    render(<ProductForm categories={[]} products={[existing]} onSaved={onSaved} onCancel={vi.fn()} />)
+    fillAndSubmit()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Agregar de todas formas' }))
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith(saved))
+    expect(mockedCreate).toHaveBeenCalledOnce()
+  })
+
+  it('"Sumar a la cantidad existente" adjusts the existing product instead of creating a new one', async () => {
+    const existing = fakeProduct({ id: 9, name: 'Nopal limpio', created_at: createdToday() })
+    const updated = fakeProduct({ id: 9, name: 'Nopal limpio', quantity: '1.50' })
+    mockedAdjustQuantity.mockResolvedValue(updated)
+    const onSaved = vi.fn()
+    render(<ProductForm categories={[]} products={[existing]} onSaved={onSaved} onCancel={vi.fn()} />)
+    fillAndSubmit()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sumar a la cantidad existente' }))
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith(updated))
+    expect(mockedAdjustQuantity).toHaveBeenCalledWith(9, 1)
+    expect(mockedCreate).not.toHaveBeenCalled()
+  })
+
+  it('"Omitir" adds nothing and defers to onCancel, same as skipping any other add', () => {
+    const existing = fakeProduct({ name: 'Nopal limpio', created_at: createdToday() })
+    const onCancel = vi.fn()
+    render(<ProductForm categories={[]} products={[existing]} onSaved={vi.fn()} onCancel={onCancel} />)
+    fillAndSubmit()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Omitir' }))
+
+    expect(onCancel).toHaveBeenCalledOnce()
+    expect(mockedCreate).not.toHaveBeenCalled()
+    expect(mockedAdjustQuantity).not.toHaveBeenCalled()
+  })
+
+  it('clears a stale warning once the name is edited, so the next submit re-checks against the new name', () => {
+    const existing = fakeProduct({ name: 'Nopal limpio', created_at: createdToday() })
+    mockedCreate.mockResolvedValue(fakeProduct())
+    render(<ProductForm categories={[]} products={[existing]} onSaved={vi.fn()} onCancel={vi.fn()} />)
+    fillAndSubmit()
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Nopal limpio, otra marca' } })
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /guardar/i }))
+    expect(mockedCreate).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/components/ProductForm.tsx
+++ b/frontend/src/components/ProductForm.tsx
@@ -3,11 +3,12 @@ import { useMemo, useState, type ChangeEvent, type FormEvent } from 'react'
 import { BarcodeScanner } from '@/components/BarcodeScanner'
 import { Modal } from '@/components/Modal'
 import { downscaleImage } from '@/downscaleImage'
-import { LOCATION_LABELS } from '@/labels'
+import { findDuplicateToday } from '@/duplicateCheck'
+import { LOCATION_LABELS, quantityLabel } from '@/labels'
 import { canStepDown, stepQuantity } from '@/quantity'
 import { toErrorMessage } from '@/services/api'
 import { lookupBarcode, rememberBarcode } from '@/services/barcodesService'
-import { createProduct, replaceProduct } from '@/services/productsService'
+import { adjustProductQuantity, createProduct, replaceProduct } from '@/services/productsService'
 import type { Category, Location, Product, ProductPayload } from '@/services/types'
 import { extractLabel } from '@/services/visionService'
 
@@ -21,6 +22,10 @@ interface ProductFormProps {
   prefill?: { name: string; quantity: string }
   /** Passed in rather than fetched here, so opening the form costs no request. */
   categories: Category[]
+  /** The active product list, for the same-day duplicate check — see #108.
+   *  Ignored when editing: a product being edited is never a duplicate of
+   *  itself. */
+  products: Product[]
   /** Called with the server's own response, so a caller that needs the new
    *  product's id — resolving a shopping trip item into it, see #84 — has
    *  it without a second request. */
@@ -59,7 +64,7 @@ function initialState(product?: Product, prefill?: { name: string; quantity: str
 }
 
 /** Create or edit a product. The same form serves both. */
-export function ProductForm({ product, prefill, categories, onSaved, onCancel, title }: ProductFormProps) {
+export function ProductForm({ product, prefill, categories, products, onSaved, onCancel, title }: ProductFormProps) {
   const [form, setForm] = useState<FormState>(() => initialState(product, prefill))
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -78,6 +83,12 @@ export function ProductForm({ product, prefill, categories, onSaved, onCancel, t
   // handleSubmit, never used on its own.
   const [pendingBarcode, setPendingBarcode] = useState<{ itemCode: string; icon: string | null } | null>(null)
 
+  // Set once handleSubmit finds a same-day match, instead of saving right
+  // away — see #108. Cleared on the next name edit rather than staying
+  // sticky, since a warning about a name the user has since changed is
+  // just noise.
+  const [duplicateWarning, setDuplicateWarning] = useState<Product | null>(null)
+
   const isEdit = product !== undefined
 
   // Categories arrive asynchronously. Until they do, a select whose value has
@@ -92,8 +103,10 @@ export function ProductForm({ product, prefill, categories, onSaved, onCancel, t
     return categories
   }, [categories, product])
 
-  const update = <K extends keyof FormState>(field: K, value: FormState[K]) =>
+  const update = <K extends keyof FormState>(field: K, value: FormState[K]) => {
     setForm((current) => ({ ...current, [field]: value }))
+    if (field === 'name') setDuplicateWarning(null)
+  }
 
   /**
    * The photo is an accuracy shortcut, not a separate flow: it fills in
@@ -171,8 +184,10 @@ export function ProductForm({ product, prefill, categories, onSaved, onCancel, t
     })()
   }
 
-  const handleSubmit = (event: FormEvent) => {
-    event.preventDefault()
+  /** The actual network save, shared by a plain submit and "Agregar de
+   *  todas formas" — the duplicate check below only ever decides whether
+   *  this runs immediately or waits on a choice first. */
+  const performCreate = () => {
     setSaving(true)
     setError(null)
 
@@ -195,6 +210,56 @@ export function ProductForm({ product, prefill, categories, onSaved, onCancel, t
           void rememberBarcode(pendingBarcode.itemCode, saved.name, saved.icon).catch(() => {})
         }
         onSaved(saved)
+      } catch (caught) {
+        setError(toErrorMessage(caught))
+      } finally {
+        setSaving(false)
+      }
+    })()
+  }
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault()
+
+    // Once a choice is already on screen, a native re-submit (e.g. Enter in
+    // a text field) must not silently pick "add anyway" on its behalf —
+    // only its own explicit button does that. See #108.
+    if (duplicateWarning) return
+
+    // Only on create — editing a product's own name can never duplicate
+    // itself.
+    if (!isEdit) {
+      const duplicate = findDuplicateToday(products, form.name)
+      if (duplicate) {
+        setDuplicateWarning(duplicate)
+        return
+      }
+    }
+
+    performCreate()
+  }
+
+  const handleAddAnyway = () => {
+    setDuplicateWarning(null)
+    performCreate()
+  }
+
+  /** Bumps the existing product's quantity instead of creating a second
+   *  row for it — see #108. Still remembers a scanned barcode against the
+   *  product that actually ends up representing this code going forward,
+   *  same as a plain create would. */
+  const handleMergeIntoExisting = () => {
+    if (!duplicateWarning) return
+    setSaving(true)
+    setError(null)
+
+    void (async () => {
+      try {
+        const updated = await adjustProductQuantity(duplicateWarning.id, Number(form.quantity))
+        if (pendingBarcode) {
+          void rememberBarcode(pendingBarcode.itemCode, updated.name, updated.icon).catch(() => {})
+        }
+        onSaved(updated)
       } catch (caught) {
         setError(toErrorMessage(caught))
       } finally {
@@ -394,25 +459,49 @@ export function ProductForm({ product, prefill, categories, onSaved, onCancel, t
           </p>
         )}
 
-        <div className="form__actions">
-          <button type="button" onClick={onCancel} disabled={saving}>
-            Cancelar
-          </button>
-          <button type="submit" className="button--primary" disabled={saving}>
-            {saving ? (
-              <>
-                {/* Stays up across the whole retry sequence, because `saving`
-                    is only cleared once withRetry settles. A dropped
-                    connection is exactly when a still-disabled button with no
-                    motion reads as a hang. */}
-                <span className="spinner" aria-hidden="true" />
-                Guardando…
-              </>
-            ) : (
-              'Guardar'
-            )}
-          </button>
-        </div>
+        {/* Replaces the normal actions rather than sitting above them —
+            Guardar going through again would just re-run into the same
+            duplicate, so the three explicit choices are the only way
+            forward from here. See #108. */}
+        {duplicateWarning ? (
+          <div className="form__duplicate-warning" role="alert">
+            <p>
+              Ya agregaste "{duplicateWarning.name}" hoy ({quantityLabel(duplicateWarning.quantity, duplicateWarning.unit)}
+              ). ¿Qué quieres hacer?
+            </p>
+            <div className="form__actions">
+              <button type="button" onClick={onCancel} disabled={saving}>
+                Omitir
+              </button>
+              <button type="button" onClick={handleMergeIntoExisting} disabled={saving}>
+                Sumar a la cantidad existente
+              </button>
+              <button type="button" className="button--primary" onClick={handleAddAnyway} disabled={saving}>
+                Agregar de todas formas
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="form__actions">
+            <button type="button" onClick={onCancel} disabled={saving}>
+              Cancelar
+            </button>
+            <button type="submit" className="button--primary" disabled={saving}>
+              {saving ? (
+                <>
+                  {/* Stays up across the whole retry sequence, because `saving`
+                      is only cleared once withRetry settles. A dropped
+                      connection is exactly when a still-disabled button with no
+                      motion reads as a hang. */}
+                  <span className="spinner" aria-hidden="true" />
+                  Guardando…
+                </>
+              ) : (
+                'Guardar'
+              )}
+            </button>
+          </div>
+        )}
       </form>
       {barcodeScanning && (
         <BarcodeScanner onDetected={handleBarcodeDetected} onCancel={() => setBarcodeScanning(false)} />

--- a/frontend/src/components/ReceiptTripDialog.test.tsx
+++ b/frontend/src/components/ReceiptTripDialog.test.tsx
@@ -70,11 +70,17 @@ function product(overrides: Partial<Product> = {}): Product {
   }
 }
 
-function renderDialog(overrides: Partial<ShoppingTrip> = {}) {
+function renderDialog(overrides: Partial<ShoppingTrip> = {}, products: Product[] = []) {
   const onClose = vi.fn()
   const onTripChanged = vi.fn()
   render(
-    <ReceiptTripDialog trip={trip(overrides)} categories={[]} onClose={onClose} onTripChanged={onTripChanged} />,
+    <ReceiptTripDialog
+      trip={trip(overrides)}
+      categories={[]}
+      products={products}
+      onClose={onClose}
+      onTripChanged={onTripChanged}
+    />,
   )
   return { onClose, onTripChanged }
 }
@@ -134,6 +140,40 @@ describe('ReceiptTripDialog review', () => {
 
     expect(screen.getByText('Nopal limpio')).toBeInTheDocument()
     expect(screen.queryByText('Jabón Grisi')).not.toBeInTheDocument()
+  })
+})
+
+describe('ReceiptTripDialog duplicate flagging', () => {
+  // Real, unmocked "now" — see ProductForm.test.tsx's own duplicate-check
+  // block for why this avoids fake timers entirely.
+  function createdToday(): string {
+    return new Date().toISOString()
+  }
+
+  it('starts a same-day match unticked and badged, regardless of is_food', () => {
+    const existing = product({ name: 'Nopal limpio', created_at: createdToday() })
+    renderDialog({ items: [tripItem({ name: 'Nopal limpio', is_food: true })] }, [existing])
+
+    expect(screen.getByRole('checkbox', { name: /nopal limpio/i })).not.toBeChecked()
+    expect(screen.getByText('Ya lo tienes hoy')).toBeInTheDocument()
+  })
+
+  it('still ticks a same-name item from a previous day', () => {
+    const existing = product({ name: 'Nopal limpio', created_at: '2026-08-20T00:00:00Z' })
+    renderDialog({ items: [tripItem({ name: 'Nopal limpio', is_food: true })] }, [existing])
+
+    expect(screen.getByRole('checkbox', { name: /nopal limpio/i })).toBeChecked()
+    expect(screen.queryByText('Ya lo tienes hoy')).not.toBeInTheDocument()
+  })
+
+  it('can still be re-ticked — the flag is a default, not a lock', () => {
+    const existing = product({ name: 'Nopal limpio', created_at: createdToday() })
+    renderDialog({ items: [tripItem({ name: 'Nopal limpio', is_food: true })] }, [existing])
+
+    const checkbox = screen.getByRole('checkbox', { name: /nopal limpio/i })
+    fireEvent.click(checkbox)
+
+    expect(checkbox).toBeChecked()
   })
 })
 

--- a/frontend/src/components/ReceiptTripDialog.tsx
+++ b/frontend/src/components/ReceiptTripDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 
 import { Modal } from '@/components/Modal'
 import { ProductForm } from '@/components/ProductForm'
+import { findDuplicateToday } from '@/duplicateCheck'
 import { quantityLabel } from '@/labels'
 import { toErrorMessage } from '@/services/api'
 import { dropTripItem, resolveTripItem } from '@/services/tripsService'
@@ -10,6 +11,10 @@ import type { Category, Product, ShoppingTrip, ShoppingTripItem } from '@/servic
 interface ReceiptTripDialogProps {
   trip: ShoppingTrip
   categories: Category[]
+  /** The active product list, threaded down to this dialog's own
+   *  ProductForm and used here too, to flag a checklist line that looks
+   *  like it was already added today — see #108. */
+  products: Product[]
   onClose: () => void
   /** Called whenever an item is dropped or resolved, so the active product
    *  list and the "current trip" banner stay in sync without a second
@@ -38,12 +43,19 @@ function itemState(item: ShoppingTripItem): ItemState {
  * because #83's own photo-of-the-label scan is exactly what a user reaches
  * for here, and that only makes sense pointed at a single product.
  */
-export function ReceiptTripDialog({ trip, categories, onClose, onTripChanged }: ReceiptTripDialogProps) {
+export function ReceiptTripDialog({ trip, categories, products, onClose, onTripChanged }: ReceiptTripDialogProps) {
   const [items, setItems] = useState(trip.items)
   // Only the pending items need a tick; a dropped or added item does not
-  // come back to this map even if a later action revisits it.
+  // come back to this map even if a later action revisits it. A line that
+  // looks like it was already added today starts unticked regardless of
+  // is_food — see #108: the receipt scan doubling as a final verification
+  // pass only works if the likely-duplicates are the ones pre-skipped.
   const [ticked, setTicked] = useState<Record<number, boolean>>(() =>
-    Object.fromEntries(trip.items.filter((item) => item.resolved_at === null).map((item) => [item.id, item.is_food])),
+    Object.fromEntries(
+      trip.items
+        .filter((item) => item.resolved_at === null)
+        .map((item) => [item.id, item.is_food && findDuplicateToday(products, item.name) === null]),
+    ),
   )
   const [queue, setQueue] = useState<ShoppingTripItem[] | null>(null)
   const [submitting, setSubmitting] = useState(false)
@@ -121,6 +133,7 @@ export function ReceiptTripDialog({ trip, categories, onClose, onTripChanged }: 
       <ProductForm
         key={current.id}
         categories={categories}
+        products={products}
         prefill={{ name: current.name, quantity: current.quantity }}
         title={remaining === 1 ? 'Agregar producto' : `Agregar producto (quedan ${remaining})`}
         onSaved={handleItemSaved}
@@ -166,19 +179,32 @@ export function ReceiptTripDialog({ trip, categories, onClose, onTripChanged }: 
         <p className="state state--empty">Ya no quedan productos pendientes en este recibo.</p>
       ) : (
         <ul className="trip-checklist">
-          {pending.map((item) => (
-            <li key={item.id} className="trip-checklist__row">
-              <label className="trip-checklist__label">
-                <input
-                  type="checkbox"
-                  checked={ticked[item.id] ?? item.is_food}
-                  onChange={() => toggle(item.id)}
-                />
-                <span className="trip-checklist__name">{item.name}</span>
-              </label>
-              <span className="trip-checklist__quantity">{quantityLabel(item.quantity, null)}</span>
-            </li>
-          ))}
+          {pending.map((item) => {
+            const duplicate = findDuplicateToday(products, item.name)
+            return (
+              <li key={item.id} className="trip-checklist__row">
+                <label className="trip-checklist__label">
+                  <input
+                    type="checkbox"
+                    checked={ticked[item.id] ?? item.is_food}
+                    onChange={() => toggle(item.id)}
+                  />
+                  <span className="trip-checklist__name">{item.name}</span>
+                  {/* A sibling of the (truncating) name, not nested inside
+                      it — flex-shrink: 0 keeps this visible even for a
+                      long name, the same way the quantity on the right
+                      already does. Un-ticking is only the default, not a
+                      decision made for the user — this is why, so a
+                      re-tick (a second purchase of the same thing, same
+                      day) is a choice made with the same information
+                      ProductForm's own check would otherwise surface only
+                      after opening the form. See #108. */}
+                  {duplicate && <span className="trip-checklist__badge">Ya lo tienes hoy</span>}
+                </label>
+                <span className="trip-checklist__quantity">{quantityLabel(item.quantity, null)}</span>
+              </li>
+            )
+          })}
         </ul>
       )}
 

--- a/frontend/src/duplicateCheck.test.ts
+++ b/frontend/src/duplicateCheck.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { findDuplicateToday } from '@/duplicateCheck'
+import type { Product } from '@/services/types'
+
+const NOW = new Date('2026-09-01T18:00:00Z')
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+
+afterEach(() => vi.useRealTimers())
+
+function product(overrides: Partial<Product> = {}): Product {
+  return {
+    id: 1,
+    name: 'Leche entera',
+    category_id: null,
+    quantity: '2.00',
+    unit: 'litros',
+    expires_at: '2026-09-10',
+    location: 'fridge',
+    notes: null,
+    category: null,
+    icon: '\u{1F95B}',
+    icon_source: 'lookup',
+    created_at: '2026-09-01T12:00:00Z',
+    updated_at: '2026-09-01T12:00:00Z',
+    consumed_at: null,
+    days_until_expiry: 9,
+    status: 'fresh',
+    ...overrides,
+  }
+}
+
+describe('findDuplicateToday', () => {
+  it('matches a product with the exact same name created today', () => {
+    const existing = product()
+
+    expect(findDuplicateToday([existing], 'Leche entera')).toBe(existing)
+  })
+
+  it('matches regardless of case or surrounding whitespace', () => {
+    const existing = product({ name: 'Leche Entera' })
+
+    expect(findDuplicateToday([existing], '  leche entera  ')).toBe(existing)
+  })
+
+  it('does not match a product created on a previous day', () => {
+    const existing = product({ created_at: '2026-08-31T12:00:00Z' })
+
+    expect(findDuplicateToday([existing], 'Leche entera')).toBeNull()
+  })
+
+  it('does not match a same-day product already marked consumed', () => {
+    const consumed = product({ consumed_at: '2026-09-01T15:00:00Z' })
+
+    expect(findDuplicateToday([consumed], 'Leche entera')).toBeNull()
+  })
+
+  it('does not match a different name', () => {
+    const existing = product({ name: 'Leche deslactosada' })
+
+    expect(findDuplicateToday([existing], 'Leche entera')).toBeNull()
+  })
+
+  it('returns null for a blank name', () => {
+    expect(findDuplicateToday([product()], '   ')).toBeNull()
+  })
+
+  it('returns null against an empty list', () => {
+    expect(findDuplicateToday([], 'Leche entera')).toBeNull()
+  })
+})

--- a/frontend/src/duplicateCheck.ts
+++ b/frontend/src/duplicateCheck.ts
@@ -1,0 +1,30 @@
+import type { Product } from '@/services/types'
+
+/**
+ * The active product this name most likely duplicates, if any — see #108.
+ *
+ * Consumed products are excluded explicitly, not just trusted to already
+ * be missing from whatever list is passed in: a same-day re-buy of
+ * something already finished is a fresh purchase, not a duplicate, and
+ * that has to hold regardless of whether the caller's list happens to
+ * include consumed rows.
+ *
+ * Matching is exact once normalized (trimmed, case-insensitive) rather
+ * than fuzzy: a fuzzy match trades false negatives for false positives,
+ * and a wrong warning erodes trust in this check faster than an occasional
+ * missed one does.
+ */
+export function findDuplicateToday(products: Product[], name: string): Product | null {
+  const normalized = name.trim().toLowerCase()
+  if (!normalized) return null
+
+  const today = new Date().toDateString()
+  return (
+    products.find(
+      (product) =>
+        product.consumed_at === null &&
+        product.name.trim().toLowerCase() === normalized &&
+        new Date(product.created_at).toDateString() === today,
+    ) ?? null
+  )
+}

--- a/frontend/src/pages/ProductList.tsx
+++ b/frontend/src/pages/ProductList.tsx
@@ -292,13 +292,14 @@ export function ProductList() {
       )}
 
       {dialog.kind === 'create' && (
-        <ProductForm categories={categories} onSaved={handleSaved} onCancel={close} />
+        <ProductForm categories={categories} products={products} onSaved={handleSaved} onCancel={close} />
       )}
 
       {dialog.kind === 'edit' && (
         <ProductForm
           product={dialog.product}
           categories={categories}
+          products={products}
           onSaved={handleSaved}
           onCancel={close}
         />
@@ -312,6 +313,7 @@ export function ProductList() {
         <ReceiptTripDialog
           trip={currentTrip}
           categories={categories}
+          products={products}
           onClose={close}
           onTripChanged={handleTripChanged}
         />


### PR DESCRIPTION
## Summary
- Adding a product whose name (trimmed, case-insensitive) matches an active product already created today now shows a three-way choice instead of saving right away: **Agregar de todas formas**, **Sumar a la cantidad existente** (bumps the existing product's quantity via the already-existing `PATCH /products/{id}/quantity`, no new endpoint), or **Omitir** (adds nothing — same as cancelling).
- Consumed products are excluded, so a same-day re-buy of something already finished is never flagged.
- The receipt checklist (#84) gets a lighter version of the same check: a pending line matching something already added today starts **un**ticked and shows a "Ya lo tienes hoy" badge — this is the actual use case that motivated the issue: scanning the ticket as a final verification pass, after adding most things during the trip by other means, so only the genuinely missing items are left ticked by default. Still fully overridable, and ProductForm's own check runs again if a flagged item gets ticked back on.
- No backend changes — the active product list is already loaded client-side (`useProducts`), and merging quantity reuses an existing endpoint.

Closes #108.

## Test plan
- [x] 293 frontend tests pass (`vitest`), `eslint` and `tsc -b` clean.
- [x] Live-verified against the real backend: re-adding "Nopal limpio" (case varied: "nopal LIMPIO") the same day it was created triggers the warning; "Sumar a la cantidad existente" bumped 2→3 litros on the existing row with no second row created; "Omitir" closed the dialog with nothing created; no console errors.
- [x] Unit tests for `findDuplicateToday` (name/case/whitespace matching, previous-day exclusion, consumed-product exclusion).
- [x] Integration tests for all three choices, the edit-mode bypass, and the warning clearing when the name is edited afterward.
- [x] Tests for the receipt checklist's pre-unticked/badged state and that it stays fully overridable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)