### PR TITLE
feat: expose a summary endpoint for the dashboard (#93)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -52,6 +52,13 @@ DB_PASSWORD=your_secure_password
 # Leave empty to disable the check — only safe behind Cloudflare Access.
 # API_KEY=your_secret_api_key_here
 
+# GET /summary — the dashboard's own contract, see the readme. Unlike
+# API_KEY above, leaving this unset does NOT disable the check: the
+# endpoint refuses every request instead, since it sits on a published
+# port with nothing else in front of it. Set this to let
+# apollo-server-dashboard poll it; sent in the same X-API-Key header.
+# SUMMARY_API_KEY=your_other_secret_api_key_here
+
 # Optional: comma-separated browser origins allowed to call the API.
 # Defaults to the Vite dev server.
 # CORS_ORIGINS=http://localhost:5173,https://cadutrack.example.com

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -51,6 +51,13 @@ class Settings(BaseSettings):
     api_port: int = 8001
     # When set, mutating endpoints require this value in the X-API-Key header.
     api_key: str = ""
+    # A dedicated shared secret for the dashboard summary endpoint — see #93
+    # and ADR 012. Deliberately separate from api_key above (which nothing
+    # currently enforces — see #114): unset here does not mean "disabled"
+    # the way it does for api_key, since this endpoint sits on a published
+    # port with nothing else standing in front of it. See
+    # routers/summary.py's own require_summary_api_key.
+    summary_api_key: str = ""
     # Origins allowed to call the API from a browser (comma-separated in .env).
     cors_origins: str = "http://localhost:5173"
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.logging_config import setup_logging
-from app.routers import alerts, barcodes, categories, health, products, reauth, trips, vision
+from app.routers import alerts, barcodes, categories, health, products, reauth, summary, trips, vision
 from app.routers import settings as settings_router
 from app.scheduler import shutdown_scheduler, start_scheduler
 
@@ -50,5 +50,6 @@ app.include_router(vision.router)
 app.include_router(reauth.router)
 app.include_router(trips.router)
 app.include_router(barcodes.router)
+app.include_router(summary.router)
 
 logger.info("CaduTrack API started")

--- a/backend/app/routers/summary.py
+++ b/backend/app/routers/summary.py
@@ -1,0 +1,69 @@
+"""Dashboard summary endpoint — see #93 and ADR 012.
+
+A small, purpose-built, additive-only contract for the dashboard, not the
+internal API — see routers/products.py for that. Read-only and cheap: one
+query over just the two columns this needs, reusing app/expiry.py's own
+thresholds rather than re-deriving them, so this never quietly disagrees
+with what the product list itself shows.
+
+Failing loudly on a database problem, rather than returning a "0" that
+looks like good news, is not something this file does on purpose — it is
+what happens by default when nothing here catches the exception. See ADR
+012's own "never returns a partial answer as a complete one."
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.db.session import get_db
+from app.expiry import ExpiryStatus, days_until_expiry, expiry_status, today
+from app.models import Product
+from app.schemas.summary import SummaryNextProduct, SummaryResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["summary"])
+
+
+def require_summary_api_key(x_api_key: str | None = Header(default=None)) -> None:
+    """Reject anything without the dashboard's own shared secret.
+
+    Fails closed when SUMMARY_API_KEY is unset, unlike every other optional
+    setting in this app: an unset Telegram token or Ollama URL just turns a
+    feature off, but an unset secret here would mean every product's name
+    and expiry date sits open on the LAN, on a published port, with nothing
+    else in front of it — Cloudflare Access only covers the public tunnel
+    hostname. See ADR 012's own "authentication is required even on the LAN."
+    """
+    if not settings.summary_api_key or x_api_key != settings.summary_api_key:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or missing X-API-Key")
+
+
+@router.get("/summary", response_model=SummaryResponse, dependencies=[Depends(require_summary_api_key)])
+def get_summary(db: Session = Depends(get_db)) -> SummaryResponse:
+    """Exactly what one dashboard card needs — see the module docstring."""
+    rows = db.execute(
+        select(Product.name, Product.expires_at)
+        .where(Product.consumed_at.is_(None))
+        .order_by(Product.expires_at.asc())
+    ).all()
+
+    reference = today()
+    expired = 0
+    expiring_soon = 0
+    for _name, expires_at in rows:
+        bucket = expiry_status(days_until_expiry(expires_at, reference))
+        if bucket == ExpiryStatus.EXPIRED:
+            expired += 1
+        elif bucket == ExpiryStatus.EXPIRING_SOON:
+            expiring_soon += 1
+
+    # rows is already sorted soonest-first, so the first row — regardless of
+    # its own bucket — is the single most urgent thing to name.
+    next_product = SummaryNextProduct(name=rows[0].name, expires_at=rows[0].expires_at) if rows else None
+
+    return SummaryResponse(expired=expired, expiring_soon=expiring_soon, next=next_product)

--- a/backend/app/schemas/summary.py
+++ b/backend/app/schemas/summary.py
@@ -1,0 +1,26 @@
+"""Summary contract for the dashboard — see #93 and ADR 012.
+
+Small, additive-only, and explicitly for external consumption: this is not
+the internal API. A future field is fine to add; changing or removing one of
+these is a breaking change for a consumer this service does not know exists.
+"""
+
+from datetime import date
+
+from pydantic import BaseModel
+
+
+class SummaryNextProduct(BaseModel):
+    """The single most urgent active product, regardless of its own status —
+    still worth naming even when it is merely fresh and nothing is actually
+    expiring soon."""
+
+    name: str
+    expires_at: date
+
+
+class SummaryResponse(BaseModel):
+    expired: int
+    expiring_soon: int
+    # None only when there are no active products at all.
+    next: SummaryNextProduct | None

--- a/backend/tests/test_summary_api.py
+++ b/backend/tests/test_summary_api.py
@@ -1,0 +1,114 @@
+"""Dashboard summary endpoint tests — see #93 and ADR 012."""
+
+from datetime import date, timedelta
+
+import pytest
+
+from app.config import settings
+
+pytestmark = pytest.mark.integration
+
+_KEY = "test-summary-shared-secret"
+
+
+def _product(**overrides) -> dict:
+    payload = {
+        "name": "Leche entera",
+        "quantity": "2.00",
+        "unit": "litros",
+        "expires_at": str(date.today() + timedelta(days=5)),
+        "location": "fridge",
+        "notes": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.fixture
+def summary_key(monkeypatch):
+    """The endpoint fails closed without this — see require_summary_api_key."""
+    monkeypatch.setattr(settings, "summary_api_key", _KEY)
+    return _KEY
+
+
+def test_rejects_a_request_with_no_key(api_client, summary_key):
+    response = api_client.get("/summary")
+
+    assert response.status_code == 401
+
+
+def test_rejects_the_wrong_key(api_client, summary_key):
+    response = api_client.get("/summary", headers={"X-API-Key": "not-it"})
+
+    assert response.status_code == 401
+
+
+def test_fails_closed_when_no_key_is_configured_at_all(api_client):
+    """Unlike api_key, an unset summary_api_key must not mean "disabled" —
+    this endpoint sits on a published port with nothing else in front of
+    it. A correct-looking key must still be rejected."""
+    response = api_client.get("/summary", headers={"X-API-Key": "anything"})
+
+    assert response.status_code == 401
+
+
+def test_accepts_the_configured_key(api_client, summary_key):
+    response = api_client.get("/summary", headers={"X-API-Key": summary_key})
+
+    assert response.status_code == 200
+
+
+def test_counts_expired_and_expiring_soon_separately(api_client, summary_key):
+    today = date.today()
+    api_client.post("/products", json=_product(name="Ya caducado", expires_at=str(today - timedelta(days=1))))
+    api_client.post("/products", json=_product(name="Por caducar", expires_at=str(today + timedelta(days=3))))
+    api_client.post("/products", json=_product(name="Fresco", expires_at=str(today + timedelta(days=30))))
+
+    body = api_client.get("/summary", headers={"X-API-Key": summary_key}).json()
+
+    assert body["expired"] == 1
+    assert body["expiring_soon"] == 1
+
+
+def test_next_is_the_single_most_urgent_product_even_if_only_fresh(api_client, summary_key):
+    """No expired or expiring_soon product exists — next must still name
+    the soonest one, not report null just because nothing is urgent yet."""
+    today = date.today()
+    api_client.post("/products", json=_product(name="Más lejano", expires_at=str(today + timedelta(days=60))))
+    api_client.post("/products", json=_product(name="Más próximo", expires_at=str(today + timedelta(days=30))))
+
+    body = api_client.get("/summary", headers={"X-API-Key": summary_key}).json()
+
+    assert body["expired"] == 0
+    assert body["expiring_soon"] == 0
+    assert body["next"] == {"name": "Más próximo", "expires_at": str(today + timedelta(days=30))}
+
+
+def test_next_is_null_when_there_are_no_active_products(api_client, summary_key):
+    body = api_client.get("/summary", headers={"X-API-Key": summary_key}).json()
+
+    assert body == {"expired": 0, "expiring_soon": 0, "next": None}
+
+
+def test_a_consumed_product_is_excluded_entirely(api_client, summary_key):
+    today = date.today()
+    created = api_client.post(
+        "/products", json=_product(name="Consumido", expires_at=str(today - timedelta(days=1)))
+    ).json()
+    api_client.post(f"/products/{created['id']}/consume")
+
+    body = api_client.get("/summary", headers={"X-API-Key": summary_key}).json()
+
+    assert body == {"expired": 0, "expiring_soon": 0, "next": None}
+
+
+def test_the_response_shape_is_exactly_the_documented_contract(api_client, summary_key):
+    """A breaking change here must fail this test, not surprise a consumer
+    this service does not know exists — see ADR 012."""
+    today = date.today()
+    api_client.post("/products", json=_product(name="Nopalitos", expires_at=str(today)))
+
+    body = api_client.get("/summary", headers={"X-API-Key": summary_key}).json()
+
+    assert set(body.keys()) == {"expired", "expiring_soon", "next"}
+    assert set(body["next"].keys()) == {"name", "expires_at"}

--- a/readme.md
+++ b/readme.md
@@ -245,11 +245,43 @@ of settings; every one of them is valid in either file.
 | `DB_HOST` / `DB_PORT` / `DB_USER` / `DB_NAME` | Backend file only — the no-Docker path's own connection parts |
 | `DB_SCHEMA`           | Schema owned by this service (`cadutrack`)         |
 | `API_KEY`             | Protects mutating endpoints via `X-API-Key`        |
+| `SUMMARY_API_KEY`     | Required for `GET /summary` — see below. Unset means the endpoint refuses everything, not that it's open |
 | `TELEGRAM_BOT_TOKEN`  | Token from @BotFather                              |
 | `TELEGRAM_CHAT_ID`    | Target chat ID for alerts                          |
 | `ALERT_DAYS_AHEAD`    | Days before expiry to trigger alert                |
 | `TIMEZONE`            | IANA timezone for log timestamps and alert times   |
 | `LOG_FILE`            | Rotating JSON log path; empty means stdout only    |
+
+---
+
+## Dashboard summary contract
+
+`GET /summary` exists for `apollo-server-dashboard` — see
+[ADR 012](https://server-documentation.apollox10.com/decisions/012-service-integration/).
+It is a small, additive-only contract, deliberately not a reflection of the
+internal API: a field may be added, but an existing one changing shape or
+disappearing is a breaking change.
+
+Requires `X-API-Key: <SUMMARY_API_KEY>`. Missing, wrong, or unconfigured all
+get a `401` — there is no unauthenticated mode for this one.
+
+```json
+{
+  "expired": 2,
+  "expiring_soon": 3,
+  "next": { "name": "Nopalitos", "expires_at": "2026-09-01" }
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `expired` | Active products already past `expires_at` |
+| `expiring_soon` | Active products expiring within 7 days, today included |
+| `next` | The single most urgent active product — soonest `expires_at`, regardless of which bucket it falls in. `null` when nothing is active |
+
+A database problem is a `500`, never a `0` that reads as good news — see
+`app/expiry.py` for the shared thresholds this reuses rather than
+re-deriving.
 
 ---
 


### PR DESCRIPTION
## Summary

`GET /summary` — a small, additive-only contract for `apollo-server-dashboard`, per [ADR 012](https://server-documentation.apollox10.com/decisions/012-service-integration/):

```json
{
  "expired": 2,
  "expiring_soon": 3,
  "next": { "name": "Nopalitos", "expires_at": "2026-09-01" }
}
```

- `expired` / `expiring_soon` — counts over active products, reusing `app/expiry.py`'s own thresholds rather than re-deriving them, so this can never quietly disagree with what the product list itself shows.
- `next` — the single most urgent active product overall (soonest `expires_at`), regardless of which bucket it falls in — still worth naming even when nothing is actually expiring soon yet. `null` only when there are no active products at all.
- A database problem is a plain `500` — nothing here catches it into a `0` that would read as good news.

**Auth:** a dedicated `SUMMARY_API_KEY`, checked via `X-API-Key`, rather than the existing `api_key` setting. This endpoint sits on a published port with nothing else in front of it (Cloudflare Access only covers the public tunnel hostname), so it fails **closed** when unconfigured — an empty key means every request is rejected, not that the check is off.

### A finding along the way, filed separately

While scoping this I checked whether the existing `api_key` setting could just be reused. It can't be trusted yet: there is no code anywhere in the backend that actually enforces it, despite `.env.example` and `config.py`'s own comments claiming it protects mutating endpoints. Filed as #114 rather than folding a broader auth fix into this PR.

## Test plan
- [x] 306 backend tests pass (9 new), `ruff check` clean.
- [x] Live-verified against the real dev server: no key → 401, wrong key → 401, correct key → 200 with real product data; added a same-day-expired and a soon-to-expire product and confirmed the counts and `next` picked the actually-most-urgent one (the expired one, correctly ranked ahead of the merely-soon one).
- [x] Response shape documented in the readme as the actual contract, per ADR 012's own acceptance criteria.

Closes #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)