### PR TITLE
fix: three mobile touch/theme issues found in a UI pass

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -93,7 +93,11 @@
 }
 
 .product-card__icon-button {
-  padding: 0;
+  /* Measured at 22x20px with padding: 0 — the smallest tappable control
+     in the app, on a row that's tapped standing at the fridge. The emoji
+     itself stays the same visual size (font-size unchanged); this just
+     grows the hit area around it. */
+  padding: 0.5rem;
   border: none;
   background: none;
   font-size: 1.25rem;
@@ -488,8 +492,12 @@
 }
 
 .filters__field select {
-  padding: 0.45rem 0.55rem;
-  font-size: 0.875rem;
+  /* 1rem, not the smaller size every other label-adjacent text in this
+     block uses: iOS Safari auto-zooms the whole page on focus of any
+     control whose computed font-size is under 16px, and these four
+     selects are the single most-tapped controls on the main screen. */
+  padding: 0.6rem 0.65rem;
+  font-size: 1rem;
 }
 
 .filters__summary {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -104,3 +104,24 @@ button:focus-visible {
 textarea {
   resize: vertical;
 }
+
+/* A plain <input type="file"> otherwise shows the browser's own native
+   button here — the one control in the app that ignores the theme
+   entirely, most visible on the label-photo field in ProductForm. The
+   surrounding box already picks up the themed border/background from the
+   input rule above; this covers the inner button the browser draws for
+   itself. */
+input[type='file']::file-selector-button {
+  font: inherit;
+  padding: 0.5rem 0.9rem;
+  margin-right: 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+}
+
+input[type='file']::file-selector-button:hover {
+  border-color: var(--accent);
+}


### PR DESCRIPTION
## Summary

Closes #117. A mobile-focused UI review across the main screens (list, filters, add/edit form, settings, history), tested at a 375px viewport with real data. Three concrete issues, all CSS-only:

- **Filter selects auto-zoom on focus.** Categoría/Ubicación/Estado/Ordenar por rendered at 14px — below the 16px threshold iOS Safari uses to decide whether to zoom the whole page in on focus. These are the highest-traffic controls on the main screen.
- **The icon-change button was the smallest tappable control in the app.** Measured at 22x20px (`padding: 0`, sized to the emoji glyph alone) vs. 36–44px for every other icon button. It's on the product name row, tapped often.
- **The label-photo file input ignored the theme entirely.** It rendered as the browser's raw native "Choose File" control — the only element in an otherwise fully dark-themed app that looked like this. Fixed via `::file-selector-button`, matching the app's existing button styling with the same tokens.

Nothing decided against on purpose was touched — e.g. the quantity stepper's `−` button is deliberately hidden (not disabled) at quantity 1, per #82's own reasoning, and that stays as-is.

## Test plan
- [x] `npm test` — 294/294 passing
- [x] Verified all three fixes visually in a real browser at 375x812 (iPhone-sized viewport) against a live backend with sample data
- [x] Re-checked the desktop breakpoint (≥30rem) — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)