### PR TITLE
fix: publish cadutrack-db as its own image instead of bind-mounting init (#56)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,3 +124,63 @@ jobs:
           subject-name: ghcr.io/juliomoralesb/cadutrack-api
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+
+  # ─── Database image: postgres:16-alpine plus this service's own init
+  #     script, baked in rather than bind-mounted — see #56's own follow-up
+  #     and db/Dockerfile for why a bind mount does not survive a deploy
+  #     that only copies compose.yaml and .env. ───────────────────────────────
+  db:
+    name: Build and push database image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/juliomoralesb/cadutrack-db
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./db
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Separate scope from the other two jobs, or they evict each
+          # other's layers from the shared Actions cache.
+          cache-from: type=gha,scope=db
+          cache-to: type=gha,mode=max,scope=db
+
+      - name: Generate provenance attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/juliomoralesb/cadutrack-db
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/compose.yaml
+++ b/compose.yaml
@@ -60,7 +60,19 @@ services:
     # a shared instance was a detail of one homelab's deployment that had
     # leaked into this application's design, and "you need a Postgres that
     # also serves another of my services" is a bad self-hosting story.
-    image: postgres:16-alpine
+    #
+    # A published image, not plain postgres:16-alpine with db/init bind-
+    # mounted from the repo: a bind mount only works when the repo is
+    # checked out next to compose.yaml, and the documented deploy path is
+    # copying just compose.yaml and .env (Dockge does exactly this) — a
+    # bind mount to a file that was never copied silently mounts nothing,
+    # and the init script never runs. Learned this the hard way deploying
+    # #56 itself. See db/Dockerfile.
+    # Pin to a specific version for reproducible deployments:
+    # image: ghcr.io/juliomoralesb/cadutrack-db:0.1.0
+    image: ghcr.io/juliomoralesb/cadutrack-db:latest
+    # build:
+    #   context: ./db
     container_name: cadutrack-db
     environment:
       # Bootstraps the cluster's own superuser, used once — only by
@@ -75,7 +87,6 @@ services:
       CADUTRACK_DB_PASSWORD: ${DB_PASSWORD}
     volumes:
       - cadutrack-db-data:/var/lib/postgresql/data
-      - ./db/init:/docker-entrypoint-initdb.d:ro
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,9 @@
+FROM postgres:16-alpine
+
+# The official image runs anything in this directory once, only on a
+# genuinely empty data directory — see init/01-create-app-role.sh. Baked in
+# here rather than bind-mounted from the repo: a bind mount only works when
+# whoever deploys this has the repo checked out next to compose.yaml, and
+# the documented deploy path is copying just compose.yaml and .env — see
+# #56's own follow-up. A published image needs nothing else on disk.
+COPY init/ /docker-entrypoint-initdb.d/

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,9 @@ weeks earlier, because the repo still described it.
 cadutrack/
 ├── frontend/       # React + Vite + TypeScript PWA
 ├── backend/        # FastAPI + PostgreSQL + APScheduler
-└── db/init/        # First-boot scripts for the bundled cadutrack-db container
+└── db/             # cadutrack-db: postgres:16-alpine plus its own first-boot
+    ├── Dockerfile  #   init script, baked in — published, not bind-mounted,
+    └── init/       #   so a compose.yaml + .env deploy needs nothing else on disk
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fixes the exact failure Julio hit deploying #56 through Dockge: `cadutrack-db`'s `ignoring /docker-entrypoint-initdb.d/*` → the `cadutrack` role never gets created → `cadutrack-api` fails with `password authentication failed for user "cadutrack"` (which is also, ambiguously, Postgres's message for "this role does not exist" — the actual cause here).

**Root cause:** `./db/init:/docker-entrypoint-initdb.d:ro` is a bind mount. It only works when the repo is checked out next to `compose.yaml`. The documented deploy path — and what Dockge actually does — is copying just `compose.yaml` and `.env`. A bind mount to a path that was never copied silently mounts an empty directory; Postgres's own entrypoint skips an empty init directory without erroring.

**Fix:** `db/Dockerfile` bakes `db/init/01-create-app-role.sh` into a real image, built and published by the same release workflow as `cadutrack` and `cadutrack-api` — `ghcr.io/juliomoralesb/cadutrack-db`. No bind mount, nothing else needed on disk beyond `compose.yaml` + `.env`.

## An alternative considered and dropped

Before reaching for a third published image, I tried keeping the init script self-contained inside `compose.yaml` itself via Compose's `configs.content` (inline file content, no external file at all). Verified directly with `docker compose config` that this doesn't work safely: Compose's own variable interpolation rewrites bare `$VAR` references (no braces) inside a `content:` block before the container ever sees it — `"$POSTGRES_USER"` in the script would have silently become `""`. The `$$` escape convention that fixes this for `environment:` values also didn't round-trip the way I expected for `configs.content` in local testing. Backing off to a real Dockerfile avoids fighting Compose's interpolation semantics entirely — the exact same init script content that's already proven, just baked into an image instead of bind-mounted.

## Test plan
- [x] `docker compose config` confirms no more bind mount, and `image: ghcr.io/juliomoralesb/cadutrack-db:latest` resolves correctly.
- [x] Built the image locally from the already-cached `postgres:16-alpine` base (no registry contact needed).
- [x] Ran it with **zero** bind mounts or extra files on disk — confirmed the init script still runs (`CREATE ROLE`, `CREATE DATABASE`), the `cadutrack` role still can't `CREATE DATABASE`, and it still owns its own database — full parity with the original bind-mounted version.
- [x] `.github/workflows/release.yml`'s new `db` job YAML-validated (structurally mirrors the existing `frontend`/`backend` jobs).

Closes out the deployment issue from #56 — after this, `docker compose pull && docker compose up -d` from a fresh `compose.yaml` + `.env` should work with no manual file creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)