### PR TITLE
feat: enforce auth on mutating endpoints (#114)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -47,10 +47,26 @@ DB_PASSWORD=your_secure_password
 # API_HOST=0.0.0.0
 # API_PORT=8001
 
-# Optional: API key protecting mutating endpoints (POST / PUT / DELETE).
-# Sent by the client in the X-API-Key header.
-# Leave empty to disable the check — only safe behind Cloudflare Access.
+# Two independent, optional ways to protect mutating endpoints
+# (POST / PUT / PATCH / DELETE) — see #114. Neither set means every
+# mutation is allowed, matching the behavior this app has always had; set
+# either one (or both — either alone is enough) to actually turn the
+# check on. Reads are never affected by either.
+
+# API_KEY: sent by the client in the X-API-Key header.
 # API_KEY=your_secret_api_key_here
+
+# CF_ACCESS_TEAM_DOMAIN / CF_ACCESS_AUD: validates the
+# Cf-Access-Jwt-Assertion header Cloudflare Access already adds to a
+# request once someone has actually logged in — this is what protects
+# the app's own normal browser usage, with nothing to add to the
+# frontend. CF_ACCESS_TEAM_DOMAIN is just the subdomain ("apollox10" for
+# apollox10.cloudflareaccess.com), and CF_ACCESS_AUD is that specific
+# Access Application's own Audience tag, from its Overview page in the
+# Zero Trust dashboard. Both are required together — one without the
+# other leaves this mechanism off, same as neither being set.
+# CF_ACCESS_TEAM_DOMAIN=your-team
+# CF_ACCESS_AUD=your_access_application_aud_tag
 
 # GET /summary — the dashboard's own contract, see the readme. Unlike
 # API_KEY above, leaving this unset does NOT disable the check: the

--- a/backend/app/access_auth.py
+++ b/backend/app/access_auth.py
@@ -1,0 +1,101 @@
+"""Cloudflare Access + API key auth for mutating requests — see #114.
+
+Applied as middleware, not a per-route dependency, so a route added later
+does not silently need remembering to protect it — the exact gap that let
+api_key sit documented but unenforced for as long as it did.
+
+Two independent, optional mechanisms, either one sufficient:
+
+- A valid Cloudflare Access session — the app's own normal browser path,
+  already gated by a real login, verified here against Access's own
+  published signing keys rather than trusting the presence of a header a
+  direct LAN request could just as easily forge.
+- A shared X-API-Key, for anything that is not a browser.
+
+If neither api_key nor the Cloudflare Access settings are configured,
+every request is allowed — matching what api_key has always documented
+("leave empty to disable the check — only safe behind Cloudflare
+Access"), so shipping this cannot, by itself, lock a deployment out of
+its own product list. Once either mechanism is configured, a mutating
+request must satisfy at least one of the ones that actually are.
+
+GET/HEAD/OPTIONS are never checked — reads stay exactly as open as they
+are today, including /summary's own separate, dedicated key (see
+routers/summary.py) and Kuma's own read-only health monitoring.
+"""
+
+import logging
+
+import jwt
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from jwt import PyJWKClient
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+class RequireAuthOnMutations(BaseHTTPMiddleware):
+    """See the module docstring."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+        # Built lazily, and rebuilt if the team domain changes — mainly for
+        # tests, which monkeypatch settings mid-run; a real deployment only
+        # ever has one value for the life of the process.
+        self._jwks_client: PyJWKClient | None = None
+        self._jwks_client_domain: str | None = None
+
+    def _jwks(self) -> PyJWKClient:
+        if self._jwks_client is None or self._jwks_client_domain != settings.cf_access_team_domain:
+            self._jwks_client = PyJWKClient(
+                f"https://{settings.cf_access_team_domain}.cloudflareaccess.com/cdn-cgi/access/certs"
+            )
+            self._jwks_client_domain = settings.cf_access_team_domain
+        return self._jwks_client
+
+    def _valid_access_jwt(self, token: str | None) -> bool:
+        if not token:
+            return False
+        try:
+            signing_key = self._jwks().get_signing_key_from_jwt(token)
+            jwt.decode(token, signing_key.key, algorithms=["RS256"], audience=settings.cf_access_aud)
+            return True
+        except jwt.PyJWTError as exc:
+            # Never the exception text itself: a JWT's own claims can end up
+            # in messages some libraries raise, and this is exactly the kind
+            # of log line that ends up pasted somewhere. The class name is
+            # enough to tell "expired" apart from "wrong audience" apart
+            # from "bad signature".
+            logger.warning("Rejected Cloudflare Access JWT: %s", exc.__class__.__name__)
+            return False
+        except Exception:
+            # PyJWKClient's own network/parsing failures (Cloudflare
+            # unreachable, an unexpected JWKS shape) are not jwt.PyJWTError
+            # subclasses. A key-fetch failure must read as "not
+            # authenticated", not as a 500 that reveals nothing useful and
+            # hides an auth bypass behind an unrelated-looking crash.
+            logger.warning("Could not verify Cloudflare Access JWT", exc_info=True)
+            return False
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        if request.method in _SAFE_METHODS:
+            return await call_next(request)
+
+        key_configured = bool(settings.api_key)
+        access_configured = bool(settings.cf_access_team_domain and settings.cf_access_aud)
+        if not key_configured and not access_configured:
+            return await call_next(request)
+
+        has_key = key_configured and request.headers.get("x-api-key") == settings.api_key
+        has_access = access_configured and self._valid_access_jwt(request.headers.get("cf-access-jwt-assertion"))
+        if not has_key and not has_access:
+            return JSONResponse(status_code=401, content={"detail": "Not authenticated"})
+
+        return await call_next(request)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -49,14 +49,24 @@ class Settings(BaseSettings):
     api_host: str = "0.0.0.0"
     # Not 8000: free-games-notifier already publishes that port on the host.
     api_port: int = 8001
-    # When set, mutating endpoints require this value in the X-API-Key header.
+    # One of two ways to satisfy RequireAuthOnMutations (main.py) on a
+    # mutating request — the other is a valid Cloudflare Access session,
+    # see cf_access_team_domain/cf_access_aud below. Leaving all three of
+    # these unset disables the check entirely — see #114 — rather than
+    # locking a fresh, unconfigured deployment out of its own product list.
     api_key: str = ""
+    # Cloudflare Access team domain (just the subdomain — "apollox10" for
+    # apollox10.cloudflareaccess.com, not the full URL) and the target
+    # Access Application's own Audience (AUD) tag, from that application's
+    # Overview page in the Zero Trust dashboard. Both are required together
+    # to validate a request's Cf-Access-Jwt-Assertion header — see #114.
+    cf_access_team_domain: str = ""
+    cf_access_aud: str = ""
     # A dedicated shared secret for the dashboard summary endpoint — see #93
-    # and ADR 012. Deliberately separate from api_key above (which nothing
-    # currently enforces — see #114): unset here does not mean "disabled"
-    # the way it does for api_key, since this endpoint sits on a published
-    # port with nothing else standing in front of it. See
-    # routers/summary.py's own require_summary_api_key.
+    # and ADR 012. Deliberately separate from api_key above: unlike the
+    # mutation check, unset here does not mean "disabled" — this endpoint
+    # sits on a published port with nothing else standing in front of it.
+    # See routers/summary.py's own require_summary_api_key.
     summary_api_key: str = ""
     # Origins allowed to call the API from a browser (comma-separated in .env).
     cors_origins: str = "http://localhost:5173"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.access_auth import RequireAuthOnMutations
 from app.config import settings
 from app.logging_config import setup_logging
 from app.routers import alerts, barcodes, categories, health, products, reauth, summary, trips, vision
@@ -33,6 +34,14 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
 app = FastAPI(title="CaduTrack", version="0.1.0", lifespan=lifespan)
 
+app.add_middleware(RequireAuthOnMutations)
+# CORSMiddleware added after RequireAuthOnMutations so it wraps the outside
+# of it, not the inside — Starlette runs the *last*-added middleware first
+# on the way in. Reversed, a 401 this middleware returns would skip
+# CORSMiddleware entirely and reach the browser with no
+# Access-Control-Allow-Origin header, indistinguishable from a network
+# error rather than a readable 401. Verified directly against a real
+# TestClient request with an Origin header.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origin_list,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ pydantic-settings>=2.0,<3.0
 httpx>=0.27,<1.0
 python-json-logger>=3.3,<4.0
 pytz>=2025.1
+PyJWT[crypto]>=2.10,<3.0

--- a/backend/tests/test_access_auth.py
+++ b/backend/tests/test_access_auth.py
@@ -1,0 +1,216 @@
+"""Auth middleware tests for mutating requests — see #114.
+
+Exercises the real cryptographic verification path end to end: a genuine
+RSA keypair, a genuine signed JWT, and PyJWT's own signature/audience/
+expiry checks. The one thing that has to be mocked is Cloudflare's own
+JWKS endpoint — not something a test should call over the network — so
+PyJWKClient.fetch_data is patched to return a JWKS built from the same
+keypair the token was signed with.
+"""
+
+import json
+import time
+from datetime import date, timedelta
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt import PyJWKClient
+from jwt.algorithms import RSAAlgorithm
+
+from app.config import settings
+
+pytestmark = pytest.mark.integration
+
+_TEAM_DOMAIN = "test-team"
+_AUD = "test-audience"
+_KID = "test-kid"
+
+
+def _product(**overrides) -> dict:
+    payload = {
+        "name": "Leche entera",
+        "quantity": "2.00",
+        "unit": "litros",
+        "expires_at": str(date.today() + timedelta(days=5)),
+        "location": "fridge",
+        "notes": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private_key, private_key.public_key()
+
+
+@pytest.fixture
+def jwks(rsa_keypair, monkeypatch):
+    """Makes the real PyJWKClient network fetch return this keypair's own
+    public key, as Cloudflare's own endpoint would — see the module
+    docstring for why this is the only mocked piece."""
+    _private, public_key = rsa_keypair
+    jwk_json = json.loads(RSAAlgorithm.to_jwk(public_key))
+    jwk_json.update(kid=_KID, alg="RS256", use="sig")
+    monkeypatch.setattr(PyJWKClient, "fetch_data", lambda self: {"keys": [jwk_json]})
+
+
+def _sign(rsa_keypair, **claim_overrides) -> str:
+    private_key, _public = rsa_keypair
+    claims = {"aud": _AUD, "exp": int(time.time()) + 3600, "email": "julio@example.com"}
+    claims.update(claim_overrides)
+    return jwt.encode(claims, private_key, algorithm="RS256", headers={"kid": _KID})
+
+
+@pytest.fixture
+def access_configured(monkeypatch):
+    monkeypatch.setattr(settings, "cf_access_team_domain", _TEAM_DOMAIN)
+    monkeypatch.setattr(settings, "cf_access_aud", _AUD)
+
+
+@pytest.fixture
+def api_key_configured(monkeypatch):
+    monkeypatch.setattr(settings, "api_key", "test-shared-secret")
+
+
+def test_a_mutation_is_allowed_when_neither_mechanism_is_configured(api_client):
+    """Matches api_key's own documented default — see #114's own reasoning
+    for why this must not lock an unconfigured deployment out of itself."""
+    response = api_client.post("/products", json=_product())
+
+    assert response.status_code == 201
+
+
+def test_reads_are_never_checked_even_when_both_mechanisms_are_configured(
+    api_client, access_configured, api_key_configured
+):
+    response = api_client.get("/products")
+
+    assert response.status_code == 200
+
+
+class TestApiKey:
+    def test_rejects_a_mutation_with_no_key(self, api_client, api_key_configured):
+        response = api_client.post("/products", json=_product())
+
+        assert response.status_code == 401
+
+    def test_rejects_the_wrong_key(self, api_client, api_key_configured):
+        response = api_client.post("/products", json=_product(), headers={"X-API-Key": "not-it"})
+
+        assert response.status_code == 401
+
+    def test_accepts_the_configured_key(self, api_client, api_key_configured):
+        response = api_client.post(
+            "/products", json=_product(), headers={"X-API-Key": "test-shared-secret"}
+        )
+
+        assert response.status_code == 201
+
+    def test_a_401_still_carries_cors_headers(self, api_client, api_key_configured):
+        """Regression guard: this middleware has to run before
+        CORSMiddleware wraps it (see main.py's own comment on the add_
+        middleware ordering) — added the other way around once, verified
+        directly that a rejected request loses Access-Control-Allow-Origin
+        entirely, which a browser reports as an opaque network error
+        instead of a readable 401."""
+        # Must be an origin settings.cors_origin_list actually allows
+        # (the default, http://localhost:5173) — CORSMiddleware correctly
+        # omits the header for one that isn't, which would look identical
+        # to this exact regression and give a false pass.
+        response = api_client.post("/products", json=_product(), headers={"Origin": "http://localhost:5173"})
+
+        assert response.status_code == 401
+        assert response.headers.get("access-control-allow-origin") == "http://localhost:5173"
+
+
+class TestCloudflareAccess:
+    def test_rejects_a_mutation_with_no_jwt(self, api_client, access_configured):
+        response = api_client.post("/products", json=_product())
+
+        assert response.status_code == 401
+
+    def test_accepts_a_validly_signed_token(self, api_client, access_configured, jwks, rsa_keypair):
+        token = _sign(rsa_keypair)
+
+        response = api_client.post("/products", json=_product(), headers={"Cf-Access-Jwt-Assertion": token})
+
+        assert response.status_code == 201
+
+    def test_rejects_a_token_signed_by_a_different_key(self, api_client, access_configured, jwks):
+        other_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        forged = jwt.encode(
+            {"aud": _AUD, "exp": int(time.time()) + 3600}, other_key, algorithm="RS256", headers={"kid": _KID}
+        )
+
+        response = api_client.post("/products", json=_product(), headers={"Cf-Access-Jwt-Assertion": forged})
+
+        assert response.status_code == 401
+
+    def test_rejects_a_token_for_a_different_audience(self, api_client, access_configured, jwks, rsa_keypair):
+        """A JWT that is validly signed by Cloudflare, but issued for a
+        different Access Application, must not pass here — checking only
+        the signature and not the audience would let any of Julio's other
+        Access-protected apps into this one."""
+        token = _sign(rsa_keypair, aud="someone-elses-application")
+
+        response = api_client.post("/products", json=_product(), headers={"Cf-Access-Jwt-Assertion": token})
+
+        assert response.status_code == 401
+
+    def test_rejects_an_expired_token(self, api_client, access_configured, jwks, rsa_keypair):
+        token = _sign(rsa_keypair, exp=int(time.time()) - 60)
+
+        response = api_client.post("/products", json=_product(), headers={"Cf-Access-Jwt-Assertion": token})
+
+        assert response.status_code == 401
+
+    def test_rejects_garbage_that_is_not_a_jwt_at_all(self, api_client, access_configured):
+        response = api_client.post(
+            "/products", json=_product(), headers={"Cf-Access-Jwt-Assertion": "not-a-real-token"}
+        )
+
+        assert response.status_code == 401
+
+    def test_a_jwks_fetch_failure_is_rejected_not_a_500(self, api_client, access_configured, monkeypatch):
+        """Cloudflare being briefly unreachable must read as "not
+        authenticated", not as a crash that could hide an auth bypass
+        behind an unrelated-looking error."""
+        monkeypatch.setattr(
+            PyJWKClient, "fetch_data", lambda self: (_ for _ in ()).throw(ConnectionError("unreachable"))
+        )
+
+        response = api_client.post(
+            "/products", json=_product(), headers={"Cf-Access-Jwt-Assertion": "irrelevant.irrelevant.irrelevant"}
+        )
+
+        assert response.status_code == 401
+
+
+class TestEitherMechanism:
+    def test_the_api_key_still_works_when_access_is_also_configured(
+        self, api_client, access_configured, api_key_configured
+    ):
+        response = api_client.post(
+            "/products", json=_product(), headers={"X-API-Key": "test-shared-secret"}
+        )
+
+        assert response.status_code == 201
+
+    def test_a_valid_token_still_works_when_the_api_key_is_also_configured(
+        self, api_client, access_configured, api_key_configured, jwks, rsa_keypair
+    ):
+        token = _sign(rsa_keypair)
+
+        response = api_client.post("/products", json=_product(), headers={"Cf-Access-Jwt-Assertion": token})
+
+        assert response.status_code == 201
+
+    def test_rejects_when_both_are_configured_and_neither_is_satisfied(
+        self, api_client, access_configured, api_key_configured
+    ):
+        response = api_client.post("/products", json=_product())
+
+        assert response.status_code == 401

--- a/readme.md
+++ b/readme.md
@@ -244,7 +244,8 @@ of settings; every one of them is valid in either file.
 | `DATABASE_URL`        | Overrides everything above to point at a different PostgreSQL entirely |
 | `DB_HOST` / `DB_PORT` / `DB_USER` / `DB_NAME` | Backend file only — the no-Docker path's own connection parts |
 | `DB_SCHEMA`           | Schema owned by this service (`cadutrack`)         |
-| `API_KEY`             | Protects mutating endpoints via `X-API-Key`        |
+| `API_KEY`             | One of two ways to protect mutating endpoints via `X-API-Key` — see below. Unset (with `CF_ACCESS_*` also unset) means every mutation is allowed |
+| `CF_ACCESS_TEAM_DOMAIN` / `CF_ACCESS_AUD` | The other way — validates the app's own Cloudflare Access session, no frontend changes needed. Both required together |
 | `SUMMARY_API_KEY`     | Required for `GET /summary` — see below. Unset means the endpoint refuses everything, not that it's open |
 | `TELEGRAM_BOT_TOKEN`  | Token from @BotFather                              |
 | `TELEGRAM_CHAT_ID`    | Target chat ID for alerts                          |


### PR DESCRIPTION
## Summary

`api_key` was documented since early on as protecting `POST`/`PUT`/`DELETE`, but nothing in the codebase ever checked it — found while scoping #93. Anything on the LAN that reached the published port could read and write every product with zero authentication; Cloudflare Access only covers the public tunnel hostname, not direct LAN-IP access.

Two independent, optional mechanisms, either one sufficient:

- **`API_KEY`**, checked via `X-API-Key` — unchanged from what was always documented, now actually enforced.
- **`CF_ACCESS_TEAM_DOMAIN` + `CF_ACCESS_AUD`**, validating the `Cf-Access-Jwt-Assertion` header Cloudflare Access already adds once someone has logged in — real signature/audience/expiry verification against Cloudflare's own published keys, not just checking that the header exists (which a direct LAN request could forge just as easily). This is what protects the app's own normal browser usage, with **no frontend changes needed**.

Applied as middleware over every non-`GET`/`HEAD`/`OPTIONS` request, not a per-route dependency — the same gap that let `api_key` sit unenforced for this long is exactly what happens when protecting a route depends on remembering to decorate it. Reads, `/summary`'s own separate key, and Kuma's health monitoring are all unaffected.

**Fails open when neither mechanism is configured** — matching what `API_KEY`'s own docs have always said, and deliberately *not* what `SUMMARY_API_KEY` does: this retrofits auth onto routes already in everyday use, and shipping it fail-closed by default would lock a deployment out of creating or editing its own products the moment it upgrades, with no warning.

## A subtlety worth flagging

`CORSMiddleware` has to wrap the *outside* of this middleware, not the inside — added the other way around at first, and verified directly (a real `TestClient` request with an `Origin` header) that a 401 from this middleware then loses `Access-Control-Allow-Origin` entirely, which a browser reports as an opaque network error instead of a readable 401. Fixed by reordering the two `add_middleware` calls in `main.py`; kept as its own regression test.

## What you'll need to actually turn this on

Nothing changes for you today — deploying this with neither setting configured behaves exactly as it does now. When you're ready:
- Your Cloudflare Access team domain is `apollox10` (confirmed from your own DevTools capture earlier).
- You'll need the CaduTrack Access Application's own **Audience (AUD) tag** — Zero Trust dashboard → Access → Applications → the CaduTrack app → Overview page.

## Test plan
- [x] 322 backend tests pass (16 new — real RSA keypair, real signed JWTs, only the network fetch to Cloudflare's JWKS endpoint mocked), `ruff check` clean.
- [x] Live-verified against the real dev server: unconfigured → mutation allowed (fail-open confirmed); `API_KEY` set → no key rejected, wrong key rejected, correct key succeeds, reads still open throughout.
- [x] `.env.example` and the readme's variable table document both mechanisms and where to find the AUD tag.

Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)