### PR TITLE
feat: bundle a least-privilege Postgres instead of a shared one (#56)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,18 +15,28 @@
 # =============================================================================
 
 # -----------------------------------------------------------------------------
-# Database — the shared apollo-server-db instance
+# Database — bundled, not shared
 # -----------------------------------------------------------------------------
-# CaduTrack owns the database named by DB_NAME and the schema inside it. The
-# database is created automatically on first start if it does not exist.
+# compose.yaml brings up its own PostgreSQL (cadutrack-db) for this service
+# alone — nothing else reads or writes it, and it reads or writes nothing
+# else's. See #56: an earlier version of this file pointed at a Postgres
+# instance shared with another service, which is a bad deployment story for
+# anyone self-hosting this on their own.
 #
-# DB_HOST defaults to the container name on apollo-server-network; leave it
-# unless PostgreSQL lives somewhere else.
-# DB_HOST=apollo-server-db
-# DB_PORT=5432
-DB_NAME=cadutrack
-DB_USER=postgres
+# DB_PASSWORD is the app's own role, created automatically the first time
+# cadutrack-db starts. Pick one without a single quote in it.
 DB_PASSWORD=your_secure_password
+#
+# DB_ADMIN_PASSWORD only bootstraps that first start — the role it creates
+# is never used again afterward, and is never handed to cadutrack-api. Still
+# worth a real value: a throwaway one is briefly a superuser on this
+# database's own Postgres.
+DB_ADMIN_PASSWORD=your_other_secure_password
+#
+# Optional: point at a different PostgreSQL entirely instead of the bundled
+# one — a shared instance, if you actually want one. Overrides DB_PASSWORD
+# above with no code or image change.
+# DATABASE_URL=postgresql+psycopg://user:password@host:5432/cadutrack
 
 # -----------------------------------------------------------------------------
 # Host

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,12 +12,14 @@
 # -----------------------------------------------------------------------------
 # Database
 # -----------------------------------------------------------------------------
-# CaduTrack connects to the shared apollo-server-db PostgreSQL instance.
+# Running outside Docker, so there is no bundled cadutrack-db to connect to
+# (see #56 and the root .env.example for that path) — point these at a real
+# PostgreSQL of your own, e.g. a local `postgres` install. Unlike the
+# bundled container, this app no longer creates the database itself: run
+# `createdb cadutrack` (or the equivalent CREATE DATABASE) first.
+#
 # It owns the database named by DB_NAME and the schema named by DB_SCHEMA
 # inside it — no other service writes there.
-#
-# When running the API in Docker on apollo-server-network, use the container
-# name as the host: DB_HOST=apollo-server-db
 DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=cadutrack
@@ -26,6 +28,11 @@ DB_PASSWORD=your_secure_password
 
 # Optional: schema owned by this service inside DB_NAME. Defaults to cadutrack.
 # DB_SCHEMA=cadutrack
+
+# Optional: a full connection string instead of the DB_* parts above —
+# takes priority over them when set. See the root .env.example's own
+# DATABASE_URL for the format.
+# DATABASE_URL=postgresql+psycopg://user:password@host:5432/cadutrack
 
 # Optional: seconds to wait for a database connection before failing.
 # Keep it short so /health fails fast. Defaults to 5.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -26,8 +26,15 @@ class Settings(BaseSettings):
     )
 
     # ── Database ─────────────────────────────────────────────────────────────
-    # Points at the shared apollo-server-db instance. CaduTrack owns the
-    # database named by db_name and the schema named by db_schema inside it.
+    # CaduTrack owns the database named by db_name and the schema named by
+    # db_schema inside it.
+    #
+    # Set directly by compose.yaml, pointed at the bundled Postgres it also
+    # brings up — see #56. Overriding DATABASE_URL in .env points the app at
+    # a different instance entirely (a shared one, say) with no code change;
+    # the db_* fields below are then only a convenience for running the API
+    # directly on your machine, without Docker.
+    database_url_override: str | None = Field(default=None, alias="DATABASE_URL")
     db_host: str = "localhost"
     db_port: int = 5432
     db_name: str = "cadutrack"
@@ -82,7 +89,22 @@ class Settings(BaseSettings):
 
     @property
     def database_url(self) -> str:
-        """SQLAlchemy connection URL built from the DB_* settings."""
+        """SQLAlchemy connection URL — DATABASE_URL verbatim when set,
+        otherwise built from the DB_* settings.
+
+        A bare "postgresql://" is rewritten to "postgresql+psycopg://":
+        that scheme is what every DATABASE_URL convention outside this repo
+        actually uses (Heroku-style envs, other tools' own docs), and
+        SQLAlchemy would otherwise reach for psycopg2, which this app does
+        not install — see #56, where DATABASE_URL first became something
+        someone other than this repo's own compose.yaml might set.
+        """
+        if self.database_url_override:
+            url = self.database_url_override
+            if url.startswith("postgresql://"):
+                url = "postgresql+psycopg://" + url.removeprefix("postgresql://")
+            return url
+
         auth = quote_plus(self.db_user)
         if self.db_password:
             auth = f"{auth}:{quote_plus(self.db_password)}"

--- a/backend/app/db/bootstrap.py
+++ b/backend/app/db/bootstrap.py
@@ -1,13 +1,13 @@
-"""Create the service's database on first start.
+"""Wait for the database to be reachable before the rest of the entrypoint runs.
 
-Alembic creates the schema; nothing creates the database that holds it. Without
-this the container crash-loops on a fresh server until someone runs
-CREATE DATABASE by hand.
-
-The maintenance database is only touched when it is actually needed: if the
-configured database already exists — the case on every start after the first —
-this connects to it, finds it healthy and returns. That keeps a least-privilege
-role viable, since the common path needs no rights beyond the app's own.
+Used to also create the configured database on a missing-database start.
+That stopped being this process's job with #56: the app's own credentials
+deliberately cannot CREATE DATABASE, so the database now has to already
+exist by the time this runs — created by the bundled compose Postgres's own
+first-boot init, or a manual step against a shared instance. This module's
+remaining job is waiting out a cold start and failing loudly, with an
+actionable message, if the database still is not there once the server
+itself answers.
 """
 
 import logging
@@ -17,7 +17,7 @@ import time
 from collections.abc import Iterator
 
 from sqlalchemy import create_engine, text
-from sqlalchemy.exc import OperationalError, ProgrammingError
+from sqlalchemy.exc import OperationalError
 
 from app.config import settings
 from app.logging_config import setup_logging
@@ -77,6 +77,20 @@ class DatabaseAuthenticationError(RuntimeError):
 
     def __init__(self, cause: OperationalError) -> None:
         super().__init__(f"Database rejected our credentials, check DB_USER/DB_PASSWORD: {cause}")
+
+
+class DatabaseMissingError(RuntimeError):
+    """The server answered, but the configured database itself is not there.
+
+    Raised instead of creating it — see #56: the app's own credentials
+    deliberately cannot CREATE DATABASE, so a missing database now always
+    means a deployment step did not run, not something this process can
+    still fix by itself.
+    """
+
+    def __init__(self, db_name: str) -> None:
+        super().__init__(f"Database {db_name!r} does not exist")
+        self.db_name = db_name
 
 
 # psycopg does not attach a SQLSTATE to failures raised during connection setup
@@ -163,45 +177,13 @@ def _database_exists_once_reachable() -> bool:
             time.sleep(delay)
 
 
-def _maintenance_url() -> str:
-    """The same connection, pointed at the default `postgres` database."""
-    return settings.database_url.rsplit("/", 1)[0] + "/postgres"
-
-
-def ensure_database_exists() -> None:
-    """Create the configured database if it is missing."""
+def verify_database_exists() -> None:
+    """Confirm the configured database is reachable, once the server itself
+    is — see #56 for why this only verifies rather than creating."""
     if _database_exists_once_reachable():
         logger.info("Database %r is present", settings.db_name)
         return
-
-    logger.info("Database %r not found, creating it", settings.db_name)
-    engine = create_engine(
-        _maintenance_url(),
-        # CREATE DATABASE cannot run inside a transaction.
-        isolation_level="AUTOCOMMIT",
-        connect_args={"connect_timeout": settings.db_connect_timeout},
-    )
-    try:
-        with engine.connect() as connection:
-            connection.execute(text(f'CREATE DATABASE "{settings.db_name}"'))
-        logger.info("Created database %r", settings.db_name)
-    except ProgrammingError as exc:
-        message = str(exc)
-        if "already exists" in message or "42P04" in message:
-            # Another container won the race. Nothing to do.
-            logger.info("Database %r was created concurrently", settings.db_name)
-            return
-        if "permission denied" in message or "42501" in message:
-            logger.error(
-                "User %r may not create databases. Create it manually and restart:\n"
-                '    CREATE DATABASE "%s";',
-                settings.db_user,
-                settings.db_name,
-            )
-            raise SystemExit(1) from exc
-        raise
-    finally:
-        engine.dispose()
+    raise DatabaseMissingError(settings.db_name)
 
 
 def main() -> None:
@@ -212,10 +194,11 @@ def main() -> None:
         level=settings.log_level,
     )
     try:
-        ensure_database_exists()
+        verify_database_exists()
     except DatabaseUnreachableError as exc:
-        # The one ERROR this module may emit: the wait was exhausted and the
-        # service genuinely cannot start. Both numbers are measured.
+        # The one ERROR this module may emit for a down server: the wait was
+        # exhausted and the service genuinely cannot start. Both numbers are
+        # measured.
         logger.error(
             "Database server unreachable after %d attempts over %.0fs: %s",
             exc.attempts,
@@ -228,11 +211,12 @@ def main() -> None:
         # reachable the whole time, so this must not be read as it being down.
         logger.error("%s", exc)
         sys.exit(1)
-    except OperationalError as exc:
-        # Only reachable from the CREATE DATABASE path, which runs after the
-        # server has already answered once. Worded so it cannot be read as the
-        # server being down, because it is not.
-        logger.error("Database bootstrap could not connect: %s", exc.__class__.__name__)
+    except DatabaseMissingError as exc:
+        logger.error(
+            "Database %r does not exist and this service cannot create it — "
+            "see the deployment docs for who creates it and when.",
+            exc.db_name,
+        )
         sys.exit(1)
 
 

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -17,10 +17,10 @@ engine = create_engine(
     future=True,
     connect_args={
         "connect_timeout": settings.db_connect_timeout,
-        # Pin the schema at connection setup rather than with a SET statement.
-        # apollo-server-db is shared, so we never rely on the default
-        # search_path — and a SET issued from a "connect" event runs inside a
-        # transaction that SQLAlchemy later rolls back, silently losing it.
+        # Pin the schema at connection setup rather than with a SET statement,
+        # so this never relies on the default search_path — and a SET issued
+        # from a "connect" event runs inside a transaction that SQLAlchemy
+        # later rolls back, silently losing it.
         "options": f"-c search_path={settings.db_schema},public",
     },
 )

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -3,18 +3,17 @@
 import logging
 
 import pytest
-from sqlalchemy import create_engine, text
 from sqlalchemy.exc import OperationalError
 
 from app.config import settings
 from app.db.bootstrap import (
     DatabaseAuthenticationError,
+    DatabaseMissingError,
     DatabaseUnreachableError,
-    _maintenance_url,
-    ensure_database_exists,
+    verify_database_exists,
 )
 
-THROWAWAY = "cadutrack_bootstrap_pytest"
+THROWAWAY = "cadutrack_bootstrap_pytest_does_not_exist"
 
 
 class FakeClock:
@@ -97,55 +96,23 @@ def test_a_generic_connection_failure_is_classified_as_neither(monkeypatch):
     assert bootstrap._is_authentication_failure(exc) is False
 
 
-def test_maintenance_url_keeps_the_credentials_and_swaps_the_database():
-    url = _maintenance_url()
-    assert url.endswith("/postgres")
-    assert url.rsplit("/", 1)[0] == settings.database_url.rsplit("/", 1)[0]
-
-
-@pytest.fixture
-def maintenance_engine():
-    engine = create_engine(_maintenance_url(), isolation_level="AUTOCOMMIT")
-    try:
-        with engine.connect() as connection:
-            connection.execute(text(f'DROP DATABASE IF EXISTS "{THROWAWAY}"'))
-        yield engine
-        with engine.connect() as connection:
-            connection.execute(text(f'DROP DATABASE IF EXISTS "{THROWAWAY}"'))
-    finally:
-        engine.dispose()
-
-
-def _exists(engine, name: str) -> bool:
-    with engine.connect() as connection:
-        return (
-            connection.execute(
-                text("SELECT 1 FROM pg_database WHERE datname = :name"), {"name": name}
-            ).scalar()
-            is not None
-        )
+@pytest.mark.integration
+def test_verify_is_a_no_op_when_the_database_already_exists():
+    """The real cadutrack_test database this whole suite runs against —
+    every start after the first takes this path, and it must not raise."""
+    verify_database_exists()
 
 
 @pytest.mark.integration
-def test_creates_the_database_when_missing(maintenance_engine, monkeypatch):
+def test_verify_raises_when_the_database_does_not_exist(monkeypatch):
+    """See #56: this process cannot create it any more, so a missing
+    database is reported instead of silently fixed."""
     monkeypatch.setattr(settings, "db_name", THROWAWAY)
-    assert not _exists(maintenance_engine, THROWAWAY)
 
-    ensure_database_exists()
+    with pytest.raises(DatabaseMissingError) as excinfo:
+        verify_database_exists()
 
-    assert _exists(maintenance_engine, THROWAWAY)
-
-
-@pytest.mark.integration
-def test_is_a_no_op_when_the_database_already_exists(maintenance_engine, monkeypatch):
-    """Every start after the first takes this path."""
-    monkeypatch.setattr(settings, "db_name", THROWAWAY)
-    ensure_database_exists()
-
-    # Must not raise, and must leave the database alone.
-    ensure_database_exists()
-
-    assert _exists(maintenance_engine, THROWAWAY)
+    assert excinfo.value.db_name == THROWAWAY
 
 
 def test_a_transient_outage_produces_warnings_and_no_error(monkeypatch, caplog):
@@ -324,3 +291,25 @@ def test_main_reports_bad_credentials_instead_of_a_server_that_never_came_up(mon
     assert excinfo.value.code == 1
     assert [record.levelname for record in caplog.records] == ["ERROR"]
     assert "DB_USER/DB_PASSWORD" in caplog.records[0].getMessage()
+
+
+def test_main_reports_a_missing_database_without_trying_to_create_it(monkeypatch, caplog):
+    """See #56: the old behavior created the database here; the new one
+    only reports that it is missing, on the very first attempt."""
+    import app.db.bootstrap as bootstrap
+
+    def missing_database() -> bool:
+        return False
+
+    monkeypatch.setattr(bootstrap, "_database_exists", missing_database)
+    monkeypatch.setattr(bootstrap, "time", FakeClock())
+    monkeypatch.setattr(bootstrap, "setup_logging", lambda **kwargs: None)
+    monkeypatch.setattr(settings, "db_name", THROWAWAY)
+
+    with caplog.at_level(logging.DEBUG, logger="app.db.bootstrap"):
+        with pytest.raises(SystemExit) as excinfo:
+            bootstrap.main()
+
+    assert excinfo.value.code == 1
+    assert [record.levelname for record in caplog.records] == ["ERROR"]
+    assert THROWAWAY in caplog.records[0].getMessage()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -31,6 +31,27 @@ def test_database_url_omits_empty_password():
     assert "postgresql+psycopg://julio@" in settings.database_url
 
 
+def test_database_url_env_var_overrides_the_parts():
+    """See #56: compose.yaml sets this to point at the bundled Postgres it
+    also brings up, and it is also how someone points at a different
+    instance entirely — a shared one, say — without a code change."""
+    settings = Settings(DATABASE_URL="postgresql+psycopg://someone:else@elsewhere:5432/db", db_user="julio")
+    assert settings.database_url == "postgresql+psycopg://someone:else@elsewhere:5432/db"
+
+
+def test_database_url_env_var_gets_the_psycopg_driver_even_when_bare():
+    """A bare "postgresql://" is what every DATABASE_URL convention outside
+    this repo actually uses — SQLAlchemy would otherwise reach for psycopg2,
+    which this app does not install."""
+    settings = Settings(DATABASE_URL="postgresql://someone:else@elsewhere:5432/db")
+    assert settings.database_url == "postgresql+psycopg://someone:else@elsewhere:5432/db"
+
+
+def test_database_url_env_var_already_naming_the_driver_is_left_alone():
+    settings = Settings(DATABASE_URL="postgresql+psycopg://someone:else@elsewhere:5432/db")
+    assert settings.database_url == "postgresql+psycopg://someone:else@elsewhere:5432/db"
+
+
 def test_cors_origins_are_split_and_trimmed():
     settings = Settings(cors_origins="http://localhost:5173, https://cadutrack.example.com ,")
     assert settings.cors_origin_list == ["http://localhost:5173", "https://cadutrack.example.com"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,7 +21,7 @@ services:
     depends_on:
       - cadutrack-api
     networks:
-      - apollo-server-network
+      - cadutrack-network
 
   cadutrack-api:
     # Pin to a specific version for reproducible deployments:
@@ -35,16 +35,61 @@ services:
     env_file:
       - .env
     environment:
-      # Reach the shared PostgreSQL by container name on apollo-server-network,
-      # so the host port mapping is irrelevant here.
-      DB_HOST: ${DB_HOST:-apollo-server-db}
-      DB_PORT: ${DB_PORT:-5432}
+      # The bundled cadutrack-db below, by default — override DATABASE_URL
+      # in .env to point at a different instance entirely (a shared one,
+      # say) with no code or image change. See #56.
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://cadutrack:${DB_PASSWORD}@cadutrack-db:5432/cadutrack}
+      # env_file above hands this container every variable in .env,
+      # DB_ADMIN_PASSWORD included — verified directly with `docker compose
+      # config`. That is the bootstrap superuser's own password, good for
+      # far more than this app needs; blanking it here is the difference
+      # between "unused" and "not present" if this container is ever
+      # compromised.
+      DB_ADMIN_PASSWORD: ""
     restart: unless-stopped
+    depends_on:
+      cadutrack-db:
+        condition: service_healthy
     # No log volume: the container writes only to stdout, which the host's log
     # pipeline collects. See https://server-documentation.apollox10.com
     networks:
-      - apollo-server-network
+      - cadutrack-network
+
+  cadutrack-db:
+    # CaduTrack's own Postgres — not shared with any other service. See #56:
+    # a shared instance was a detail of one homelab's deployment that had
+    # leaked into this application's design, and "you need a Postgres that
+    # also serves another of my services" is a bad self-hosting story.
+    image: postgres:16-alpine
+    container_name: cadutrack-db
+    environment:
+      # Bootstraps the cluster's own superuser, used once — only by
+      # db/init/01-create-app-role.sh, and only on a genuinely empty data
+      # directory — to create the actual, deliberately unprivileged role
+      # cadutrack-api connects as. Never passed to cadutrack-api itself.
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${DB_ADMIN_PASSWORD}
+      # Read by db/init/01-create-app-role.sh to set the app role's own
+      # password — the same value cadutrack-api's DATABASE_URL above
+      # connects with.
+      CADUTRACK_DB_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - cadutrack-db-data:/var/lib/postgresql/data
+      - ./db/init:/docker-entrypoint-initdb.d:ro
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - cadutrack-network
 
 networks:
-  apollo-server-network:
-    external: true
+  # Not external, and not apollo-server-network — see #56. This network
+  # exists only to let cadutrack-api reach its own bundled cadutrack-db;
+  # nothing outside this compose file needs to join it.
+  cadutrack-network:
+
+volumes:
+  cadutrack-db-data:

--- a/db/init/01-create-app-role.sh
+++ b/db/init/01-create-app-role.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Runs once, only when cadutrack-db's data directory is first initialized —
+# the official postgres image's own docker-entrypoint-initdb.d convention.
+# POSTGRES_USER is always a cluster superuser by construction (it is
+# initdb's own bootstrap role, and the first role in any Postgres cluster
+# cannot be anything else); this creates the actual, deliberately
+# unprivileged role cadutrack-api connects as instead — see #56.
+#
+# Owning the database from CREATE DATABASE onward means no later
+# ALTER ... OWNER TO is needed, and no window where the database exists
+# but is owned by the superuser.
+#
+# CADUTRACK_DB_PASSWORD is trusted as-is: it becomes a single-quoted SQL
+# literal below, so a password containing a single quote breaks this
+# script — pick one without.
+#
+# "Cannot read any other database" holds structurally, not through an
+# explicit REVOKE: this instance exists to hold exactly cadutrack and
+# nothing else, ever, so there is no other database for the role to read.
+# A REVOKE was tried and dropped — verified directly that Postgres's
+# per-database CONNECT ACL is not inherited from template1, so there is no
+# single statement here that would pre-authorize denying PUBLIC on some
+# future database that does not exist yet.
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres <<EOSQL
+CREATE ROLE cadutrack WITH LOGIN PASSWORD '${CADUTRACK_DB_PASSWORD}';
+CREATE DATABASE cadutrack OWNER cadutrack;
+EOSQL

--- a/readme.md
+++ b/readme.md
@@ -31,9 +31,8 @@ A food expiry tracker app to register purchased food items, their expiration dat
 
 ## Where this runs
 
-CaduTrack is deployed on a home server whose architecture — the shared PostgreSQL
-instance, the Docker network, how logs are collected, how services are exposed —
-is documented in one place:
+CaduTrack is deployed on a home server whose architecture — the Docker network,
+how logs are collected, how services are exposed — is documented in one place:
 
 **[server-documentation.apollox10.com](https://server-documentation.apollox10.com)**
 
@@ -50,7 +49,8 @@ weeks earlier, because the repo still described it.
 ```
 cadutrack/
 ├── frontend/       # React + Vite + TypeScript PWA
-└── backend/        # FastAPI + PostgreSQL + APScheduler
+├── backend/        # FastAPI + PostgreSQL + APScheduler
+└── db/init/        # First-boot scripts for the bundled cadutrack-db container
 ```
 
 ---
@@ -78,9 +78,10 @@ cadutrack/
 | created_at | timestamp                         |
 | updated_at | timestamp                         |
 
-> CaduTrack owns the database `cadutrack` and the schema `cadutrack` inside the
-> shared `apollo-server-db` PostgreSQL instance. It does not run its own database
-> server. Alembic's version table lives in `public`.
+> CaduTrack owns the database `cadutrack` and the schema `cadutrack` inside it,
+> on its own bundled PostgreSQL — `compose.yaml` brings up `cadutrack-db`
+> alongside the app, and nothing else reads or writes it. Alembic's version
+> table lives in `public`.
 
 ### Expiry Status Logic
 
@@ -134,7 +135,9 @@ Steps for each issue:
 
 ## Getting Started
 
-> Prerequisites: Python 3.11+, Node.js 20+, PostgreSQL 15+, Docker (optional)
+> Prerequisites: Python 3.11+, Node.js 20+, Docker (for `docker compose up`,
+> which brings its own PostgreSQL) — or PostgreSQL 15+ of your own for the
+> backend's no-Docker path
 
 ### Backend
 
@@ -222,19 +225,22 @@ There are two `.env.example` files, and they are not interchangeable:
 | [`.env.example`](.env.example) (repo root) | **Deploying** with `compose.yaml` — Dockge or `docker compose up -d` |
 | [`backend/.env.example`](backend/.env.example) | Running the API **directly on your machine**, without Docker |
 
-The root file omits `DB_HOST` on purpose: `compose.yaml` points the container at
-`apollo-server-db` over the shared network. The backend file sets it to
-`localhost`, which is correct on your machine and wrong inside a container — so
-do not copy that one to the root.
+The root file's database section looks different from the backend one on
+purpose — see #56. `compose.yaml` brings up its own PostgreSQL (`cadutrack-db`)
+and points the API at it directly; `DB_HOST`/`DB_PORT`/`DB_USER`/`DB_NAME` do
+not need setting there at all. The backend file's `DB_HOST=localhost` is
+correct on your own machine and wrong inside a container — so do not copy
+that one to the root.
 
 See [`backend/.env.example`](backend/.env.example) for the full documented list
 of settings; every one of them is valid in either file.
 
 | Variable              | Description                                        |
 |-----------------------|----------------------------------------------------|
-| `DB_HOST` / `DB_PORT` | Shared `apollo-server-db` host and port            |
-| `DB_NAME`             | Database owned by this service (`cadutrack`)       |
-| `DB_USER` / `DB_PASSWORD` | PostgreSQL credentials                         |
+| `DB_PASSWORD`         | The app's own database role, created on first start |
+| `DB_ADMIN_PASSWORD`   | Root file only — bootstraps `cadutrack-db`'s first start, never reaches the API container |
+| `DATABASE_URL`        | Overrides everything above to point at a different PostgreSQL entirely |
+| `DB_HOST` / `DB_PORT` / `DB_USER` / `DB_NAME` | Backend file only — the no-Docker path's own connection parts |
 | `DB_SCHEMA`           | Schema owned by this service (`cadutrack`)         |
 | `API_KEY`             | Protects mutating endpoints via `X-API-Key`        |
 | `TELEGRAM_BOT_TOKEN`  | Token from @BotFather                              |


### PR DESCRIPTION
## Summary

Implements the revised #56, per [ADR 012](https://server-documentation.apollox10.com/decisions/012-service-integration/) and the issue's own updated comment: each service now brings its own Postgres instead of a role reassigned in-place on the shared instance.

- `compose.yaml` brings up `cadutrack-db` (`postgres:16-alpine`) alongside the app.
- `db/init/01-create-app-role.sh` (runs once, on first boot only) creates a `cadutrack` role that **owns its database from `CREATE DATABASE` onward** — no `CREATEDB`, no `SUPERUSER`, and no later `ALTER ... OWNER TO` needed.
- `backend/app/config.py` now accepts `DATABASE_URL` directly (set by `compose.yaml` by default), falling back to the `DB_*` parts for the no-Docker dev path. Overriding `DATABASE_URL` in `.env` points at a different instance entirely — a shared one, if one is ever wanted again — with no code change.
- `backend/app/db/bootstrap.py` no longer creates the database itself — the app's own credentials deliberately cannot — so a missing database now fails loudly with an actionable message instead of being silently created.

## Verified directly, not assumed

The full Docker image builds hung on this environment's own Docker Desktop (a stuck credential-helper, unrelated to this change — `docker ps`/`docker run` against already-cached images worked fine throughout). Rather than skip verification, I tested the actual new logic directly against a real `postgres:16-alpine` container:

- The init script runs cleanly; the `cadutrack` role owns the `cadutrack` database.
- `CREATE DATABASE` as `cadutrack` fails with `permission denied to create database` — confirmed, not assumed.
- `alembic upgrade head` runs every migration cleanly under this least-privilege role.
- The real FastAPI app starts against it and answers `/health` and `/products`.

Two real issues turned up from this and got fixed before commit:
- `DB_ADMIN_PASSWORD` (the bootstrap superuser's own password) would have leaked into `cadutrack-api`'s environment through the blanket `env_file` — confirmed with `docker compose config`, fixed by blanking it explicitly for that service.
- An initial `REVOKE CONNECT ... ON DATABASE template1 FROM PUBLIC`, meant to stop `cadutrack` from reading some hypothetical other database on the instance, turned out to be a no-op — verified Postgres does not inherit per-database `CONNECT` ACLs from `template1` at all. That guarantee is now documented as structural (this instance is never meant to hold more than one database) rather than backed by a statement that doesn't do what it claims.

Backend: 297 tests pass, `ruff check` clean.

## What's NOT in this PR — the actual data migration

Moving the real production data is a manual step against live infrastructure this environment can't reach. Exact commands, run by hand, in order:

```bash
# 1. Dump the current data from the shared instance — from wherever already
#    reaches apollo-server-db (the host, or a container on
#    apollo-server-network). --no-owner: ownership on restore becomes
#    whoever restores it (the new cadutrack role), not the old superuser.
pg_dump -h apollo-server-db -U postgres -d cadutrack \
  --no-owner --format=custom --file=/tmp/cadutrack-backup.dump

# Sanity check before trusting it.
pg_restore --list /tmp/cadutrack-backup.dump | grep -c "TABLE DATA"

# 2. Deploy this PR, but bring up ONLY the new database first — not the API
#    yet, so alembic never touches it before the restore does.
docker compose pull
docker compose up -d cadutrack-db
docker compose ps cadutrack-db   # wait for "healthy"

# 3. Copy the dump in and restore it. Restoring AS the app's own new role is
#    what makes ownership correct by construction.
docker cp /tmp/cadutrack-backup.dump cadutrack-db:/tmp/cadutrack-backup.dump
docker compose exec -e PGPASSWORD=<DB_PASSWORD from .env> cadutrack-db \
  pg_restore -U cadutrack -d cadutrack --no-owner /tmp/cadutrack-backup.dump

# 4. Verify row counts match, table by table, before anything irreversible.
#    Old side:
psql -h apollo-server-db -U postgres -d cadutrack -c \
  "SELECT relname, n_live_tup FROM pg_stat_user_tables ORDER BY relname;"
#    New side — through the app's own role, which also proves its
#    privileges are enough to read its own tables:
docker compose exec -e PGPASSWORD=<DB_PASSWORD> cadutrack-db \
  psql -U cadutrack -d cadutrack -c \
  "SELECT relname, n_live_tup FROM pg_stat_user_tables ORDER BY relname;"
# These two outputs must match exactly.

# 5. Bring up the app against the new database, and confirm it's actually
#    healthy against it — not just that the numbers matched.
docker compose up -d cadutrack-api cadutrack
curl -s http://localhost:${FRONTEND_PORT:-9903}/api/health

# 6. Only once you're sure: retire the old database. Rename rather than
#    drop — keeps a full safety net for a few days at zero cost, and an
#    actual DROP is easy to do later once you're confident, hard to undo
#    right now if step 4 missed something.
psql -h apollo-server-db -U postgres -c \
  'ALTER DATABASE cadutrack RENAME TO cadutrack_old_backup;'
```

## Test plan
- [x] 297 backend tests pass, `ruff check` clean.
- [x] `docker compose config` confirms the compose file resolves correctly — `DATABASE_URL` interpolation, network scoping, and (after the fix) `DB_ADMIN_PASSWORD` no longer reaching `cadutrack-api`.
- [x] Live-verified against a real `postgres:16-alpine` container: role creation, ownership, the `CREATE DATABASE` denial, a full `alembic upgrade head`, and the running app answering real requests against it.
- [ ] Not verified: the full `docker compose up` of all three services together (blocked by this environment's own Docker Desktop credential-helper hang, unrelated to this change) — worth a real `docker compose up` on your end before applying the migration.
- [ ] The actual data migration — see the runbook above, run by hand.

Closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)