### PR TITLE
fix: /summary's next lists every product tied for soonest, not just one

### DIFF
--- a/backend/app/routers/summary.py
+++ b/backend/app/routers/summary.py
@@ -62,8 +62,14 @@ def get_summary(db: Session = Depends(get_db)) -> SummaryResponse:
         elif bucket == ExpiryStatus.EXPIRING_SOON:
             expiring_soon += 1
 
-    # rows is already sorted soonest-first, so the first row — regardless of
-    # its own bucket — is the single most urgent thing to name.
-    next_product = SummaryNextProduct(name=rows[0].name, expires_at=rows[0].expires_at) if rows else None
+    # rows is already sorted soonest-first, so every row sharing the first
+    # row's own date — not just the first row itself — is equally the most
+    # urgent thing to name. A same-day tie is the common case, not an edge
+    # case: a shopping trip usually adds several products at once.
+    next_products = [
+        SummaryNextProduct(name=name, expires_at=expires_at)
+        for name, expires_at in rows
+        if expires_at == rows[0].expires_at
+    ]
 
-    return SummaryResponse(expired=expired, expiring_soon=expiring_soon, next=next_product)
+    return SummaryResponse(expired=expired, expiring_soon=expiring_soon, next=next_products)

--- a/backend/app/schemas/summary.py
+++ b/backend/app/schemas/summary.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 
 
 class SummaryNextProduct(BaseModel):
-    """The single most urgent active product, regardless of its own status —
+    """One of the most urgent active products, regardless of its own status —
     still worth naming even when it is merely fresh and nothing is actually
     expiring soon."""
 
@@ -22,5 +22,8 @@ class SummaryNextProduct(BaseModel):
 class SummaryResponse(BaseModel):
     expired: int
     expiring_soon: int
-    # None only when there are no active products at all.
-    next: SummaryNextProduct | None
+    # Every active product sharing the soonest expires_at — a same-day tie
+    # is common (a shopping trip usually adds several at once), and naming
+    # only one of them hid the rest from the one field meant to say what's
+    # most urgent. Empty only when there are no active products at all.
+    next: list[SummaryNextProduct]

--- a/backend/tests/test_summary_api.py
+++ b/backend/tests/test_summary_api.py
@@ -70,9 +70,9 @@ def test_counts_expired_and_expiring_soon_separately(api_client, summary_key):
     assert body["expiring_soon"] == 1
 
 
-def test_next_is_the_single_most_urgent_product_even_if_only_fresh(api_client, summary_key):
+def test_next_names_the_single_most_urgent_product_even_if_only_fresh(api_client, summary_key):
     """No expired or expiring_soon product exists — next must still name
-    the soonest one, not report null just because nothing is urgent yet."""
+    the soonest one, not report empty just because nothing is urgent yet."""
     today = date.today()
     api_client.post("/products", json=_product(name="Más lejano", expires_at=str(today + timedelta(days=60))))
     api_client.post("/products", json=_product(name="Más próximo", expires_at=str(today + timedelta(days=30))))
@@ -81,13 +81,32 @@ def test_next_is_the_single_most_urgent_product_even_if_only_fresh(api_client, s
 
     assert body["expired"] == 0
     assert body["expiring_soon"] == 0
-    assert body["next"] == {"name": "Más próximo", "expires_at": str(today + timedelta(days=30))}
+    assert body["next"] == [{"name": "Más próximo", "expires_at": str(today + timedelta(days=30))}]
 
 
-def test_next_is_null_when_there_are_no_active_products(api_client, summary_key):
+def test_next_lists_every_product_tied_for_soonest(api_client, summary_key):
+    """A same-day tie is the common case (a shopping trip usually adds
+    several products at once), not an edge case — every one of them
+    belongs in next, not just whichever the query happened to return
+    first."""
+    today = date.today()
+    tied_at = today + timedelta(days=3)
+    api_client.post("/products", json=_product(name="Yogurt", expires_at=str(tied_at)))
+    api_client.post("/products", json=_product(name="Leche", expires_at=str(tied_at)))
+    api_client.post("/products", json=_product(name="Más lejano", expires_at=str(today + timedelta(days=30))))
+
     body = api_client.get("/summary", headers={"X-API-Key": summary_key}).json()
 
-    assert body == {"expired": 0, "expiring_soon": 0, "next": None}
+    assert {(item["name"], item["expires_at"]) for item in body["next"]} == {
+        ("Yogurt", str(tied_at)),
+        ("Leche", str(tied_at)),
+    }
+
+
+def test_next_is_empty_when_there_are_no_active_products(api_client, summary_key):
+    body = api_client.get("/summary", headers={"X-API-Key": summary_key}).json()
+
+    assert body == {"expired": 0, "expiring_soon": 0, "next": []}
 
 
 def test_a_consumed_product_is_excluded_entirely(api_client, summary_key):
@@ -99,7 +118,7 @@ def test_a_consumed_product_is_excluded_entirely(api_client, summary_key):
 
     body = api_client.get("/summary", headers={"X-API-Key": summary_key}).json()
 
-    assert body == {"expired": 0, "expiring_soon": 0, "next": None}
+    assert body == {"expired": 0, "expiring_soon": 0, "next": []}
 
 
 def test_the_response_shape_is_exactly_the_documented_contract(api_client, summary_key):
@@ -111,4 +130,5 @@ def test_the_response_shape_is_exactly_the_documented_contract(api_client, summa
     body = api_client.get("/summary", headers={"X-API-Key": summary_key}).json()
 
     assert set(body.keys()) == {"expired", "expiring_soon", "next"}
-    assert set(body["next"].keys()) == {"name", "expires_at"}
+    assert isinstance(body["next"], list)
+    assert set(body["next"][0].keys()) == {"name", "expires_at"}

--- a/readme.md
+++ b/readme.md
@@ -270,7 +270,10 @@ get a `401` — there is no unauthenticated mode for this one.
 {
   "expired": 2,
   "expiring_soon": 3,
-  "next": { "name": "Nopalitos", "expires_at": "2026-09-01" }
+  "next": [
+    { "name": "Nopalitos", "expires_at": "2026-09-01" },
+    { "name": "Yogurt griego", "expires_at": "2026-09-01" }
+  ]
 }
 ```
 
@@ -278,7 +281,7 @@ get a `401` — there is no unauthenticated mode for this one.
 |---|---|
 | `expired` | Active products already past `expires_at` |
 | `expiring_soon` | Active products expiring within 7 days, today included |
-| `next` | The single most urgent active product — soonest `expires_at`, regardless of which bucket it falls in. `null` when nothing is active |
+| `next` | Every active product tied for soonest `expires_at`, regardless of which bucket that date falls in — a same-day tie is common, not an edge case. `[]` when nothing is active |
 
 A database problem is a `500`, never a `0` that reads as good news — see
 `app/expiry.py` for the shared thresholds this reuses rather than


### PR DESCRIPTION
## Summary

Closes #121. `GET /summary`'s `next` named only the single soonest-expiring product — when several products share the same soonest `expires_at`, the rest were silently dropped. That's the common case, not an edge case: a shopping trip usually adds several products at once.

- `next` is now `list[SummaryNextProduct]` instead of `SummaryNextProduct | None` — every product tied for the soonest `expires_at`, empty list when nothing is active.
- Breaking change to the response shape, per ADR 012's own definition of the contract — acceptable now since the dashboard hasn't built against this yet (its own agent is only just getting the spec).
- Updated the readme's own documented contract (example JSON + field table) to match.

## Test plan
- [x] Added `test_next_lists_every_product_tied_for_soonest`, covering the actual bug
- [x] Updated existing tests for the new list shape (was asserting a single object / `null`)
- [x] `pytest tests/test_summary_api.py` — 10/10 passing
- [x] Full backend suite — 323/323 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)