### PR TITLE
fix: tell FastAPI its own root path so Swagger UI can load its spec

### DIFF
--- a/backend/app/__main__.py
+++ b/backend/app/__main__.py
@@ -23,6 +23,9 @@ def main() -> None:
         "app.main:app",
         host=settings.api_host,
         port=settings.api_port,
+        # See config.py's own comment: only set in the container, where
+        # nginx actually proxies under this prefix.
+        root_path=settings.api_root_path,
         # log_config=None leaves the loggers alone, so uvicorn's records
         # propagate to the root handler set up above.
         log_config=None,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -49,6 +49,16 @@ class Settings(BaseSettings):
     api_host: str = "0.0.0.0"
     # Not 8000: free-games-notifier already publishes that port on the host.
     api_port: int = 8001
+    # Set to "/api" by compose.yaml only — nginx proxies /api/* to this
+    # service, stripping the prefix before the request ever reaches here
+    # (see frontend/nginx.conf). Without telling FastAPI about that prefix,
+    # /api/docs loads fine but its Swagger UI then fetches /openapi.json
+    # (absolute, no prefix) for the actual spec — a path nginx does not
+    # proxy, so it falls through to the SPA's index.html, which Swagger UI
+    # then fails to parse as JSON. Left empty for a direct `uvicorn` run
+    # (see the readme's own Getting Started), where there is no proxy and
+    # no prefix to account for.
+    api_root_path: str = ""
     # One of two ways to satisfy RequireAuthOnMutations (main.py) on a
     # mutating request — the other is a valid Cloudflare Access session,
     # see cf_access_team_domain/cf_access_aud below. Leaving all three of

--- a/compose.yaml
+++ b/compose.yaml
@@ -46,6 +46,11 @@ services:
       # between "unused" and "not present" if this container is ever
       # compromised.
       DB_ADMIN_PASSWORD: ""
+      # nginx proxies /api/* here with the prefix stripped — see
+      # frontend/nginx.conf and app/config.py's own comment on
+      # api_root_path. Fixed, not a .env setting: it is a fact of this
+      # compose file's own nginx rule, not something a deployer chooses.
+      API_ROOT_PATH: /api
     restart: unless-stopped
     depends_on:
       cadutrack-db:


### PR DESCRIPTION
## Summary

Closes #119. Reported live: `https://cadutrack.server.apollox10.com/api/docs` loads Swagger UI's own page, but it fails with a parser error trying to render the spec.

**Root cause:** nginx proxies `/api/*` to the backend with the prefix stripped (`frontend/nginx.conf`), but FastAPI doesn't know it's mounted behind that prefix. The Swagger UI page it serves embeds `url: '/openapi.json'` — absolute, no `/api` prefix — a path nginx never proxies. That falls through to `location /` and returns the SPA's `index.html`, which Swagger UI then tries to parse as the spec and fails.

Confirmed directly against production:
- `GET /api/openapi.json` → `200 application/json`, the real 38KB spec
- `GET /openapi.json` (no prefix) → `200 text/html`, the SPA's `index.html`

**Fix:** uvicorn's own `root_path` — the standard mechanism FastAPI documents for exactly this ("behind a proxy"). Set only in the container via `API_ROOT_PATH: /api` in `compose.yaml`, not `.env`: it's a fixed fact of how this compose file's own nginx rule works, not a per-deployment choice. A direct local `uvicorn app.main:app` run (per the readme's own Getting Started) has no proxy in front of it, so the setting stays empty there and nothing changes for local dev.

## Test plan
- [ ] Not verified locally — the dev machine was under heavy load while investigating (a plain `import app.main` hung 45s+), so I could not get a clean local run before opening this. `root_path` is FastAPI's own documented, standard mechanism for this exact proxy-prefix scenario.
- [ ] Verify after deploy: `https://cadutrack.server.apollox10.com/api/docs` should render Swagger UI with the spec loaded, and `https://cadutrack.server.apollox10.com/api/openapi.json`'s own `servers` field should show the `/api` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)