### PR TITLE
feat: manual link to any existing product from the receipt checklist

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -748,15 +748,21 @@
 
 .trip-checklist__row {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.625rem;
+  flex-direction: column;
+  gap: 0.375rem;
   padding: 0.625rem 0;
   border-bottom: 1px solid var(--border);
 }
 
 .trip-checklist__row:last-child {
   border-bottom: none;
+}
+
+.trip-checklist__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.625rem;
 }
 
 .trip-checklist__label {
@@ -804,6 +810,30 @@
   flex-shrink: 0;
   padding: 0.25rem 0.6rem;
   font-size: 0.75rem;
+}
+
+.trip-checklist__manual-link-toggle {
+  align-self: flex-start;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--accent);
+  font-size: 0.75rem;
+  text-decoration: underline;
+}
+
+.trip-checklist__manual-link {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.trip-checklist__manual-link-select {
+  flex: 1;
+  min-width: 0;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.8125rem;
 }
 
 .trip-checklist__quantity {

--- a/frontend/src/components/ReceiptTripDialog.test.tsx
+++ b/frontend/src/components/ReceiptTripDialog.test.tsx
@@ -177,7 +177,7 @@ describe('ReceiptTripDialog duplicate flagging', () => {
   })
 })
 
-describe('ReceiptTripDialog link to existing', () => {
+describe('ReceiptTripDialog automatic link to existing', () => {
   // Real, unmocked "now" — same reasoning as the duplicate-flagging block
   // above.
   function createdToday(): string {
@@ -213,6 +213,104 @@ describe('ReceiptTripDialog link to existing', () => {
     renderDialog({ items: [tripItem({ id: 1, name: 'Nopal limpio' })] }, [existing])
 
     fireEvent.click(screen.getByRole('button', { name: 'Vincular' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
+    expect(screen.getByText('Nopal limpio')).toBeInTheDocument()
+  })
+})
+
+describe('ReceiptTripDialog manual link to existing product', () => {
+  it('offers the manual picker for every pending item, even without an auto-detected match', () => {
+    const unrelated = product({ id: 9, name: 'Leche entera', created_at: '2026-08-01T00:00:00Z' })
+    renderDialog({ items: [tripItem({ id: 1, name: 'Nopal limpio' })] }, [unrelated])
+
+    expect(screen.getByRole('button', { name: 'Vincular a producto existente' })).toBeInTheDocument()
+  })
+
+  it('hides the manual picker when there is no active product to link to', () => {
+    renderDialog({ items: [tripItem({ id: 1, name: 'Nopal limpio' })] }, [])
+
+    expect(screen.queryByRole('button', { name: 'Vincular a producto existente' })).not.toBeInTheDocument()
+  })
+
+  it('lists every active product, sorted, once opened', () => {
+    const leche = product({ id: 9, name: 'Leche entera', created_at: '2026-08-01T00:00:00Z' })
+    const yogurt = product({ id: 10, name: 'Yogurt griego', created_at: '2026-08-01T00:00:00Z' })
+    renderDialog({ items: [tripItem({ id: 1, name: 'Nopal limpio' })] }, [yogurt, leche])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Vincular a producto existente' }))
+
+    const select = screen.getByLabelText('Vincular Nopal limpio a un producto existente')
+    expect(Array.from(select.querySelectorAll('option')).map((option) => option.textContent)).toEqual([
+      'Elige un producto…',
+      'Leche entera',
+      'Yogurt griego',
+    ])
+  })
+
+  it('excludes a consumed product from the picker', () => {
+    const consumed = product({ id: 9, name: 'Leche entera', consumed_at: '2026-08-02T00:00:00Z' })
+    renderDialog({ items: [tripItem({ id: 1, name: 'Nopal limpio' })] }, [consumed])
+
+    expect(screen.queryByRole('button', { name: 'Vincular a producto existente' })).not.toBeInTheDocument()
+  })
+
+  it('keeps Confirmar disabled until a product is chosen', () => {
+    const existing = product({ id: 9, name: 'Leche entera' })
+    renderDialog({ items: [tripItem({ id: 1, name: 'Nopal limpio' })] }, [existing])
+    fireEvent.click(screen.getByRole('button', { name: 'Vincular a producto existente' }))
+
+    expect(screen.getByRole('button', { name: 'Confirmar' })).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Vincular Nopal limpio a un producto existente'), {
+      target: { value: '9' },
+    })
+
+    expect(screen.getByRole('button', { name: 'Confirmar' })).not.toBeDisabled()
+  })
+
+  it('resolves to the chosen product on confirm', async () => {
+    const existing = product({ id: 9, name: 'Leche entera' })
+    mockedResolve.mockResolvedValue(tripItem({ id: 1, resolved_at: '2026-09-01T00:00:00Z', product_id: 9 }))
+    const { onTripChanged } = renderDialog({ items: [tripItem({ id: 1, name: 'Nopal limpio' })] }, [existing])
+    fireEvent.click(screen.getByRole('button', { name: 'Vincular a producto existente' }))
+    fireEvent.change(screen.getByLabelText('Vincular Nopal limpio a un producto existente'), {
+      target: { value: '9' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirmar' }))
+
+    await waitFor(() => expect(mockedResolve).toHaveBeenCalledWith(1, 1, 9))
+    expect(mockedCreate).not.toHaveBeenCalled()
+    expect(onTripChanged).toHaveBeenCalled()
+    await waitFor(() => expect(screen.queryByText('Nopal limpio')).not.toBeInTheDocument())
+  })
+
+  it('closes without resolving on cancel', () => {
+    const existing = product({ id: 9, name: 'Leche entera' })
+    renderDialog({ items: [tripItem({ id: 1, name: 'Nopal limpio' })] }, [existing])
+    fireEvent.click(screen.getByRole('button', { name: 'Vincular a producto existente' }))
+    fireEvent.change(screen.getByLabelText('Vincular Nopal limpio a un producto existente'), {
+      target: { value: '9' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancelar vínculo' }))
+
+    expect(screen.queryByRole('button', { name: 'Confirmar' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Vincular a producto existente' })).toBeInTheDocument()
+    expect(mockedResolve).not.toHaveBeenCalled()
+  })
+
+  it('shows the error and leaves the item in place when the manual link fails', async () => {
+    const existing = product({ id: 9, name: 'Leche entera' })
+    mockedResolve.mockRejectedValue(new Error('nope'))
+    renderDialog({ items: [tripItem({ id: 1, name: 'Nopal limpio' })] }, [existing])
+    fireEvent.click(screen.getByRole('button', { name: 'Vincular a producto existente' }))
+    fireEvent.change(screen.getByLabelText('Vincular Nopal limpio a un producto existente'), {
+      target: { value: '9' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirmar' }))
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Ocurrió un error inesperado.')
     expect(screen.getByText('Nopal limpio')).toBeInTheDocument()

--- a/frontend/src/components/ReceiptTripDialog.tsx
+++ b/frontend/src/components/ReceiptTripDialog.tsx
@@ -64,8 +64,19 @@ export function ReceiptTripDialog({ trip, categories, products, onClose, onTripC
   // handleLinkToExisting. Only one link action can be in flight at a time,
   // the same as the queue only ever creating one product at a time.
   const [linking, setLinking] = useState<number | null>(null)
+  // Which item's manual "link to an existing product" picker is open, if
+  // any — see #128. Separate from the automatic same-day match above: that
+  // one only ever offers the one product findDuplicateToday found, this is
+  // for everything else (a different day, a name that doesn't match).
+  const [manualLinkFor, setManualLinkFor] = useState<number | null>(null)
+  const [manualLinkProductId, setManualLinkProductId] = useState('')
 
   const pending = items.filter((item) => itemState(item) === 'pending')
+  // Sorted once, not per row — nothing about this list depends on which
+  // item's picker is open.
+  const activeProducts = [...products]
+    .filter((product) => product.consumed_at === null)
+    .sort((a, b) => a.name.localeCompare(b.name, 'es'))
 
   const toggle = (itemId: number) =>
     setTicked((current) => ({ ...current, [itemId]: !current[itemId] }))
@@ -115,6 +126,24 @@ export function ReceiptTripDialog({ trip, categories, products, onClose, onTripC
         setLinking(null)
       }
     })()
+  }
+
+  const openManualLink = (item: ShoppingTripItem) => {
+    setManualLinkFor(item.id)
+    setManualLinkProductId('')
+    setError(null)
+  }
+
+  const closeManualLink = () => {
+    setManualLinkFor(null)
+    setManualLinkProductId('')
+  }
+
+  const confirmManualLink = (item: ShoppingTripItem) => {
+    const product = activeProducts.find((candidate) => candidate.id === Number(manualLinkProductId))
+    if (!product) return
+    handleLinkToExisting(item, product)
+    closeManualLink()
   }
 
   /** After a product is created for the item at the front of the queue,
@@ -207,37 +236,86 @@ export function ReceiptTripDialog({ trip, categories, products, onClose, onTripC
         <ul className="trip-checklist">
           {pending.map((item) => {
             const duplicate = findDuplicateToday(products, item.name)
+            const picking = manualLinkFor === item.id
             return (
               <li key={item.id} className="trip-checklist__row">
-                <label className="trip-checklist__label">
-                  <input
-                    type="checkbox"
-                    checked={ticked[item.id] ?? item.is_food}
-                    onChange={() => toggle(item.id)}
-                  />
-                  <span className="trip-checklist__name">{item.name}</span>
-                  {/* A sibling of the (truncating) name, not nested inside
-                      it — flex-shrink: 0 keeps this visible even for a
-                      long name, the same way the quantity on the right
-                      already does. Un-ticking is only the default, not a
-                      decision made for the user — this is why, so a
-                      re-tick (a second purchase of the same thing, same
-                      day) is a choice made with the same information
-                      ProductForm's own check would otherwise surface only
-                      after opening the form. See #108. */}
-                  {duplicate && <span className="trip-checklist__badge">Ya lo tienes hoy</span>}
-                </label>
-                {duplicate && (
-                  <button
-                    type="button"
-                    className="trip-checklist__link-button"
-                    onClick={() => handleLinkToExisting(item, duplicate)}
-                    disabled={linking === item.id || submitting}
-                  >
-                    {linking === item.id ? 'Vinculando…' : 'Vincular'}
-                  </button>
-                )}
-                <span className="trip-checklist__quantity">{quantityLabel(item.quantity, null)}</span>
+                <div className="trip-checklist__top">
+                  <label className="trip-checklist__label">
+                    <input
+                      type="checkbox"
+                      checked={ticked[item.id] ?? item.is_food}
+                      onChange={() => toggle(item.id)}
+                    />
+                    <span className="trip-checklist__name">{item.name}</span>
+                    {/* A sibling of the (truncating) name, not nested inside
+                        it — flex-shrink: 0 keeps this visible even for a
+                        long name, the same way the quantity on the right
+                        already does. Un-ticking is only the default, not a
+                        decision made for the user — this is why, so a
+                        re-tick (a second purchase of the same thing, same
+                        day) is a choice made with the same information
+                        ProductForm's own check would otherwise surface only
+                        after opening the form. See #108. */}
+                    {duplicate && <span className="trip-checklist__badge">Ya lo tienes hoy</span>}
+                  </label>
+                  {duplicate && (
+                    <button
+                      type="button"
+                      className="trip-checklist__link-button"
+                      onClick={() => handleLinkToExisting(item, duplicate)}
+                      disabled={linking === item.id || submitting}
+                    >
+                      {linking === item.id ? 'Vinculando…' : 'Vincular'}
+                    </button>
+                  )}
+                  <span className="trip-checklist__quantity">{quantityLabel(item.quantity, null)}</span>
+                </div>
+                {/* The automatic match above only ever offers the one
+                    product findDuplicateToday found — same name, same
+                    calendar day. This is for everything else: a different
+                    day, or a name the receipt just doesn't match. See #128. */}
+                {activeProducts.length > 0 &&
+                  (picking ? (
+                    <div className="trip-checklist__manual-link">
+                      <select
+                        className="trip-checklist__manual-link-select"
+                        aria-label={`Vincular ${item.name} a un producto existente`}
+                        value={manualLinkProductId}
+                        onChange={(event) => setManualLinkProductId(event.target.value)}
+                      >
+                        <option value="">Elige un producto…</option>
+                        {activeProducts.map((product) => (
+                          <option key={product.id} value={product.id}>
+                            {product.name}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        type="button"
+                        className="trip-checklist__link-button"
+                        onClick={() => confirmManualLink(item)}
+                        disabled={!manualLinkProductId || linking === item.id || submitting}
+                      >
+                        {linking === item.id ? 'Vinculando…' : 'Confirmar'}
+                      </button>
+                      {/* Not "Cancelar" — the dialog's own Cancelar button
+                          below already carries that name, and two controls
+                          sharing one accessible name is exactly what a
+                          screen reader user cannot tell apart. */}
+                      <button type="button" className="trip-checklist__link-button" onClick={closeManualLink}>
+                        Cancelar vínculo
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      className="trip-checklist__manual-link-toggle"
+                      onClick={() => openManualLink(item)}
+                      disabled={submitting}
+                    >
+                      Vincular a producto existente
+                    </button>
+                  ))}
               </li>
             )
           })}


### PR DESCRIPTION
## Summary

Closes #128. Follow-up to #126: the automatic "Vincular" button only appears when `findDuplicateToday` finds a match — exact name (accent/case-insensitive) **and** created the same calendar day (confirmed while explaining that to Julio — it's a calendar-day comparison, not a rolling 24h window). That leaves a real gap: a product added a different day, or under a name the receipt doesn't match exactly, had no way to link at all.

## What changed

- Every pending checklist line now also gets a "Vincular a producto existente" toggle, independent of the automatic same-day match, hidden only when there's no active product to offer at all.
- Opening it reveals a `<select>` listing every active (unconsumed) product, sorted alphabetically, plus Confirmar/Cancelar vínculo.
- Confirming calls the same `resolveTripItem` the automatic path already uses — no backend change needed, since `resolve_trip_item` never required the product to be freshly created, only that it exists.
- The new "Cancelar vínculo" button is deliberately not labeled "Cancelar" — the dialog's own Cancelar button already carries that accessible name.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] New `ReceiptTripDialog.test.tsx` coverage: toggle shown/hidden per active-product availability, consumed products excluded from the picker, options sorted, Confirmar disabled until a choice is made, successful resolve, cancel leaves nothing resolved, failure shows the error and leaves the item pending
- [x] Manual review of the full diff (accessible-name collision with the existing "Cancelar" caught and fixed during review)
- [ ] `vitest`/`eslint` not run locally — same known worker/process sandboxing hang in this dev environment as PR #125 and #127; CI runs both cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)