### PR TITLE
feat: remember receipt line names and link a line to an existing product

### DIFF
--- a/backend/alembic/versions/497560948ecc_add_receipt_name_lookup.py
+++ b/backend/alembic/versions/497560948ecc_add_receipt_name_lookup.py
@@ -1,0 +1,37 @@
+"""add receipt name lookup
+
+Revision ID: 497560948ecc
+Revises: 1c3f3dcfbd63
+Create Date: 2026-09-07 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '497560948ecc'
+down_revision: str | None = '1c3f3dcfbd63'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('receipt_name_lookup',
+    sa.Column('raw_text', sa.String(length=255), nullable=False),
+    sa.Column('product_name', sa.String(length=255), nullable=False),
+    sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.PrimaryKeyConstraint('raw_text', name=op.f('pk_receipt_name_lookup')),
+    schema='cadutrack'
+    )
+    op.add_column('shopping_trip_items', sa.Column('raw_name', sa.String(length=255), server_default='', nullable=False), schema='cadutrack')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('shopping_trip_items', 'raw_name', schema='cadutrack')
+    op.drop_table('receipt_name_lookup', schema='cadutrack')

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -7,6 +7,7 @@ Base.metadata before autogenerate runs.
 from app.models.barcode import BarcodeLookup
 from app.models.category import Category
 from app.models.product import IconSource, Location, Product
+from app.models.receipt_name import ReceiptNameLookup
 from app.models.setting import AlertSettings, IconNameCache, IconSettings
 from app.models.trip import ShoppingTrip, ShoppingTripItem
 
@@ -19,6 +20,7 @@ __all__ = [
     "IconSource",
     "Location",
     "Product",
+    "ReceiptNameLookup",
     "ShoppingTrip",
     "ShoppingTripItem",
 ]

--- a/backend/app/models/receipt_name.py
+++ b/backend/app/models/receipt_name.py
@@ -1,0 +1,33 @@
+"""Receipt line name lookup — see #126."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class ReceiptNameLookup(Base):
+    """What a raw, abbreviated receipt line was named last time it was
+    actually turned into (or matched to) a product.
+
+    Keyed on the raw printed text, not the model's own guess at what it
+    means: app/receipt_client.py's extraction step no longer expands or
+    corrects a name, precisely so this key stays the one stable thing
+    across two photos of the same store's receipt — the model's own
+    expansion can vary slightly between reads, but the printed abbreviation
+    for a given item does not. Same shape and reasoning as BarcodeLookup,
+    recorded only once a trip item actually resolves, never on read.
+    """
+
+    __tablename__ = "receipt_name_lookup"
+
+    raw_text: Mapped[str] = mapped_column(String(255), primary_key=True)
+    product_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    def __repr__(self) -> str:
+        return f"<ReceiptNameLookup {self.raw_text!r} -> {self.product_name!r}>"

--- a/backend/app/models/trip.py
+++ b/backend/app/models/trip.py
@@ -51,6 +51,11 @@ class ShoppingTripItem(Base):
         ForeignKey("shopping_trips.id", ondelete="CASCADE"), nullable=False, index=True
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
+    # The line's own printed text, before any expansion — the stable key
+    # app.receipt_name_cache remembers a correction against once this item
+    # resolves. `name` above is what the user actually sees and can correct;
+    # this never changes after creation. See #126.
+    raw_name: Mapped[str] = mapped_column(String(255), nullable=False, server_default="")
     quantity: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
     # The model's own guess at whether this line is worth tracking at all —
     # see #84: "non-food is a real fraction" of a typical receipt. Drives the

--- a/backend/app/receipt_client.py
+++ b/backend/app/receipt_client.py
@@ -1,16 +1,22 @@
-"""A local Ollama call for reading a shopping receipt photo — see #84.
+"""Local Ollama calls for reading a shopping receipt photo — see #84 and #126.
 
 Same never-raise contract as app/vision_client.py, for the same reason: an
 unconfigured URL, a refused connection, a timeout, an HTTP error, or a
-response that doesn't parse are all reported as None, and the caller falls
-back to manual entry rather than blocking on a model that might be down,
-slow, or mid-restart.
+response that doesn't parse are all reported as None (or, for expand_names,
+an empty dict), and the caller falls back to manual entry rather than
+blocking on a model that might be down, slow, or mid-restart.
 
 A separate module rather than folded into vision_client.py: the request
 shape (an array of lines, not one name/date/weight triple) and the failure
 semantics (a single bad line is dropped, not the whole extraction) are
 different enough that sharing one function would mean branching on which
 call this actually is throughout.
+
+Two functions, not one: extract_receipt reads the photo but deliberately
+never expands or corrects a name — see #126. Only expand_names, a second,
+text-only call, turns an unseen raw name into something natural, and the
+caller (routers/trips.py) only ever asks it about names
+app.receipt_name_cache doesn't already have an answer for.
 """
 
 import base64
@@ -60,13 +66,18 @@ _RESPONSE_SCHEMA = {
     "required": ["items", "stated_item_count"],
 }
 
+# OCR only — no expansion or correction. See #126: the raw printed text is
+# app.receipt_name_cache's own key, and that only stays a stable key across
+# two receipts from the same store if it is genuinely the same string both
+# times, rather than a fresh guess the model is free to phrase differently
+# on each read. expand_names below is what turns an unseen one of these into
+# a natural name, once, the first time it shows up.
 _PROMPT = (
     "Analiza esta foto de un recibo o ticket de compra de supermercado.\n\n"
     "Para cada línea de producto, extrae:\n"
-    "- name: el nombre del producto, expandido y corregido a partir del "
-    "texto impreso (los recibos abrevian y truncan nombres — por ejemplo "
-    "'CHAMP CREMINI' es 'Champiñones cremini', 'HEB MILANESA DE PULPA NEG' "
-    "es 'Milanesa de pulpa negra'). Usa el nombre más natural en español.\n"
+    "- name: el texto EXACTO tal como aparece impreso en el recibo para "
+    "ese producto — sin corregir, expandir ni traducir abreviaciones. "
+    "Cópialo tal cual está impreso, truncado o abreviado.\n"
     "- quantity: la cantidad comprada de ese producto (la columna de "
     "cantidad, no el precio).\n"
     "- is_food: true si es algo que se come o se bebe — esto incluye "
@@ -81,10 +92,57 @@ _PROMPT = (
     "aparece, usa null."
 )
 
+_EXPAND_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "items": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "index": {"type": "integer"},
+                    "name": {"type": "string"},
+                },
+                "required": ["index", "name"],
+            },
+        },
+    },
+    "required": ["items"],
+}
+
+# Text-only — no image, since the raw text is already known from
+# extract_receipt. Kept well under extract_receipt's own timeout: this has
+# no image tokens to read and only ever runs for names receipt_name_cache
+# hasn't already learned, so it is both a smaller prompt and, over time, an
+# increasingly rare call rather than one made on every receipt.
+EXPAND_TIMEOUT_SECONDS = 30.0
+
+
+def _expand_prompt(raw_names: list[str]) -> str:
+    # Numbered, matched back by index rather than by asking the model to
+    # echo the raw string — tried that first and it silently broke every
+    # match: against the real model (not a mock), a bullet-prefixed list
+    # came back with the "-" still attached to every "raw" field, which
+    # looked like every single name had failed to expand rather than an
+    # obviously wrong response. An index the model only has to copy a
+    # single integer for is far less for it to get wrong.
+    lines = "\n".join(f"{i + 1}. {raw}" for i, raw in enumerate(raw_names))
+    return (
+        "Estos son nombres de productos tal como aparecen impresos, "
+        "abreviados y truncados, en un recibo de supermercado mexicano:\n\n"
+        f"{lines}\n\n"
+        "Para cada uno, da su nombre más natural y corregido en español — "
+        "por ejemplo 'CHAMP CREMINI' es 'Champiñones cremini', 'HEB "
+        "MILANESA DE PULPA NEG' es 'Milanesa de pulpa negra'. Responde con "
+        "un item por cada número de la lista, en el mismo orden, con "
+        "'index' igual al número de esa línea (1, 2, 3…) y 'name' el "
+        "nombre corregido — no repitas el texto original."
+    )
+
 
 @dataclass
 class ReceiptItem:
-    name: str
+    raw_name: str
     quantity: Decimal
     is_food: bool
 
@@ -123,7 +181,7 @@ def _parse_item(raw: object) -> ReceiptItem | None:
     if not isinstance(is_food, bool):
         return None
 
-    return ReceiptItem(name=name, quantity=quantity, is_food=is_food)
+    return ReceiptItem(raw_name=name, quantity=quantity, is_food=is_food)
 
 
 def _parse_stated_item_count(value: object) -> int | None:
@@ -194,3 +252,76 @@ def extract_receipt(image_bytes: bytes) -> ReceiptExtraction | None:
         items=items,
         stated_item_count=_parse_stated_item_count(raw.get("stated_item_count")),
     )
+
+
+def expand_names(raw_names: list[str]) -> dict[str, str]:
+    """A natural Spanish name for each of `raw_names`, keyed by the exact
+    string passed in — best-effort, never raising.
+
+    Text-only, unlike extract_receipt: the raw text is already known, so
+    this never re-sends the photo. Call it only with names
+    app.receipt_name_cache doesn't already have an answer for — that is
+    what keeps a repeat purchase to one model call, not two.
+
+    A name the model dropped, or any failure at all (unconfigured, network,
+    unparsable), is simply absent from the result — not an exception and
+    not a null placeholder. The caller falls back to the raw text itself
+    rather than letting a naming nicety block a trip that already has
+    usable items and quantities, the same judgement extract_receipt makes
+    for a single bad line.
+    """
+    if not raw_names or not settings.ollama_url:
+        return {}
+
+    try:
+        response = httpx.post(
+            f"{settings.ollama_url}/api/generate",
+            json={
+                "model": settings.ollama_model,
+                "prompt": _expand_prompt(raw_names),
+                "stream": False,
+                "think": False,
+                "format": _EXPAND_RESPONSE_SCHEMA,
+                "options": {"temperature": 0},
+            },
+            timeout=EXPAND_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        logger.warning(
+            "Ollama name expansion returned %s: %r",
+            exc.response.status_code,
+            exc.response.text[:500],
+        )
+        return {}
+    except httpx.HTTPError as exc:
+        logger.warning("Ollama name expansion failed: %s", exc.__class__.__name__)
+        return {}
+
+    try:
+        raw = json.loads(response.json()["response"])
+    except (KeyError, TypeError, ValueError) as exc:
+        logger.warning(
+            "Ollama returned an unparsable name-expansion response (%s): %r",
+            exc.__class__.__name__,
+            response.text[:200],
+        )
+        return {}
+
+    raw_items = raw.get("items")
+    if not isinstance(raw_items, list):
+        return {}
+
+    expanded: dict[str, str] = {}
+    for entry in raw_items:
+        if not isinstance(entry, dict):
+            continue
+        index = entry.get("index")
+        name = entry.get("name")
+        name = name.strip() if isinstance(name, str) else ""
+        # 1-based, matching _expand_prompt's own numbering; bool is an int
+        # subclass in Python, so it is excluded explicitly the same way
+        # _parse_item excludes it from quantity.
+        if isinstance(index, int) and not isinstance(index, bool) and name and 1 <= index <= len(raw_names):
+            expanded[raw_names[index - 1]] = name
+    return expanded

--- a/backend/app/receipt_name_cache.py
+++ b/backend/app/receipt_name_cache.py
@@ -1,0 +1,41 @@
+"""Caches the accepted product name for a raw receipt line — see #126.
+
+A cache hit never reaches the model — this exists purely to stop the same
+raw ticket text ever being (mis)read twice, and to make a correction stick
+permanently instead of being asked again on the next receipt.
+"""
+
+import logging
+
+from sqlalchemy.orm import Session
+
+from app.icons import normalize as normalize_name
+from app.models import ReceiptNameLookup
+
+logger = logging.getLogger(__name__)
+
+
+def _key(raw_text: str) -> str:
+    """Collapse incidental OCR noise (repeated spaces, case, accents) so the
+    same physical item still keys the same row even if a later read of the
+    same receipt varies slightly in spacing or capitalization."""
+    return normalize_name(" ".join(raw_text.split()))
+
+
+def get(session: Session, raw_text: str) -> str | None:
+    """A previously accepted name for this raw text, or None on a miss."""
+    cached = session.get(ReceiptNameLookup, _key(raw_text))
+    return cached.product_name if cached is not None else None
+
+
+def remember(session: Session, raw_text: str, product_name: str) -> None:
+    """Record the name a trip item actually resolved to, so this raw text
+    never has to be read or guessed again.
+
+    Overwrites rather than skipping on a duplicate key, same reasoning as
+    icon_cache.remember: a later, corrected resolve for the same raw text
+    should simply win over an earlier guess.
+    """
+    session.merge(ReceiptNameLookup(raw_text=_key(raw_text), product_name=product_name))
+    session.commit()
+    logger.info("Cached receipt name for %r: %s", raw_text, product_name)

--- a/backend/app/routers/trips.py
+++ b/backend/app/routers/trips.py
@@ -6,9 +6,10 @@ from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from sqlalchemy import exists, func, select
 from sqlalchemy.orm import Session, selectinload
 
+from app import receipt_name_cache
 from app.db.session import get_db
 from app.models import Product, ShoppingTrip, ShoppingTripItem
-from app.receipt_client import extract_receipt
+from app.receipt_client import expand_names, extract_receipt
 from app.schemas.trip import (
     ShoppingTripItemRead,
     ShoppingTripItemResolve,
@@ -104,9 +105,33 @@ async def create_trip_from_receipt(
             detail="No se pudo leer el recibo. Agrega los productos manualmente.",
         )
 
+    # A name for every line, cache first — see #126. Only a raw text
+    # receipt_name_cache has never seen before ever reaches expand_names,
+    # so a repeat purchase costs one model call (the OCR pass above), not
+    # two, and a name the user already corrected once is never re-guessed.
+    resolved_names: dict[str, str] = {}
+    unseen_raw_names: set[str] = set()
+    for item in extraction.items:
+        if item.raw_name in resolved_names or item.raw_name in unseen_raw_names:
+            continue
+        cached_name = receipt_name_cache.get(db, item.raw_name)
+        if cached_name is not None:
+            resolved_names[item.raw_name] = cached_name
+        else:
+            unseen_raw_names.add(item.raw_name)
+
+    if unseen_raw_names:
+        resolved_names.update(expand_names(list(unseen_raw_names)))
+
     trip = ShoppingTrip(stated_item_count=extraction.stated_item_count)
     for item in extraction.items:
-        trip.items.append(ShoppingTripItem(name=item.name, quantity=item.quantity, is_food=item.is_food))
+        # A name expand_names couldn't produce (unconfigured, a failure, or
+        # simply dropped) falls back to the raw text itself — still usable,
+        # just uncorrected, same as before #126.
+        name = resolved_names.get(item.raw_name, item.raw_name)
+        trip.items.append(
+            ShoppingTripItem(name=name, raw_name=item.raw_name, quantity=item.quantity, is_food=item.is_food)
+        )
 
     db.add(trip)
     db.commit()
@@ -151,12 +176,15 @@ def drop_trip_item(trip_id: int, item_id: int, db: Session = Depends(get_db)) ->
 def resolve_trip_item(
     trip_id: int, item_id: int, payload: ShoppingTripItemResolve, db: Session = Depends(get_db)
 ) -> ShoppingTripItem:
-    """Link a line to the product it became, once the client has already
-    created that product through the normal POST /products."""
+    """Link a line to the product it became — either one just created
+    through the normal POST /products, or an existing one the user is
+    saying this line is really the same thing as (see #126: there is
+    nothing here that requires the product to be new)."""
     item = _get_item_or_404(db, trip_id, item_id)
     _require_unresolved(item)
 
-    if db.get(Product, payload.product_id) is None:
+    product = db.get(Product, payload.product_id)
+    if product is None:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"Product {payload.product_id} does not exist",
@@ -166,5 +194,11 @@ def resolve_trip_item(
     item.product_id = payload.product_id
     db.commit()
     db.refresh(item)
+
+    # Whatever name the user actually settled on for this raw text — via
+    # the product just created, or the existing one just linked — so the
+    # next receipt with this same line never has to ask again. See #126.
+    receipt_name_cache.remember(db, item.raw_name, product.name)
+
     logger.info("Resolved trip item %s (%s) into product %s", item.id, item.name, payload.product_id)
     return item

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -50,7 +50,7 @@ def db_session():
     session.execute(
         text(
             "TRUNCATE products, categories, alert_settings, icon_settings, icon_name_cache, "
-            "shopping_trips, shopping_trip_items, barcode_lookups "
+            "shopping_trips, shopping_trip_items, barcode_lookups, receipt_name_lookup "
             "RESTART IDENTITY CASCADE"
         )
     )

--- a/backend/tests/test_receipt_client.py
+++ b/backend/tests/test_receipt_client.py
@@ -12,7 +12,7 @@ import httpx
 import pytest
 
 from app.config import settings
-from app.receipt_client import extract_receipt
+from app.receipt_client import expand_names, extract_receipt
 
 _REQUEST = httpx.Request("POST", "http://ollama.example:11434/api/generate")
 _IMAGE = b"\xff\xd8\xff fake bytes, never actually decoded in these tests"
@@ -54,7 +54,7 @@ def test_extracts_every_line_from_a_well_formed_response(mocker):
 
     result = extract_receipt(_IMAGE)
 
-    assert [(i.name, str(i.quantity), i.is_food) for i in result.items] == [
+    assert [(i.raw_name, str(i.quantity), i.is_food) for i in result.items] == [
         ("Nopal limpio", "1.00", True),
         ("Jabón Grisi", "2.00", False),
     ]
@@ -91,7 +91,7 @@ def test_a_malformed_line_is_dropped_not_the_whole_receipt(mocker, bad_item):
 
     result = extract_receipt(_IMAGE)
 
-    assert [i.name for i in result.items] == ["Nopal limpio"]
+    assert [i.raw_name for i in result.items] == ["Nopal limpio"]
 
 
 def test_returns_none_when_every_line_is_malformed(mocker):
@@ -171,3 +171,107 @@ def test_returns_none_when_the_response_field_is_not_json(mocker):
     )
 
     assert extract_receipt(_IMAGE) is None
+
+
+def _expand_response(items: list[dict]) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        json={"model": "qwen3.5:4b", "response": json.dumps({"items": items}), "done": True},
+        request=_REQUEST,
+    )
+
+
+class TestExpandNames:
+    """expand_names is text-only (no image) and best-effort — see #126: a
+    failure here must fall back to the raw text, never block the trip."""
+
+    def test_returns_empty_without_calling_the_model_when_ollama_is_not_configured(self, monkeypatch, mocker):
+        monkeypatch.setattr(settings, "ollama_url", "")
+        post = mocker.patch("app.receipt_client.httpx.post")
+
+        assert expand_names(["CHAMP CREMINI"]) == {}
+        post.assert_not_called()
+
+    def test_returns_empty_without_calling_the_model_for_an_empty_list(self, mocker):
+        post = mocker.patch("app.receipt_client.httpx.post")
+
+        assert expand_names([]) == {}
+        post.assert_not_called()
+
+    def test_maps_each_raw_name_to_its_expanded_guess_by_index(self, mocker):
+        """Matched back by index, not by asking the model to echo the raw
+        string — see _expand_prompt's own comment: tried the echo approach
+        first and it broke silently against the real model."""
+        mocker.patch(
+            "app.receipt_client.httpx.post",
+            return_value=_expand_response(
+                [
+                    {"index": 1, "name": "Champiñones cremini"},
+                    {"index": 2, "name": "Milanesa de pulpa negra"},
+                ]
+            ),
+        )
+
+        result = expand_names(["CHAMP CREMINI", "HEB MILANESA DE PULPA NEG"])
+
+        assert result == {
+            "CHAMP CREMINI": "Champiñones cremini",
+            "HEB MILANESA DE PULPA NEG": "Milanesa de pulpa negra",
+        }
+
+    def test_does_not_send_an_image(self, mocker):
+        post = mocker.patch(
+            "app.receipt_client.httpx.post", return_value=_expand_response([{"index": 1, "name": "Y"}])
+        )
+
+        expand_names(["X"])
+
+        _, kwargs = post.call_args
+        assert "images" not in kwargs["json"]
+
+    @pytest.mark.parametrize(
+        "bad_entry",
+        [
+            {"index": 0, "name": "Algo"},
+            {"index": 2, "name": "Algo"},
+            {"index": True, "name": "Algo"},
+            {"index": 1, "name": ""},
+            {"index": 1, "name": "   "},
+            {"name": "Algo"},
+            {"index": 1},
+            {"index": "1", "name": "Algo"},
+            "not even an object",
+        ],
+    )
+    def test_a_malformed_entry_is_simply_dropped(self, mocker, bad_entry):
+        mocker.patch(
+            "app.receipt_client.httpx.post",
+            return_value=_expand_response([{"index": 1, "name": "Bien"}, bad_entry]),
+        )
+
+        assert expand_names(["OK"]) == {"OK": "Bien"}
+
+    def test_returns_empty_on_a_connection_failure(self, mocker):
+        mocker.patch("app.receipt_client.httpx.post", side_effect=httpx.ConnectError("refused"))
+
+        assert expand_names(["X"]) == {}
+
+    def test_returns_empty_on_an_http_error_status(self, mocker):
+        mocker.patch(
+            "app.receipt_client.httpx.post",
+            return_value=httpx.Response(status_code=500, text="boom", request=_REQUEST),
+        )
+
+        assert expand_names(["X"]) == {}
+
+    def test_returns_empty_when_the_response_field_is_not_json(self, mocker):
+        mocker.patch(
+            "app.receipt_client.httpx.post",
+            return_value=httpx.Response(
+                status_code=200,
+                json={"model": "qwen3.5:4b", "response": "not json", "done": True},
+                request=_REQUEST,
+            ),
+        )
+
+        assert expand_names(["X"]) == {}

--- a/backend/tests/test_receipt_name_cache.py
+++ b/backend/tests/test_receipt_name_cache.py
@@ -1,0 +1,43 @@
+"""Receipt name-cache tests — see #126."""
+
+import pytest
+
+from app import receipt_name_cache
+
+
+@pytest.mark.integration
+def test_a_fresh_raw_text_is_a_miss(db_session):
+    assert receipt_name_cache.get(db_session, "CHAMP CREMINI") is None
+
+
+@pytest.mark.integration
+def test_a_remembered_raw_text_is_found(db_session):
+    receipt_name_cache.remember(db_session, "CHAMP CREMINI", "Champiñones cremini")
+
+    assert receipt_name_cache.get(db_session, "CHAMP CREMINI") == "Champiñones cremini"
+
+
+@pytest.mark.integration
+def test_remembering_the_same_raw_text_again_overwrites_rather_than_erroring(db_session):
+    """A later, corrected resolve for the same raw text should simply win
+    over an earlier guess — same reasoning as icon_cache.remember."""
+    receipt_name_cache.remember(db_session, "CHAMP CREMINI", "Champiñones")
+    receipt_name_cache.remember(db_session, "CHAMP CREMINI", "Champiñones cremini")
+
+    assert receipt_name_cache.get(db_session, "CHAMP CREMINI") == "Champiñones cremini"
+
+
+@pytest.mark.integration
+def test_lookup_is_case_and_accent_insensitive(db_session):
+    receipt_name_cache.remember(db_session, "CHAMP CREMINI", "Champiñones cremini")
+
+    assert receipt_name_cache.get(db_session, "champ cremini") == "Champiñones cremini"
+
+
+@pytest.mark.integration
+def test_lookup_ignores_incidental_whitespace_differences(db_session):
+    """A receipt scanned twice can read the same printed line with
+    different incidental spacing — that must not miss the cache."""
+    receipt_name_cache.remember(db_session, "CHAMP   CREMINI", "Champiñones cremini")
+
+    assert receipt_name_cache.get(db_session, "CHAMP CREMINI") == "Champiñones cremini"

--- a/backend/tests/test_trips_api.py
+++ b/backend/tests/test_trips_api.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 
 import pytest
 
+from app import receipt_name_cache
 from app.receipt_client import ReceiptExtraction, ReceiptItem
 
 pytestmark = pytest.mark.integration
@@ -26,8 +27,8 @@ def _product(**overrides) -> dict:
 def _extraction(**overrides) -> ReceiptExtraction:
     defaults = {
         "items": [
-            ReceiptItem(name="Nopal limpio", quantity=Decimal("1.00"), is_food=True),
-            ReceiptItem(name="Jabón Grisi", quantity=Decimal("2.00"), is_food=False),
+            ReceiptItem(raw_name="Nopal limpio", quantity=Decimal("1.00"), is_food=True),
+            ReceiptItem(raw_name="Jabón Grisi", quantity=Decimal("2.00"), is_food=False),
         ],
         "stated_item_count": 3,
     }
@@ -51,6 +52,44 @@ def test_a_receipt_photo_creates_a_trip_with_its_items(api_client, mocker):
     ]
     assert body["stated_item_count"] == 3
     assert all(i["resolved_at"] is None and i["product_id"] is None for i in body["items"])
+
+
+def test_a_cached_raw_name_is_used_without_calling_expand_names(api_client, db_session, mocker):
+    """#126: a raw text receipt_name_cache already has an answer for never
+    has to be re-guessed."""
+    receipt_name_cache.remember(db_session, "Nopal limpio", "Nopal")
+    receipt_name_cache.remember(db_session, "Jabón Grisi", "Jabón")
+    expand = mocker.patch("app.routers.trips.expand_names")
+
+    response = _upload_receipt(api_client, mocker)
+
+    assert [item["name"] for item in response.json()["items"]] == ["Nopal", "Jabón"]
+    expand.assert_not_called()
+
+
+def test_expand_names_is_only_asked_about_names_not_already_cached(api_client, db_session, mocker):
+    receipt_name_cache.remember(db_session, "Nopal limpio", "Nopal")
+    expand = mocker.patch("app.routers.trips.expand_names", return_value={})
+
+    _upload_receipt(api_client, mocker)
+
+    expand.assert_called_once_with(["Jabón Grisi"])
+
+
+def test_an_uncached_raw_name_uses_expand_names_result(api_client, mocker):
+    mocker.patch("app.routers.trips.expand_names", return_value={"Nopal limpio": "Nopal expandido"})
+
+    response = _upload_receipt(api_client, mocker)
+
+    assert response.json()["items"][0]["name"] == "Nopal expandido"
+
+
+def test_a_name_expand_names_could_not_produce_falls_back_to_the_raw_text(api_client, mocker):
+    mocker.patch("app.routers.trips.expand_names", return_value={})
+
+    response = _upload_receipt(api_client, mocker)
+
+    assert response.json()["items"][0]["name"] == "Nopal limpio"
 
 
 def test_counted_quantity_and_reconciliation_match_when_they_should(api_client, mocker):
@@ -194,6 +233,37 @@ def test_resolving_an_item_links_it_to_a_real_product(api_client, mocker):
     body = response.json()
     assert body["resolved_at"] is not None
     assert body["product_id"] == product["id"]
+
+
+def test_resolving_remembers_the_products_name_for_the_lines_raw_text(api_client, db_session, mocker):
+    """#126: this is what makes the same raw text auto-resolve to the same
+    name on a future receipt, without ever asking the model twice."""
+    trip = _upload_receipt(api_client, mocker).json()
+    item = trip["items"][0]
+    product = api_client.post("/products", json=_product(name="Nopal")).json()
+
+    api_client.post(f"/trips/{trip['id']}/items/{item['id']}/resolve", json={"product_id": product["id"]})
+
+    # "Nopal limpio" is _extraction()'s own raw_name for this item — see the
+    # module fixture above. It equals item["name"] here only because
+    # expand_names isn't reached (no ollama_url configured in tests); the
+    # cache key is always the raw text, not whatever name ended up displayed.
+    assert receipt_name_cache.get(db_session, "Nopal limpio") == "Nopal"
+
+
+def test_resolving_against_a_product_that_predates_the_trip_links_without_creating_a_new_one(api_client, mocker):
+    """#126: "vincular a producto existente" — resolve never required the
+    product to be freshly created, only that it exists."""
+    existing = api_client.post("/products", json=_product(name="Ya lo tenía")).json()
+    trip = _upload_receipt(api_client, mocker).json()
+    item = trip["items"][0]
+
+    response = api_client.post(
+        f"/trips/{trip['id']}/items/{item['id']}/resolve", json={"product_id": existing["id"]}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["product_id"] == existing["id"]
 
 
 def test_resolving_against_a_nonexistent_product_is_rejected(api_client, mocker):

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -800,6 +800,12 @@
   white-space: nowrap;
 }
 
+.trip-checklist__link-button {
+  flex-shrink: 0;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+}
+
 .trip-checklist__quantity {
   flex-shrink: 0;
   color: var(--text-muted);

--- a/frontend/src/components/ReceiptTripDialog.test.tsx
+++ b/frontend/src/components/ReceiptTripDialog.test.tsx
@@ -177,6 +177,48 @@ describe('ReceiptTripDialog duplicate flagging', () => {
   })
 })
 
+describe('ReceiptTripDialog link to existing', () => {
+  // Real, unmocked "now" — same reasoning as the duplicate-flagging block
+  // above.
+  function createdToday(): string {
+    return new Date().toISOString()
+  }
+
+  it('offers a link button only for a flagged duplicate', () => {
+    const existing = product({ name: 'Nopal limpio', created_at: createdToday() })
+    renderDialog(
+      { items: [tripItem({ id: 1, name: 'Nopal limpio' }), tripItem({ id: 2, name: 'Plátano' })] },
+      [existing],
+    )
+
+    expect(screen.getAllByRole('button', { name: 'Vincular' })).toHaveLength(1)
+  })
+
+  it('resolves straight to the existing product, without ProductForm', async () => {
+    const existing = product({ id: 9, name: 'Nopal limpio', created_at: createdToday() })
+    mockedResolve.mockResolvedValue(tripItem({ id: 1, resolved_at: '2026-09-01T00:00:00Z', product_id: 9 }))
+    const { onTripChanged } = renderDialog({ items: [tripItem({ id: 1, name: 'Nopal limpio' })] }, [existing])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Vincular' }))
+
+    await waitFor(() => expect(mockedResolve).toHaveBeenCalledWith(1, 1, 9))
+    expect(mockedCreate).not.toHaveBeenCalled()
+    expect(onTripChanged).toHaveBeenCalled()
+    await waitFor(() => expect(screen.queryByText('Nopal limpio')).not.toBeInTheDocument())
+  })
+
+  it('shows the error and leaves the item in place when linking fails', async () => {
+    const existing = product({ id: 9, name: 'Nopal limpio', created_at: createdToday() })
+    mockedResolve.mockRejectedValue(new Error('nope'))
+    renderDialog({ items: [tripItem({ id: 1, name: 'Nopal limpio' })] }, [existing])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Vincular' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
+    expect(screen.getByText('Nopal limpio')).toBeInTheDocument()
+  })
+})
+
 describe('ReceiptTripDialog continue', () => {
   it('drops every unticked item and notifies the parent', async () => {
     mockedDrop.mockResolvedValue(tripItem({ resolved_at: '2026-09-01T00:00:00Z' }))

--- a/frontend/src/components/ReceiptTripDialog.tsx
+++ b/frontend/src/components/ReceiptTripDialog.tsx
@@ -60,6 +60,10 @@ export function ReceiptTripDialog({ trip, categories, products, onClose, onTripC
   const [queue, setQueue] = useState<ShoppingTripItem[] | null>(null)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // The id of the item currently being linked, if any — see
+  // handleLinkToExisting. Only one link action can be in flight at a time,
+  // the same as the queue only ever creating one product at a time.
+  const [linking, setLinking] = useState<number | null>(null)
 
   const pending = items.filter((item) => itemState(item) === 'pending')
 
@@ -87,6 +91,28 @@ export function ReceiptTripDialog({ trip, categories, products, onClose, onTripC
         setError(toErrorMessage(caught))
       } finally {
         setSubmitting(false)
+      }
+    })()
+  }
+
+  /**
+   * Resolve a line straight into a product that already exists — see #126.
+   * The alternative to the queue above, for exactly the case its badge
+   * already flags: re-adding would just create a duplicate, so this skips
+   * ProductForm entirely and links the line to the product it actually is.
+   */
+  const handleLinkToExisting = (item: ShoppingTripItem, product: Product) => {
+    setLinking(item.id)
+    setError(null)
+    void (async () => {
+      try {
+        const resolved = await resolveTripItem(trip.id, item.id, product.id)
+        replaceItem(resolved)
+        onTripChanged()
+      } catch (caught) {
+        setError(toErrorMessage(caught))
+      } finally {
+        setLinking(null)
       }
     })()
   }
@@ -201,6 +227,16 @@ export function ReceiptTripDialog({ trip, categories, products, onClose, onTripC
                       after opening the form. See #108. */}
                   {duplicate && <span className="trip-checklist__badge">Ya lo tienes hoy</span>}
                 </label>
+                {duplicate && (
+                  <button
+                    type="button"
+                    className="trip-checklist__link-button"
+                    onClick={() => handleLinkToExisting(item, duplicate)}
+                    disabled={linking === item.id || submitting}
+                  >
+                    {linking === item.id ? 'Vinculando…' : 'Vincular'}
+                  </button>
+                )}
                 <span className="trip-checklist__quantity">{quantityLabel(item.quantity, null)}</span>
               </li>
             )

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,7 @@ cadutrack/
 | `icon_name_cache` | Local name → emoji lookup, consulted before falling back to the vision model |
 | `shopping_trips`, `shopping_trip_items` | A receipt photo's checklist; a resolved item links to the `products` row it became |
 | `barcode_lookups` | What a scanned barcode was called (and iconned) last time |
+| `receipt_name_lookup` | What a receipt line's raw printed text was named last time it resolved into a product |
 
 > CaduTrack owns the database `cadutrack` and the schema `cadutrack` inside it,
 > on its own bundled PostgreSQL — `compose.yaml` brings up `cadutrack-db`


### PR DESCRIPTION
## Summary

Closes #126. Two related gaps in the receipt-scan flow:

1. **A name correction never stuck.** `receipt_client.extract_receipt` used to both read *and* expand/correct a receipt line's name in one model call — so the same abbreviation was re-guessed cold on every future receipt, and there was no stable key for "have I bought this before" to key off of.
2. **A real duplicate could only be reconciled by creating a second product.** `resolve_trip_item` already accepted any valid `product_id`, not just a freshly-created one — but nothing in the UI let a checklist line flagged "Ya lo tienes hoy" actually use that path.

## What changed

- `extract_receipt`'s prompt no longer expands or corrects anything — it copies the raw printed text verbatim.
- A new `receipt_name_lookup` table (same shape as `barcode_lookups`) remembers the accepted name for a raw text once a trip item actually resolves — via `receipt_name_cache.py`, same pattern as `icon_cache.py`.
- An unseen raw name goes through a new, second, **text-only** `expand_names` call — no image, so it's cheaper than the OCR pass — and only ever runs for names the cache doesn't already have an answer for. A repeat purchase costs one model call, not two.
- `resolve_trip_item` now also writes the resolved product's name back into the cache, closing the loop.
- `ReceiptTripDialog` gets a "Vincular" button next to the "Ya lo tienes hoy" badge — resolves the line straight to the matching product, skipping `ProductForm` entirely, so a real duplicate never has to become a second product record.

## Verified against the real model

Mocked `httpx` tests alone weren't enough here, since the whole point is whether the model actually follows the new/changed prompts. Pointed `OLLAMA_URL` at the real Ollama instance and ran both prompts against a receipt image (a synthetic re-render of a real one, built from its actual text):

- **OCR-only prompt**: held up — every one of 18 lines came back copied verbatim (case, punctuation, truncation all preserved), `is_food` and `stated_item_count` both correct.
- **First `expand_names` design**: did not survive contact with the real model. It asked the model to echo the raw text back as its own match key ("raw"), and the model included the prompt's own `"- "` bullet prefix in that echo — silently missing **every single name**, with no exception thrown to say so. Redesigned to match by numbered index instead, which never depends on the model reproducing text exactly. Re-verified against the real model afterward — all 18 names matched and expanded correctly.

## Test plan

- [x] `pytest tests/` — 350/350 passed (Postgres 16, `alembic upgrade head` applied cleanly on top of the current head)
- [x] `ruff check .` — clean
- [x] `npx tsc --noEmit` — clean
- [x] Real-model verification described above (backend)
- [ ] `vitest`/`eslint` not run locally — both hit a known worker/process sandboxing hang in this dev environment this session (vitest: consistent across every PR so far; eslint: two runs stuck at 20+ minutes with near-zero CPU, killed). CI runs both cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)