### PR TITLE
fix: barcode scanner focus and raw-value display

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -456,12 +456,41 @@
   gap: 0.875rem;
 }
 
+.barcode-scanner__viewport {
+  position: relative;
+}
+
 .barcode-scanner__video {
   width: 100%;
   aspect-ratio: 3 / 4;
   object-fit: cover;
   border-radius: 0.5rem;
   background: #000;
+  cursor: pointer;
+}
+
+.barcode-scanner__focus-ring {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 4.5rem;
+  height: 4.5rem;
+  margin: -2.25rem 0 0 -2.25rem;
+  border: 2px solid #fff;
+  border-radius: 0.5rem;
+  pointer-events: none;
+  animation: barcode-focus-ring 0.5s ease-out;
+}
+
+@keyframes barcode-focus-ring {
+  from {
+    opacity: 1;
+    transform: scale(1.3);
+  }
+  to {
+    opacity: 0;
+    transform: scale(1);
+  }
 }
 
 /* Filters */

--- a/frontend/src/components/BarcodeScanner.test.tsx
+++ b/frontend/src/components/BarcodeScanner.test.tsx
@@ -24,9 +24,12 @@ vi.mock('@zxing/library', () => ({
   DecodeHintType: { POSSIBLE_FORMATS: 'possible_formats' },
 }))
 
+const VIDEO_CONSTRAINTS = { video: { facingMode: 'environment', advanced: [{ focusMode: 'continuous' }] } }
+
 function fakeStream() {
   const stop = vi.fn()
-  return { stream: { getTracks: () => [{ stop }] } as unknown as MediaStream, stop }
+  const track = { stop }
+  return { stream: { getTracks: () => [track], getVideoTracks: () => [track] } as unknown as MediaStream, stop }
 }
 
 /** jsdom implements neither — both are exercised by the component whenever
@@ -64,7 +67,7 @@ describe('BarcodeScanner, native BarcodeDetector available', () => {
     render(<BarcodeScanner onDetected={onDetected} onCancel={vi.fn()} />)
 
     await waitFor(() => expect(onDetected).toHaveBeenCalledWith('5449000000996'))
-    expect(getUserMedia).toHaveBeenCalledWith({ video: { facingMode: 'environment' } })
+    expect(getUserMedia).toHaveBeenCalledWith(VIDEO_CONSTRAINTS)
     expect(stop).toHaveBeenCalled()
   })
 
@@ -88,6 +91,46 @@ describe('BarcodeScanner, native BarcodeDetector available', () => {
     render(<BarcodeScanner onDetected={vi.fn()} onCancel={vi.fn()} />)
 
     expect(await screen.findByRole('alert')).toHaveTextContent('No se pudo abrir la cámara.')
+  })
+
+  it('requests a refocus when the video is tapped and the track supports it', async () => {
+    const applyConstraints = vi.fn().mockResolvedValue(undefined)
+    const track = {
+      stop: vi.fn(),
+      getCapabilities: () => ({ focusMode: ['continuous', 'single-shot'] }),
+      applyConstraints,
+    }
+    const stream = { getTracks: () => [track], getVideoTracks: () => [track] } as unknown as MediaStream
+    const getUserMedia = vi.fn().mockResolvedValue(stream)
+    Object.defineProperty(navigator, 'mediaDevices', { value: { getUserMedia }, configurable: true })
+    window.BarcodeDetector = vi.fn(function FakeBarcodeDetector() {
+      return { detect: vi.fn().mockResolvedValue([]) }
+    }) as unknown as typeof BarcodeDetector
+
+    render(<BarcodeScanner onDetected={vi.fn()} onCancel={vi.fn()} />)
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByLabelText('Vista de la cámara'))
+
+    expect(applyConstraints).toHaveBeenCalledWith({ advanced: [{ focusMode: 'single-shot' }] })
+  })
+
+  it('does nothing on tap when the track has no manual focus mode to request', async () => {
+    const applyConstraints = vi.fn()
+    const track = { stop: vi.fn(), getCapabilities: () => ({ focusMode: ['continuous'] }), applyConstraints }
+    const stream = { getTracks: () => [track], getVideoTracks: () => [track] } as unknown as MediaStream
+    const getUserMedia = vi.fn().mockResolvedValue(stream)
+    Object.defineProperty(navigator, 'mediaDevices', { value: { getUserMedia }, configurable: true })
+    window.BarcodeDetector = vi.fn(function FakeBarcodeDetector() {
+      return { detect: vi.fn().mockResolvedValue([]) }
+    }) as unknown as typeof BarcodeDetector
+
+    render(<BarcodeScanner onDetected={vi.fn()} onCancel={vi.fn()} />)
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByLabelText('Vista de la cámara'))
+
+    expect(applyConstraints).not.toHaveBeenCalled()
   })
 
   it('notifies the caller on cancel, and releases the camera once unmounted', async () => {
@@ -129,11 +172,7 @@ describe('BarcodeScanner, no native BarcodeDetector', () => {
     render(<BarcodeScanner onDetected={onDetected} onCancel={vi.fn()} />)
 
     await waitFor(() => expect(onDetected).toHaveBeenCalledWith('2520157108483'))
-    expect(decodeFromConstraints).toHaveBeenCalledWith(
-      { video: { facingMode: 'environment' } },
-      expect.anything(),
-      expect.any(Function),
-    )
+    expect(decodeFromConstraints).toHaveBeenCalledWith(VIDEO_CONSTRAINTS, expect.anything(), expect.any(Function))
   })
 
   it('ignores a callback fired with no result — a normal miss on one frame', async () => {

--- a/frontend/src/components/BarcodeScanner.tsx
+++ b/frontend/src/components/BarcodeScanner.tsx
@@ -19,7 +19,37 @@ interface BarcodeScannerProps {
  */
 const FORMATS = ['code_128', 'ean_13', 'ean_8', 'upc_e']
 
-const VIDEO_CONSTRAINTS: MediaStreamConstraints = { video: { facingMode: 'environment' } }
+/**
+ * `focusMode` isn't in TS's own MediaTrackConstraintSet (it's a Chrome-only
+ * extension, mainly on Android), so it has to be declared here rather than
+ * just cast away.
+ */
+interface FocusConstraintSet extends MediaTrackConstraintSet {
+  focusMode?: 'continuous' | 'single-shot' | 'manual' | 'none'
+}
+
+const VIDEO_CONSTRAINTS: MediaStreamConstraints = {
+  video: {
+    facingMode: 'environment',
+    // Best-effort: ignored outright on browsers that don't support it
+    // (notably Safari) rather than throwing, since it's requested here as
+    // an `advanced` constraint, not a required one. Where it does work —
+    // mainly Chrome on Android, the common case for a phone-first app —
+    // this is the difference between the camera ever refocusing on a
+    // barcode held close and it staying fixed on whatever it first saw.
+    advanced: [{ focusMode: 'continuous' } as FocusConstraintSet],
+  },
+}
+
+/** Nudge the camera to refocus right now — see the video's own onClick.
+ *  Same best-effort story as the `advanced` constraint above: most tracks
+ *  either don't expose `focusMode` in their capabilities at all, or don't
+ *  support `single-shot`, and this is a silent no-op there. */
+function requestRefocus(track: MediaStreamTrack | null | undefined) {
+  const capabilities = track?.getCapabilities?.() as { focusMode?: string[] } | undefined
+  if (!capabilities?.focusMode?.includes('single-shot')) return
+  void track?.applyConstraints({ advanced: [{ focusMode: 'single-shot' } as FocusConstraintSet] })
+}
 
 /**
  * Live camera barcode scanner — see #30. Prefers the native BarcodeDetector
@@ -30,7 +60,25 @@ const VIDEO_CONSTRAINTS: MediaStreamConstraints = { video: { facingMode: 'enviro
  */
 export function BarcodeScanner({ onDetected, onCancel }: BarcodeScannerProps) {
   const videoRef = useRef<HTMLVideoElement>(null)
+  const trackRef = useRef<MediaStreamTrack | null>(null)
+  const focusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [focusing, setFocusing] = useState(false)
+
+  useEffect(() => () => {
+    if (focusTimeoutRef.current) clearTimeout(focusTimeoutRef.current)
+  }, [])
+
+  const handleTapToFocus = () => {
+    requestRefocus(trackRef.current)
+    // Shown regardless of whether the device actually supports refocusing —
+    // same reason a native camera app always shows its focus box on tap:
+    // the user needs to see the tap register even when the hardware can't
+    // act on it.
+    setFocusing(true)
+    if (focusTimeoutRef.current) clearTimeout(focusTimeoutRef.current)
+    focusTimeoutRef.current = setTimeout(() => setFocusing(false), 500)
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -53,6 +101,7 @@ export function BarcodeScanner({ onDetected, onCancel }: BarcodeScannerProps) {
         return
       }
       stopStream = () => stream.getTracks().forEach((track) => track.stop())
+      trackRef.current = stream.getVideoTracks()[0] ?? null
       videoRef.current.srcObject = stream
       await videoRef.current.play()
 
@@ -100,6 +149,7 @@ export function BarcodeScanner({ onDetected, onCancel }: BarcodeScannerProps) {
         return
       }
       stopStream = () => controls.stop()
+      trackRef.current = (videoRef.current.srcObject as MediaStream | null)?.getVideoTracks()[0] ?? null
     }
 
     void (async () => {
@@ -123,6 +173,7 @@ export function BarcodeScanner({ onDetected, onCancel }: BarcodeScannerProps) {
     return () => {
       cancelled = true
       stopStream?.()
+      trackRef.current = null
     }
   }, [onDetected])
 
@@ -135,8 +186,18 @@ export function BarcodeScanner({ onDetected, onCancel }: BarcodeScannerProps) {
           </p>
         ) : (
           <>
-            <video ref={videoRef} className="barcode-scanner__video" muted playsInline aria-label="Vista de la cámara" />
-            <p className="settings__hint">Apunta la cámara al código de barras.</p>
+            <div className="barcode-scanner__viewport">
+              <video
+                ref={videoRef}
+                className="barcode-scanner__video"
+                muted
+                playsInline
+                aria-label="Vista de la cámara"
+                onClick={handleTapToFocus}
+              />
+              {focusing && <span className="barcode-scanner__focus-ring" aria-hidden="true" />}
+            </div>
+            <p className="settings__hint">Apunta la cámara al código de barras. Toca la imagen para enfocar.</p>
           </>
         )}
         <div className="form__actions">

--- a/frontend/src/components/ProductForm.test.tsx
+++ b/frontend/src/components/ProductForm.test.tsx
@@ -316,7 +316,7 @@ describe('ProductForm barcode scan', () => {
     // A barcode never carries an expiry date — see #30 — so this is left
     // exactly as it started, for the user to fill in by hand.
     expect(screen.getByLabelText('Caduca el')).toHaveValue('')
-    expect(screen.getByText('Código escaneado. Revisa los datos antes de guardar.')).toBeInTheDocument()
+    expect(screen.getByText('Código 5449000000996 escaneado. Revisa los datos antes de guardar.')).toBeInTheDocument()
   })
 
   it('leaves a field the lookup could not resolve untouched', async () => {
@@ -337,7 +337,9 @@ describe('ProductForm barcode scan', () => {
     scanBarcode()
 
     expect(
-      await screen.findByText('Código leído, pero sin información conocida. Completa los campos manualmente.'),
+      await screen.findByText(
+        'Código 5449000000996 leído, pero sin información conocida. Completa los campos manualmente.',
+      ),
     ).toBeInTheDocument()
   })
 
@@ -347,7 +349,7 @@ describe('ProductForm barcode scan', () => {
 
     scanBarcode()
 
-    expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
+    expect(await screen.findByRole('alert')).toHaveTextContent('Código 5449000000996: Ocurrió un error inesperado.')
     fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Huevos' } })
     expect(screen.getByLabelText('Nombre')).toHaveValue('Huevos')
   })

--- a/frontend/src/components/ProductForm.tsx
+++ b/frontend/src/components/ProductForm.tsx
@@ -173,11 +173,14 @@ export function ProductForm({ product, prefill, categories, products, onSaved, o
         setPendingBarcode({ itemCode: result.item_code, icon: result.icon })
         setBarcodeHint(
           result.name || result.quantity
-            ? 'Código escaneado. Revisa los datos antes de guardar.'
-            : 'Código leído, pero sin información conocida. Completa los campos manualmente.',
+            ? `Código ${raw} escaneado. Revisa los datos antes de guardar.`
+            : `Código ${raw} leído, pero sin información conocida. Completa los campos manualmente.`,
         )
       } catch (caught) {
-        setBarcodeError(toErrorMessage(caught))
+        // Showing raw here too: a lookup failure and a misread look
+        // identical to the user otherwise, and this is the only place they
+        // can check the scanner actually saw the right digits.
+        setBarcodeError(`Código ${raw}: ${toErrorMessage(caught)}`)
       } finally {
         setBarcodeLookupPending(false)
       }


### PR DESCRIPTION
## Summary
Two friction points reported after scanning several products in a row (#124):

1. **No camera focus control.** `VIDEO_CONSTRAINTS` only set `facingMode` — no focus mode was ever requested, and there was no way to make the camera refocus. Now requests `focusMode: 'continuous'` as an `advanced` (best-effort, non-throwing) constraint — this matters most on Chrome/Android, the common case for this phone-first app — and tapping the video attempts a `single-shot` refocus on tracks that support it, with a brief visual focus-ring on every tap so the gesture always gives feedback even when the hardware can't act on it.
2. **A failed or mismatched read never showed what was detected.** `ProductForm`'s `handleBarcodeDetected` passed the decoded value straight into the lookup without ever displaying it — so a misread and a genuinely unknown code looked identical. The raw scanned value is now shown in all three outcomes: found, unknown, and lookup failure.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.app.json` — clean
- [x] Manual review of the full diff
- [x] Updated `BarcodeScanner.test.tsx` (new tap-to-refocus tests, updated constraint assertions) and `ProductForm.test.tsx` (assertions now include the raw code)
- [ ] `vitest` itself could not be run in this environment — every attempt (`--pool=threads` and `--pool=forks`, various worker counts, single file and full suite) hit `[vitest-pool-runner]: Timeout waiting for worker to respond` before a single test ran, a sandboxing limitation of this machine unrelated to the change (same as PR #120's Swagger fix, which hit an analogous local-verification limitation and was merged unverified without issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)