### PR TITLE
fix: offer the reauth link from the offline banner too (#112)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -578,6 +578,15 @@
   font-weight: 600;
 }
 
+.stale-banner__status {
+  margin: 0;
+}
+
+.stale-banner__hint {
+  margin: 0.3rem 0 0;
+  font-weight: 400;
+}
+
 /* History */
 
 .product-history {

--- a/frontend/src/components/StaleBanner.test.tsx
+++ b/frontend/src/components/StaleBanner.test.tsx
@@ -37,4 +37,17 @@ describe('StaleBanner', () => {
     expect(screen.getByRole('status')).toHaveTextContent('Sin conexión')
     expect(screen.getByRole('status')).toHaveTextContent('datos guardados')
   })
+
+  it('always offers the reauth link — see #112', () => {
+    // This banner is the only place a Cloudflare Access session expiring is
+    // ever visible: the service worker's own cache fallback (sw.ts) hides
+    // the failure from axios entirely, so ProductList's own error-triggered
+    // reauth link never gets a chance to render. Unconditional here for the
+    // same reason it is harmless in that other state: a genuinely offline
+    // device just gets a link that fails to load, no worse off than before.
+    render(<StaleBanner cachedAt={ago(60_000)} />)
+
+    const link = screen.getByRole('link', { name: 'reautentícate aquí' })
+    expect(link).toHaveAttribute('href', expect.stringContaining('/reauth'))
+  })
 })

--- a/frontend/src/components/StaleBanner.tsx
+++ b/frontend/src/components/StaleBanner.tsx
@@ -1,3 +1,5 @@
+import { apiUrl } from '@/services/api'
+
 interface StaleBannerProps {
   cachedAt: Date
 }
@@ -23,11 +25,27 @@ function ageLabel(cachedAt: Date): string {
  *
  * Without this the offline cache would be actively harmful: yesterday's list
  * looks exactly like today's, and you would act on it in front of the fridge.
+ *
+ * Always offers the same reauth link ProductList's own hard-error state
+ * does, for the same reason it is harmless there — see #112. This is the
+ * *only* place a Cloudflare Access session expiring is ever visible: the
+ * service worker's own NetworkFirst strategy (sw.ts) falls back to this
+ * cached copy the moment the live fetch fails for any reason, including
+ * Access blocking it, and it does that before axios — where the
+ * unreachable-then-offer-reauth logic actually lives — ever sees a
+ * failure. A user who already has a cached list, which is every returning
+ * user, would otherwise have no way to discover that logging back in is
+ * even an option: everything just quietly looks like ordinary offline use,
+ * forever.
  */
 export function StaleBanner({ cachedAt }: StaleBannerProps) {
   return (
-    <p className="stale-banner" role="status">
-      Sin conexión — mostrando datos guardados {ageLabel(cachedAt)}
-    </p>
+    <div className="stale-banner" role="status">
+      <p className="stale-banner__status">Sin conexión — mostrando datos guardados {ageLabel(cachedAt)}</p>
+      <p className="stale-banner__hint">
+        Si tu sesión expiró, <a href={apiUrl('/reauth')}>reautentícate aquí</a> — te regresa solo
+        cuando termines.
+      </p>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary

Julio's phone had a genuinely expired Cloudflare Access session — the first real chance to exercise this flow since it shipped in v0.17.0. It never showed the "reautentícate aquí" link. Root cause, found by actually reproducing it (DevTools Network tab on a cleared-cookies session, confirmed `/api/products` redirecting to `apollox10.cloudflareaccess.com/cdn-cgi/access/login/...`):

`sw.ts`'s `NetworkFirst` strategy for `GET /api/products` falls back to the last cached response the instant the live fetch fails for **any** reason — a genuinely offline device, or Access blocking a request because the session expired. That fallback happens at the service-worker layer, before axios (where `useProducts`'s `unreachable`-then-offer-reauth logic lives) ever sees a failure. From the page's perspective, the request just... succeeded, with slightly old data.

Any returning user already has a cached list by the time their session expires — so this isn't an edge case, it's what happens on every session expiry, and the reauth link built for exactly this case had no way to ever render.

## Fix

`StaleBanner` — the only place a session expiring like this is ever visible — now always offers the same reauth link `ProductList`'s hard-error state does, for the same reason it's harmless there: a genuinely offline device just gets a link that fails to load, no worse off than before.

## Test plan
- [x] 294 frontend tests pass, `eslint` and `tsc -b` clean.
- [x] New test asserting the link is always present in `StaleBanner`.
- [x] Existing `StaleBanner` tests (age labels, "not current" wording) still pass unchanged.

Closes #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)